### PR TITLE
fix: track R version and base packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1884,7 +1884,7 @@ dependencies = [
 
 [[package]]
 name = "rpx"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "clap",
  "deb822-fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpx"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 description = "Rust CLI for managing R package project dependencies"
 repository = "https://github.com/scalerail-solutions/rpx"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,9 @@ mod ui;
 
 use cli::{Cli, Commands, RepoCommands};
 use description::{DescriptionExt, init_description, read_description, write_description};
-use lockfile::{LockedR, Lockfile, read_lockfile, read_lockfile_optional, write_lockfile};
+use lockfile::{
+    LOCKFILE_VERSION, LockedR, Lockfile, read_lockfile, read_lockfile_optional, write_lockfile,
+};
 use project::{
     build_temp_library_path, cache_dir_path, compiled_cache_package_path, project_library_path,
     project_library_root_path,
@@ -298,6 +300,13 @@ fn cmd_status() {
             std::process::exit(1);
         }
     };
+
+    if lockfile.version < LOCKFILE_VERSION {
+        println!("Lockfile is out of date");
+        println!();
+        print_relock_message();
+        std::process::exit(1);
+    }
 
     let manifest_requirements = project
         .description
@@ -687,6 +696,7 @@ fn sync_from_lockfile() -> SyncOutcome {
         .into_iter()
         .collect::<BTreeSet<_>>();
     let lockfile = read_lockfile().expect("failed to read lockfile");
+    validate_lockfile_version_for_sync(&lockfile);
     validate_runtime_for_sync(&lockfile);
     let lock_requirements = lockfile
         .roots
@@ -928,7 +938,7 @@ fn lockfile_from_resolution(
 ) -> Lockfile {
     let required_base_packages = locked_base_packages(&roots, resolved);
     Lockfile {
-        version: 1,
+        version: LOCKFILE_VERSION,
         registry: registry.to_string(),
         r: LockedR {
             version: runtime_info().version,
@@ -966,6 +976,21 @@ fn lockfile_from_resolution(
             })
             .collect(),
     }
+}
+
+fn print_relock_message() {
+    println!("Your lockfile was created by an older rpx version and needs to be updated.");
+    println!("Run: rpx lock");
+}
+
+fn validate_lockfile_version_for_sync(lockfile: &Lockfile) {
+    if lockfile.version >= LOCKFILE_VERSION {
+        return;
+    }
+
+    eprintln!("Your lockfile was created by an older rpx version and needs to be updated.");
+    eprintln!("Run: rpx lock");
+    std::process::exit(1);
 }
 
 fn locked_base_packages(roots: &[ResolutionRoot], resolved: &[ResolvedPackage]) -> Vec<String> {
@@ -1615,7 +1640,7 @@ mod tests {
     use crate::description::RDescription;
     use crate::{
         description::DescriptionExt,
-        lockfile::{LockedDependency, LockedPackage, LockedR, Lockfile},
+        lockfile::{LOCKFILE_VERSION, LockedDependency, LockedPackage, LockedR, Lockfile},
         r::RuntimeInfo,
         registry::ResolutionRoot,
         resolver::{ResolvedDependency, ResolvedPackage},
@@ -1705,7 +1730,7 @@ mod tests {
         );
 
         assert_eq!(lockfile.registry, "https://api.rrepo.org");
-        assert_eq!(lockfile.version, 1);
+        assert_eq!(lockfile.version, LOCKFILE_VERSION);
         assert_eq!(lockfile.r.base_packages, vec!["base", "utils"]);
         assert_eq!(lockfile.roots[0].package, "digest");
         assert_eq!(lockfile.roots[1].package, "cli");
@@ -1862,7 +1887,7 @@ mod tests {
     #[test]
     fn installs_locked_packages_in_dependency_order() {
         let lockfile = Lockfile {
-            version: 1,
+            version: LOCKFILE_VERSION,
             registry: "https://api.rrepo.org".to_string(),
             r: LockedR::default(),
             roots: vec![],
@@ -1932,7 +1957,7 @@ mod tests {
     #[test]
     fn rejects_cyclic_locked_dependencies() {
         let lockfile = Lockfile {
-            version: 1,
+            version: LOCKFILE_VERSION,
             registry: "https://api.rrepo.org".to_string(),
             r: LockedR::default(),
             roots: vec![],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,13 +20,13 @@ mod ui;
 
 use cli::{Cli, Commands, RepoCommands};
 use description::{DescriptionExt, init_description, read_description, write_description};
-use lockfile::{Lockfile, read_lockfile, read_lockfile_optional, write_lockfile};
+use lockfile::{LockedR, Lockfile, read_lockfile, read_lockfile_optional, write_lockfile};
 use project::{
     build_temp_library_path, cache_dir_path, compiled_cache_package_path, project_library_path,
     project_library_root_path,
 };
 use r::{
-    InstallFailure, RuntimeInfo, install_local_package, installed_packages,
+    InstallFailure, RuntimeInfo, base_packages, install_local_package, installed_packages,
     installed_packages_by_name, project_command, remove_installed_package_dir,
     remove_installed_packages, runtime_info,
 };
@@ -37,7 +37,7 @@ use registry::{
 use repository::{
     RepositorySet, RepositorySource, normalize_repository_url, repository_source_from_package_url,
 };
-use resolver::{ResolvedPackage, resolve_from_registry};
+use resolver::{ResolvedPackage, is_base_package, resolve_from_registry};
 use ui::{InstallKind, SyncUi};
 
 const SYNC_WORKERS: usize = 4;
@@ -318,7 +318,8 @@ fn cmd_status() {
         .iter()
         .map(|package| (package.package.clone(), package.version.clone()))
         .collect::<std::collections::BTreeMap<_, _>>();
-    let locked_names = lockfile.packages.keys().cloned().collect::<BTreeSet<_>>();
+    let locked_names = locked_package_names(&lockfile);
+    let runtime_status = runtime_status(&lockfile);
 
     let missing_from_lockfile = manifest_requirements
         .difference(&lock_requirements)
@@ -339,6 +340,7 @@ fn cmd_status() {
     let version_mismatches = lockfile
         .packages
         .iter()
+        .filter(|(name, _)| !is_base_package(name))
         .filter_map(|(name, package)| {
             installed_versions
                 .get(name)
@@ -357,7 +359,9 @@ fn cmd_status() {
         && missing_from_library.is_empty()
         && extra_in_library.is_empty()
         && version_mismatches.is_empty()
+        && runtime_status.missing_base_packages.is_empty()
     {
+        print_runtime_version_warning(&runtime_status);
         println!("Project is in sync");
         return;
     }
@@ -366,6 +370,7 @@ fn cmd_status() {
     let library_out_of_date = !missing_from_library.is_empty()
         || !extra_in_library.is_empty()
         || !version_mismatches.is_empty();
+    let runtime_out_of_date = !runtime_status.missing_base_packages.is_empty();
 
     if lockfile_out_of_date && library_out_of_date {
         println!("Project is out of sync");
@@ -375,6 +380,8 @@ fn cmd_status() {
         println!("Lockfile is out of date");
         println!();
         println!("Run: rpx lock");
+    } else if runtime_out_of_date {
+        println!("R runtime is out of sync");
     } else {
         println!("Project library is out of sync");
         println!();
@@ -394,6 +401,11 @@ fn cmd_status() {
     print_status_group(
         "Installed versions that differ from rpx.lock:",
         &version_mismatches,
+    );
+    print_runtime_version_warning(&runtime_status);
+    print_status_group(
+        "R runtime is missing locked base packages:",
+        &runtime_status.missing_base_packages,
     );
 
     std::process::exit(1);
@@ -629,6 +641,10 @@ fn constraints_from_resolved_roots(
     packages
         .iter()
         .map(|package| {
+            if is_base_package(package) {
+                return Ok((package.clone(), vec![]));
+            }
+
             let version = resolved_by_package
                 .get(package.as_str())
                 .ok_or_else(|| format!("missing resolved version for {package}"))?;
@@ -671,6 +687,7 @@ fn sync_from_lockfile() -> SyncOutcome {
         .into_iter()
         .collect::<BTreeSet<_>>();
     let lockfile = read_lockfile().expect("failed to read lockfile");
+    validate_runtime_for_sync(&lockfile);
     let lock_requirements = lockfile
         .roots
         .iter()
@@ -796,9 +813,10 @@ fn sync_from_lockfile() -> SyncOutcome {
     }
     ui.finish_installs();
 
+    let locked_names = locked_package_names(&lockfile);
     let extras = installed_packages_by_name()
         .into_keys()
-        .filter(|name| !lockfile.packages.contains_key(name))
+        .filter(|name| !locked_names.contains(name))
         .collect::<Vec<_>>();
     outcome.removed = extras.len();
     ui.start_removals(extras.len());
@@ -806,20 +824,20 @@ fn sync_from_lockfile() -> SyncOutcome {
     ui.finish_removals();
 
     let final_state = installed_packages_by_name();
-    let missing = lockfile
-        .packages
-        .keys()
+    let missing = locked_names
+        .iter()
         .filter(|name| !final_state.contains_key(*name))
         .cloned()
         .collect::<Vec<_>>();
     let extras = final_state
         .keys()
-        .filter(|name| !lockfile.packages.contains_key(*name))
+        .filter(|name| !locked_names.contains(*name))
         .cloned()
         .collect::<Vec<_>>();
     let version_mismatches = lockfile
         .packages
         .iter()
+        .filter(|(name, _)| !is_base_package(name))
         .filter_map(|(name, package)| {
             final_state
                 .get(name)
@@ -908,9 +926,14 @@ fn lockfile_from_resolution(
     registry: &str,
     resolved: &[ResolvedPackage],
 ) -> Lockfile {
+    let required_base_packages = locked_base_packages(&roots, resolved);
     Lockfile {
         version: 1,
         registry: registry.to_string(),
+        r: LockedR {
+            version: runtime_info().version,
+            base_packages: required_base_packages,
+        },
         roots: roots
             .into_iter()
             .map(|root| lockfile::LockedRoot {
@@ -943,6 +966,106 @@ fn lockfile_from_resolution(
             })
             .collect(),
     }
+}
+
+fn locked_base_packages(roots: &[ResolutionRoot], resolved: &[ResolvedPackage]) -> Vec<String> {
+    let mut packages = BTreeSet::new();
+
+    packages.extend(
+        roots
+            .iter()
+            .filter(|root| is_base_package(&root.name))
+            .map(|root| root.name.clone()),
+    );
+    packages.extend(
+        resolved
+            .iter()
+            .flat_map(|package| &package.dependencies)
+            .filter(|dependency| is_base_package(&dependency.package))
+            .map(|dependency| dependency.package.clone()),
+    );
+
+    packages.into_iter().collect()
+}
+
+fn locked_package_names(lockfile: &Lockfile) -> BTreeSet<String> {
+    lockfile
+        .packages
+        .keys()
+        .filter(|name| !is_base_package(name))
+        .cloned()
+        .collect()
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct RuntimeStatus {
+    version_mismatch: Option<String>,
+    missing_base_packages: Vec<String>,
+}
+
+fn runtime_status(lockfile: &Lockfile) -> RuntimeStatus {
+    let runtime = runtime_info();
+    let version_mismatch =
+        (!lockfile.r.version.is_empty() && lockfile.r.version != runtime.version).then(|| {
+            format!(
+                "R {} installed, R {} locked",
+                runtime.version, lockfile.r.version
+            )
+        });
+    let available_base_packages = base_packages().into_iter().collect::<BTreeSet<_>>();
+    let locked_base_packages = lockfile
+        .r
+        .base_packages
+        .iter()
+        .chain(lockfile.roots.iter().map(|root| &root.package))
+        .chain(lockfile.packages.keys())
+        .filter(|package| is_base_package(package))
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let missing_base_packages = lockfile
+        .r
+        .base_packages
+        .iter()
+        .chain(locked_base_packages.iter())
+        .filter(|package| !available_base_packages.contains(*package))
+        .cloned()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+
+    RuntimeStatus {
+        version_mismatch,
+        missing_base_packages,
+    }
+}
+
+fn print_runtime_version_warning(status: &RuntimeStatus) {
+    let Some(version_mismatch) = &status.version_mismatch else {
+        return;
+    };
+
+    println!();
+    println!("R runtime differs from lockfile:");
+    println!("- {version_mismatch}");
+}
+
+fn validate_runtime_for_sync(lockfile: &Lockfile) {
+    let status = runtime_status(lockfile);
+
+    if let Some(version_mismatch) = status.version_mismatch {
+        eprintln!("warning: {version_mismatch}");
+    }
+
+    if status.missing_base_packages.is_empty() {
+        return;
+    }
+
+    for package in &status.missing_base_packages {
+        eprintln!("R runtime is missing required base package: {package}");
+    }
+    eprintln!("These packages are part of R itself and cannot be installed by rpx.");
+    eprintln!("Use a complete R installation compatible with this project.");
+    std::process::exit(1);
 }
 
 fn registry_source_url(registry: &str, package: &str, version: &str) -> String {
@@ -1048,6 +1171,7 @@ fn collect_pending_installs(
     lockfile
         .packages
         .iter()
+        .filter(|(name, _)| !is_base_package(name))
         .filter_map(|(name, package)| match installed.get(name) {
             Some(installed_package) if installed_package.version == package.version => None,
             _ => {
@@ -1491,7 +1615,7 @@ mod tests {
     use crate::description::RDescription;
     use crate::{
         description::DescriptionExt,
-        lockfile::{LockedDependency, LockedPackage, LockedRoot, Lockfile},
+        lockfile::{LockedDependency, LockedPackage, LockedR, Lockfile},
         r::RuntimeInfo,
         registry::ResolutionRoot,
         resolver::{ResolvedDependency, ResolvedPackage},
@@ -1582,6 +1706,7 @@ mod tests {
 
         assert_eq!(lockfile.registry, "https://api.rrepo.org");
         assert_eq!(lockfile.version, 1);
+        assert_eq!(lockfile.r.base_packages, vec!["base", "utils"]);
         assert_eq!(lockfile.roots[0].package, "digest");
         assert_eq!(lockfile.roots[1].package, "cli");
         assert_eq!(
@@ -1685,6 +1810,29 @@ mod tests {
     }
 
     #[test]
+    fn derives_empty_constraints_for_base_package_roots() {
+        let constraints = constraints_from_resolved_roots(&["grid".to_string()], &[])
+            .expect("base package constraints should derive");
+
+        assert_eq!(constraints, BTreeMap::from([("grid".to_string(), vec![])]));
+    }
+
+    #[test]
+    fn records_direct_base_roots_as_runtime_requirements() {
+        let lockfile = lockfile_from_resolution(
+            vec![ResolutionRoot {
+                name: "grid".to_string(),
+                constraint: "*".to_string(),
+            }],
+            "https://api.rrepo.org",
+            &[],
+        );
+
+        assert_eq!(lockfile.r.base_packages, vec!["grid"]);
+        assert!(!lockfile.packages.contains_key("grid"));
+    }
+
+    #[test]
     fn keeps_existing_roots_when_adding_new_package() {
         let description = RDescription::from_str(
             "Package: testpkg\nVersion: 0.1.0\nTitle: Test Package\nDescription: Test package for unit tests.\nLicense: MIT\nImports: cli\n",
@@ -1716,6 +1864,7 @@ mod tests {
         let lockfile = Lockfile {
             version: 1,
             registry: "https://api.rrepo.org".to_string(),
+            r: LockedR::default(),
             roots: vec![],
             packages: BTreeMap::from([
                 (
@@ -1785,6 +1934,7 @@ mod tests {
         let lockfile = Lockfile {
             version: 1,
             registry: "https://api.rrepo.org".to_string(),
+            r: LockedR::default(),
             roots: vec![],
             packages: BTreeMap::from([
                 (

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -6,8 +6,18 @@ use std::{collections::BTreeMap, fs};
 pub struct Lockfile {
     pub version: u32,
     pub registry: String,
+    #[serde(default)]
+    pub r: LockedR,
     pub roots: Vec<LockedRoot>,
     pub packages: BTreeMap<String, LockedPackage>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LockedR {
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub version: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub base_packages: Vec<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -63,13 +73,17 @@ pub fn write_lockfile(lockfile: Lockfile) {
 mod tests {
     use std::collections::BTreeMap;
 
-    use super::{LockedDependency, LockedPackage, LockedRoot, Lockfile};
+    use super::{LockedDependency, LockedPackage, LockedR, LockedRoot, Lockfile};
 
     #[test]
     fn serializes_new_registry_lockfile_shape() {
         let lockfile = Lockfile {
             version: 1,
             registry: "https://api.rrepo.org".to_string(),
+            r: LockedR {
+                version: "4.4.1".to_string(),
+                base_packages: vec!["utils".to_string()],
+            },
             roots: vec![LockedRoot {
                 package: "digest".to_string(),
                 constraint: "*".to_string(),
@@ -97,6 +111,8 @@ mod tests {
 
         assert!(json.contains("\"version\": 1"));
         assert!(json.contains("\"registry\": \"https://api.rrepo.org\""));
+        assert!(json.contains("\"r\""));
+        assert!(json.contains("\"base_packages\""));
         assert!(json.contains("\"roots\""));
         assert!(json.contains("\"source_url\""));
         assert!(json.contains("\"dependencies\""));
@@ -118,5 +134,19 @@ mod tests {
 
         assert!(!json.contains("source_url"));
         assert!(!json.contains("source"));
+    }
+
+    #[test]
+    fn reads_lockfile_without_runtime_requirements() {
+        let json = r#"{
+  "version": 1,
+  "registry": "https://api.rrepo.org",
+  "roots": [],
+  "packages": {}
+}"#;
+
+        let lockfile: Lockfile = serde_json::from_str(json).expect("lockfile should parse");
+
+        assert_eq!(lockfile.r, LockedR::default());
     }
 }

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -2,6 +2,8 @@ use crate::project::{LOCKFILE_NAME, lockfile_path};
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, fs};
 
+pub const LOCKFILE_VERSION: u32 = 2;
+
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Lockfile {
     pub version: u32,
@@ -73,12 +75,12 @@ pub fn write_lockfile(lockfile: Lockfile) {
 mod tests {
     use std::collections::BTreeMap;
 
-    use super::{LockedDependency, LockedPackage, LockedR, LockedRoot, Lockfile};
+    use super::{LOCKFILE_VERSION, LockedDependency, LockedPackage, LockedR, LockedRoot, Lockfile};
 
     #[test]
     fn serializes_new_registry_lockfile_shape() {
         let lockfile = Lockfile {
-            version: 1,
+            version: LOCKFILE_VERSION,
             registry: "https://api.rrepo.org".to_string(),
             r: LockedR {
                 version: "4.4.1".to_string(),
@@ -109,7 +111,7 @@ mod tests {
 
         let json = serde_json::to_string_pretty(&lockfile).expect("lockfile should serialize");
 
-        assert!(json.contains("\"version\": 1"));
+        assert!(json.contains("\"version\": 2"));
         assert!(json.contains("\"registry\": \"https://api.rrepo.org\""));
         assert!(json.contains("\"r\""));
         assert!(json.contains("\"base_packages\""));

--- a/src/r.rs
+++ b/src/r.rs
@@ -30,6 +30,7 @@ pub struct RuntimeInfo {
 }
 
 static RUNTIME_INFO: OnceLock<RuntimeInfo> = OnceLock::new();
+static BASE_PACKAGES: OnceLock<Vec<String>> = OnceLock::new();
 
 pub fn project_command(program: impl AsRef<str>) -> Command {
     library_command(program, &project_library_path(), &[])
@@ -118,6 +119,10 @@ pub fn install_local_package(
 
 pub fn runtime_info() -> RuntimeInfo {
     RUNTIME_INFO.get_or_init(fetch_runtime_info).clone()
+}
+
+pub fn base_packages() -> Vec<String> {
+    BASE_PACKAGES.get_or_init(fetch_base_packages).clone()
 }
 
 pub fn installed_packages() -> Vec<InstalledPackage> {
@@ -232,6 +237,23 @@ fn fetch_runtime_info() -> RuntimeInfo {
             .expect("R package type should be present")
             .to_string(),
     }
+}
+
+fn fetch_base_packages() -> Vec<String> {
+    let output = Command::new("Rscript")
+        .arg("-e")
+        .arg("writeLines(rownames(installed.packages(priority = 'base')))")
+        .output()
+        .expect("failed to run Rscript");
+
+    crate::exit_with_status(output.status.code());
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToString::to_string)
+        .collect()
 }
 
 fn summarize_install_output(stdout: &[u8], stderr: &[u8]) -> String {

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -14,6 +14,22 @@ use crate::{
 };
 
 const ROOT_PACKAGE: &str = "__rpx_root__";
+const BASE_PACKAGES: &[&str] = &[
+    "base",
+    "compiler",
+    "datasets",
+    "graphics",
+    "grDevices",
+    "grid",
+    "methods",
+    "parallel",
+    "splines",
+    "stats",
+    "stats4",
+    "tcltk",
+    "tools",
+    "utils",
+];
 type VersionRange = Ranges<Version>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -82,6 +98,7 @@ impl<'a> RegistryDependencyProvider<'a> {
         let progress = ResolutionUi::new();
         let root_dependencies = roots
             .iter()
+            .filter(|root| !is_base_package(&root.name))
             .map(|root| {
                 let range = parse_constraint_range(&root.constraint)?;
                 Ok(PackageDependency {
@@ -298,6 +315,7 @@ impl DependencyProvider for RegistryDependencyProvider<'_> {
             metadata
                 .dependencies
                 .into_iter()
+                .filter(|dependency| !is_base_package(&dependency.resolved.package))
                 .filter_map(|dependency| {
                     match self.registry_contains_package(&dependency.resolved.package) {
                         Ok(true) => {
@@ -312,6 +330,10 @@ impl DependencyProvider for RegistryDependencyProvider<'_> {
                 .collect::<DependencyConstraints<_, _>>(),
         ))
     }
+}
+
+pub fn is_base_package(package: &str) -> bool {
+    BASE_PACKAGES.contains(&package)
 }
 
 pub fn resolve_from_registry(

--- a/tests/deps.rs
+++ b/tests/deps.rs
@@ -84,6 +84,34 @@ fn runs_rpx_add_inside_custom_r_image() {
 }
 
 #[test]
+fn records_base_package_as_runtime_requirement() {
+    let container = start_container();
+    let project_path = "/tmp/rpx-project-add-base-package";
+    create_package_project(&container, project_path);
+
+    let command = format!("mkdir -p {project_path} && cd {project_path} && rpx add grid");
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &command);
+
+    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
+    assert!(
+        stdout.contains("Added grid"),
+        "stdout was: {stdout}\nstderr was: {stderr}"
+    );
+    assert_package_state(&container, project_path, "grid", "FALSE");
+
+    let lockfile = read_project_file(&container, project_path, "rpx.lock");
+    assert!(lockfile.contains("\"r\""), "lockfile was: {lockfile}");
+    assert!(
+        lockfile.contains("\"base_packages\": [\n      \"grid\"\n    ]"),
+        "lockfile was: {lockfile}"
+    );
+    assert!(
+        lockfile.contains("\"packages\": {}"),
+        "lockfile was: {lockfile}"
+    );
+}
+
+#[test]
 fn runs_rpx_remove_inside_custom_r_image() {
     let container = start_container();
     let project_path = "/tmp/rpx-project-remove";

--- a/tests/status.rs
+++ b/tests/status.rs
@@ -31,7 +31,7 @@ fn runs_rpx_status_for_lockfile_drift() {
     assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
 
     let seed_lockfile = format!(
-        "mkdir -p {project_path} && cd {project_path} && cat > rpx.lock <<'EOF'\n{{\n  \"version\": 1,\n  \"registry\": \"https://api.rrepo.org\",\n  \"roots\": [],\n  \"packages\": {{}}\n}}\nEOF"
+        "mkdir -p {project_path} && cd {project_path} && cat > rpx.lock <<'EOF'\n{{\n  \"version\": 2,\n  \"registry\": \"https://api.rrepo.org\",\n  \"roots\": [],\n  \"packages\": {{}}\n}}\nEOF"
     );
     let (exit_code, stdout, stderr) = run_shell_command(&container, &seed_lockfile);
     assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
@@ -53,6 +53,35 @@ fn runs_rpx_status_for_lockfile_drift() {
     );
     assert!(
         stdout.contains("- digest"),
+        "stdout was: {stdout}\nstderr was: {stderr}"
+    );
+}
+
+#[test]
+fn reports_old_lockfile_needs_update() {
+    let container = start_container();
+    let project_path = "/tmp/rpx-project-status-old-lockfile";
+    create_package_project(&container, project_path);
+    let seed_lockfile = format!(
+        "mkdir -p {project_path} && cd {project_path} && cat > rpx.lock <<'EOF'\n{{\n  \"version\": 1,\n  \"registry\": \"https://api.rrepo.org\",\n  \"roots\": [],\n  \"packages\": {{}}\n}}\nEOF"
+    );
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &seed_lockfile);
+    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
+
+    let status_command = format!("cd {project_path} && rpx status");
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &status_command);
+    assert_eq!(exit_code, 1, "stdout was: {stdout}\nstderr was: {stderr}");
+    assert!(
+        stdout.contains("Lockfile is out of date"),
+        "stdout was: {stdout}\nstderr was: {stderr}"
+    );
+    assert!(
+        stdout
+            .contains("Your lockfile was created by an older rpx version and needs to be updated."),
+        "stdout was: {stdout}\nstderr was: {stderr}"
+    );
+    assert!(
+        stdout.contains("Run: rpx lock"),
         "stdout was: {stdout}\nstderr was: {stderr}"
     );
 }

--- a/tests/status.rs
+++ b/tests/status.rs
@@ -162,7 +162,7 @@ fn runs_rpx_status_for_version_mismatch() {
     assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
 
     let mutate_lockfile = format!(
-        "cd {project_path} && perl -0pi -e 's/\"version\": \"[0-9.]+\"/\"version\": \"0.0.1\"/' rpx.lock"
+        "cd {project_path} && perl -0pi -e 's/(\"digest\": \\{{\\s+\"package\": \"digest\",\\s+\"version\": )\"[0-9.]+\"/${{1}}\"0.0.1\"/' rpx.lock"
     );
     let (exit_code, stdout, stderr) = run_shell_command(&container, &mutate_lockfile);
     assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
@@ -184,6 +184,39 @@ fn runs_rpx_status_for_version_mismatch() {
     );
     assert!(
         stdout.contains("0.0.1 locked"),
+        "stdout was: {stdout}\nstderr was: {stderr}"
+    );
+}
+
+#[test]
+fn reports_r_runtime_version_mismatch_without_failing_status() {
+    let container = start_container();
+    let project_path = "/tmp/rpx-project-status-r-version-mismatch";
+    create_package_project(&container, project_path);
+
+    let setup_command = format!("cd {project_path} && rpx add digest");
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &setup_command);
+    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
+
+    let mutate_lockfile = format!(
+        "cd {project_path} && perl -0pi -e 's/(\"r\": \\{{\\s+\"version\": )\"[0-9.]+\"/${{1}}\"0.0.1\"/' rpx.lock"
+    );
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &mutate_lockfile);
+    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
+
+    let status_command = format!("cd {project_path} && rpx status");
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &status_command);
+    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
+    assert!(
+        stdout.contains("R runtime differs from lockfile:"),
+        "stdout was: {stdout}\nstderr was: {stderr}"
+    );
+    assert!(
+        stdout.contains("R 0.0.1 locked"),
+        "stdout was: {stdout}\nstderr was: {stderr}"
+    );
+    assert!(
+        stdout.contains("Project is in sync"),
         "stdout was: {stdout}\nstderr was: {stderr}"
     );
 }

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -165,7 +165,7 @@ fn runs_rpx_sync_restores_locked_versions() {
     assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
 
     let seed_lockfile = format!(
-        "mkdir -p {project_path} && cd {project_path} && cat > rpx.lock <<'EOF'\n{{\n  \"version\": 1,\n  \"registry\": \"https://api.rrepo.org\",\n  \"roots\": [\n    {{\n      \"package\": \"digest\",\n      \"constraint\": \"*\"\n    }}\n  ],\n  \"packages\": {{\n    \"digest\": {{\n      \"package\": \"digest\",\n      \"version\": \"0.6.37\",\n      \"source\": \"registry\",\n      \"source_url\": \"https://api.rrepo.org/packages/digest/versions/0.6.37/source\"\n    }}\n  }}\n}}\nEOF"
+        "mkdir -p {project_path} && cd {project_path} && cat > rpx.lock <<'EOF'\n{{\n  \"version\": 2,\n  \"registry\": \"https://api.rrepo.org\",\n  \"roots\": [\n    {{\n      \"package\": \"digest\",\n      \"constraint\": \"*\"\n    }}\n  ],\n  \"packages\": {{\n    \"digest\": {{\n      \"package\": \"digest\",\n      \"version\": \"0.6.37\",\n      \"source\": \"registry\",\n      \"source_url\": \"https://api.rrepo.org/packages/digest/versions/0.6.37/source\"\n    }}\n  }}\n}}\nEOF"
     );
     let (exit_code, stdout, stderr) = run_shell_command(&container, &seed_lockfile);
     assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
@@ -182,6 +182,31 @@ fn runs_rpx_sync_restores_locked_versions() {
     assert_eq!(
         after, before,
         "lockfile changed during strict sync\nbefore:\n{before}\nafter:\n{after}"
+    );
+}
+
+#[test]
+fn refuses_to_sync_old_lockfile() {
+    let container = start_container();
+    let project_path = "/tmp/rpx-project-sync-old-lockfile";
+    create_package_project(&container, project_path);
+    let seed_lockfile = format!(
+        "mkdir -p {project_path} && cd {project_path} && cat > rpx.lock <<'EOF'\n{{\n  \"version\": 1,\n  \"registry\": \"https://api.rrepo.org\",\n  \"roots\": [],\n  \"packages\": {{}}\n}}\nEOF"
+    );
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &seed_lockfile);
+    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
+
+    let sync_command = format!("cd {project_path} && rpx sync");
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &sync_command);
+    assert_eq!(exit_code, 1, "stdout was: {stdout}\nstderr was: {stderr}");
+    assert!(
+        stderr
+            .contains("Your lockfile was created by an older rpx version and needs to be updated."),
+        "stdout was: {stdout}\nstderr was: {stderr}"
+    );
+    assert!(
+        stderr.contains("Run: rpx lock"),
+        "stdout was: {stdout}\nstderr was: {stderr}"
     );
 }
 


### PR DESCRIPTION
Installs used to fail because dependencies resolved packages like grid from the registry not the base package set.