### PR TITLE
Enhance system dependency management and sync functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1919,7 +1919,7 @@ dependencies = [
 
 [[package]]
 name = "rpx"
-version = "1.1.6"
+version = "1.2.0"
 dependencies = [
  "clap",
  "deb822-fast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,6 +446,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7704b5fdd17b18ae31c4c1da5a2e0305a2bf17b5249300a9ee9ed7b72114c636"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,6 +643,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1286,6 +1311,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1889,15 +1924,18 @@ dependencies = [
  "clap",
  "deb822-fast",
  "directories",
+ "flate2",
  "indicatif",
  "keyring",
  "mockito",
  "pubgrub",
  "r-description",
+ "regex",
  "reqwest",
  "rpassword",
  "serde",
  "serde_json",
+ "tar",
  "testcontainers",
  "tracing",
  "tracing-indicatif",
@@ -2197,6 +2235,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2294,6 +2338,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpx"
-version = "1.1.6"
+version = "1.2.0"
 edition = "2024"
 description = "Rust CLI for managing R package project dependencies"
 repository = "https://github.com/scalerail-solutions/rpx"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,14 +12,17 @@ categories = ["command-line-utilities", "development-tools"]
 clap = { version = "4.6.0", features = ["derive"] }
 deb822-fast = "0.2.3"
 directories = "6.0.0"
+flate2 = "1.1.5"
 indicatif = "0.18.4"
 keyring = { version = "3.6.3", default-features = false, features = ["apple-native", "linux-native", "windows-native"] }
 pubgrub = "0.3.0"
+regex = "1.12.2"
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 rpassword = "7.3.1"
 r-description = "0.3.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+tar = "0.4.44"
 tracing = "0.1.41"
 tracing-indicatif = "0.3.13"
 tracing-subscriber = "0.3.19"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -80,11 +80,16 @@ pub enum Commands {
     Sync {
         #[arg(
             long,
+            conflicts_with = "install_only_system",
             help = "Install missing system dependencies before syncing R packages"
         )]
         install_system: bool,
 
-        #[arg(long, help = "Install only missing system dependencies and stop")]
+        #[arg(
+            long,
+            conflicts_with = "install_system",
+            help = "Install only missing system dependencies and stop"
+        )]
         install_only_system: bool,
     },
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -77,7 +77,16 @@ pub enum Commands {
         about = "Install the locked package set",
         long_about = "Install the exact package set recorded in rpx.lock into the project library."
     )]
-    Sync,
+    Sync {
+        #[arg(
+            long,
+            help = "Install missing system dependencies before syncing R packages"
+        )]
+        install_system: bool,
+
+        #[arg(long, help = "Install only missing system dependencies and stop")]
+        install_only_system: bool,
+    },
 
     #[command(
         about = "Remove project library and caches",

--- a/src/description.rs
+++ b/src/description.rs
@@ -106,6 +106,14 @@ impl RDescription {
             .unwrap_or_default()
     }
 
+    pub fn system_requirements(&self) -> Option<String> {
+        self.paragraph
+            .get("SystemRequirements")
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToString::to_string)
+    }
+
     pub fn remove_field(&mut self, field_name: &str) {
         self.paragraph.remove(field_name);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 use std::{
     collections::{BTreeMap, BTreeSet, VecDeque},
     env, fs,
+    io::{IsTerminal, Write},
     path::{Path, PathBuf},
     sync::{Arc, Mutex, mpsc},
     thread,
@@ -16,12 +17,14 @@ mod r;
 mod registry;
 mod repository;
 mod resolver;
+mod sysreqs;
 mod ui;
 
 use cli::{Cli, Commands, RepoCommands};
 use description::{DescriptionExt, init_description, read_description, write_description};
 use lockfile::{
-    LOCKFILE_VERSION, LockedR, Lockfile, read_lockfile, read_lockfile_optional, write_lockfile,
+    LOCKFILE_VERSION, LockedR, LockedSystemRequirements, Lockfile, read_lockfile,
+    read_lockfile_optional, write_lockfile,
 };
 use project::{
     build_temp_library_path, cache_dir_path, compiled_cache_package_path, project_library_path,
@@ -40,6 +43,11 @@ use repository::{
     RepositorySet, RepositorySource, normalize_repository_url, repository_source_from_package_url,
 };
 use resolver::{ResolvedPackage, is_base_package, resolve_from_registry};
+use sysreqs::{
+    SystemDependencyPlan, current_host_platform, install as install_system_dependencies,
+    latest_snapshot as latest_sysreq_snapshot, preview_commands as sysreq_preview_commands,
+    resolve_plan as resolve_system_plan,
+};
 use ui::{InstallKind, SyncUi};
 
 const SYNC_WORKERS: usize = 4;
@@ -54,7 +62,10 @@ pub fn run() {
         Commands::Run { command } => cmd_run(&command),
         Commands::Lock => cmd_lock(),
         Commands::Status => cmd_status(),
-        Commands::Sync => cmd_sync(),
+        Commands::Sync {
+            install_system,
+            install_only_system,
+        } => cmd_sync(install_system, install_only_system),
         Commands::Clean => cmd_clean(),
         Commands::Repo { command } => cmd_repo(command),
     }
@@ -83,6 +94,8 @@ fn cmd_add(packages: &[String]) {
     }
 
     if !new_packages.is_empty() {
+        let sysreq_db =
+            latest_sysreq_snapshot().expect("failed to load system requirements database");
         let resolved_addition = resolve_additions_from_latest(
             &project.description,
             lockfile.as_ref(),
@@ -105,6 +118,7 @@ fn cmd_add(packages: &[String]) {
             project.description.resolution_roots(),
             &default_registry_base_url(),
             &resolved_addition.resolved,
+            &sysreq_db,
         ));
     }
 
@@ -114,7 +128,7 @@ fn cmd_add(packages: &[String]) {
     } else {
         let _ = lock_from_description();
     }
-    let _ = sync_from_lockfile();
+    let _ = sync_from_lockfile(false, false);
     println!("Added {}", packages.join(", "));
 }
 
@@ -236,7 +250,7 @@ fn cmd_remove(packages: &[String]) {
     }
 
     let _ = lock_from_description();
-    let _ = sync_from_lockfile();
+    let _ = sync_from_lockfile(false, false);
 
     if !removed.is_empty() {
         println!("Removed {}", removed.join(", "));
@@ -272,8 +286,11 @@ fn cmd_lock() {
     }
 }
 
-fn cmd_sync() {
-    let outcome = sync_from_lockfile();
+fn cmd_sync(install_system: bool, install_only_system: bool) {
+    let outcome = sync_from_lockfile(install_system, install_only_system);
+    if install_only_system {
+        return;
+    }
     if outcome.installed == 0 && outcome.removed == 0 {
         println!("Project library is already in sync");
     } else {
@@ -329,6 +346,7 @@ fn cmd_status() {
         .collect::<std::collections::BTreeMap<_, _>>();
     let locked_names = locked_package_names(&lockfile);
     let runtime_status = runtime_status(&lockfile);
+    let system_plan = system_plan_from_lockfile(&lockfile).ok();
 
     let missing_from_lockfile = manifest_requirements
         .difference(&lock_requirements)
@@ -369,6 +387,10 @@ fn cmd_status() {
         && extra_in_library.is_empty()
         && version_mismatches.is_empty()
         && runtime_status.missing_base_packages.is_empty()
+        && system_plan
+            .as_ref()
+            .map(|plan| plan.missing_packages.is_empty() && plan.unsupported_rules.is_empty())
+            .unwrap_or(true)
     {
         print_runtime_version_warning(&runtime_status);
         println!("Project is in sync");
@@ -380,6 +402,10 @@ fn cmd_status() {
         || !extra_in_library.is_empty()
         || !version_mismatches.is_empty();
     let runtime_out_of_date = !runtime_status.missing_base_packages.is_empty();
+    let system_out_of_date = system_plan
+        .as_ref()
+        .map(|plan| !plan.missing_packages.is_empty() || !plan.unsupported_rules.is_empty())
+        .unwrap_or(false);
 
     if lockfile_out_of_date && library_out_of_date {
         println!("Project is out of sync");
@@ -391,6 +417,8 @@ fn cmd_status() {
         println!("Run: rpx lock");
     } else if runtime_out_of_date {
         println!("R runtime is out of sync");
+    } else if system_out_of_date {
+        println!("System dependencies are out of sync");
     } else {
         println!("Project library is out of sync");
         println!();
@@ -416,6 +444,16 @@ fn cmd_status() {
         "R runtime is missing locked base packages:",
         &runtime_status.missing_base_packages,
     );
+    if let Some(plan) = system_plan {
+        print_status_group(
+            "Missing system packages for this host:",
+            &plan.missing_packages,
+        );
+        print_status_group(
+            "System requirement rules without a host mapping:",
+            &plan.unsupported_rules,
+        );
+    }
 
     std::process::exit(1);
 }
@@ -671,9 +709,10 @@ fn lock_from_description() -> LockOutcome {
     let registry = default_registry_base_url();
     let repositories = configured_repositories(&project);
     let existing_lockfile = read_lockfile_optional().expect("failed to read lockfile");
+    let sysreq_db = latest_sysreq_snapshot().expect("failed to load system requirements database");
 
     if roots.is_empty() {
-        let lockfile = lockfile_from_resolution(vec![], &registry, &[]);
+        let lockfile = lockfile_from_resolution(vec![], &registry, &[], &sysreq_db);
         let changed = existing_lockfile.as_ref() != Some(&lockfile);
         write_lockfile(lockfile);
         return LockOutcome { changed };
@@ -682,13 +721,13 @@ fn lock_from_description() -> LockOutcome {
     let resolved = resolve_from_registry(&repositories, &roots, &BTreeMap::new())
         .unwrap_or_else(|error| panic!("failed to resolve package set from registry: {error}"));
 
-    let lockfile = lockfile_from_resolution(roots, &registry, &resolved);
+    let lockfile = lockfile_from_resolution(roots, &registry, &resolved, &sysreq_db);
     let changed = existing_lockfile.as_ref() != Some(&lockfile);
     write_lockfile(lockfile);
     LockOutcome { changed }
 }
 
-fn sync_from_lockfile() -> SyncOutcome {
+fn sync_from_lockfile(install_system: bool, install_only_system: bool) -> SyncOutcome {
     let project = read_description().expect("failed to read DESCRIPTION");
     let manifest_requirements = project
         .description
@@ -698,6 +737,15 @@ fn sync_from_lockfile() -> SyncOutcome {
     let lockfile = read_lockfile().expect("failed to read lockfile");
     validate_lockfile_version_for_sync(&lockfile);
     validate_runtime_for_sync(&lockfile);
+    let system_plan = system_plan_from_lockfile(&lockfile).unwrap_or_else(|error| {
+        eprintln!("warning: failed to prepare system dependency plan: {error}");
+        system_plan_without_db(&lockfile)
+    });
+    let proceed_with_r =
+        handle_system_requirements(&system_plan, install_system, install_only_system);
+    if install_only_system || !proceed_with_r {
+        return SyncOutcome::default();
+    }
     let lock_requirements = lockfile
         .roots
         .iter()
@@ -935,8 +983,10 @@ fn lockfile_from_resolution(
     roots: Vec<ResolutionRoot>,
     registry: &str,
     resolved: &[ResolvedPackage],
+    sysreq_db: &sysreqs::SysreqDbSnapshot,
 ) -> Lockfile {
     let required_base_packages = locked_base_packages(&roots, resolved);
+    let sysreqs = locked_system_requirements(resolved, sysreq_db);
     Lockfile {
         version: LOCKFILE_VERSION,
         registry: registry.to_string(),
@@ -944,6 +994,7 @@ fn lockfile_from_resolution(
             version: runtime_info().version,
             base_packages: required_base_packages,
         },
+        sysreqs,
         roots: roots
             .into_iter()
             .map(|root| lockfile::LockedRoot {
@@ -1072,6 +1123,149 @@ fn print_runtime_version_warning(status: &RuntimeStatus) {
     println!();
     println!("R runtime differs from lockfile:");
     println!("- {version_mismatch}");
+}
+
+fn system_plan_from_lockfile(lockfile: &Lockfile) -> Result<SystemDependencyPlan, String> {
+    if lockfile.sysreqs.db_commit.is_empty() {
+        return Ok(system_plan_without_db(lockfile));
+    }
+
+    let snapshot = sysreqs::snapshot_for_commit(&lockfile.sysreqs.db_commit)?;
+    Ok(resolve_system_plan(&snapshot, &lockfile.sysreqs.packages))
+}
+
+fn system_plan_without_db(lockfile: &Lockfile) -> SystemDependencyPlan {
+    SystemDependencyPlan {
+        host: current_host_platform(),
+        missing_packages: vec![],
+        install_packages: vec![],
+        pre_install_commands: vec![],
+        post_install_commands: vec![],
+        unsupported_rules: lockfile.sysreqs.rules.clone(),
+        package_rules: lockfile.sysreqs.packages.clone(),
+        install_supported: false,
+        can_auto_install: false,
+        installed_query_error: None,
+    }
+}
+
+fn handle_system_requirements(
+    plan: &SystemDependencyPlan,
+    install_system: bool,
+    install_only_system: bool,
+) -> bool {
+    if !plan.unsupported_rules.is_empty() {
+        eprintln!(
+            "warning: some system requirement rules do not have an install mapping for {}: {}",
+            plan.host.label(),
+            plan.unsupported_rules.join(", ")
+        );
+    }
+
+    if let Some(error) = &plan.installed_query_error {
+        eprintln!("warning: {error}");
+    }
+
+    if plan.missing_packages.is_empty() {
+        if install_only_system {
+            println!("System dependencies are already installed");
+        }
+        return !install_only_system;
+    }
+
+    eprintln!(
+        "warning: missing system packages for {}: {}",
+        plan.host.label(),
+        plan.missing_packages.join(", ")
+    );
+    let preview = sysreq_preview_commands(plan);
+    if !preview.is_empty() {
+        eprintln!("System install commands:");
+        for command in &preview {
+            eprintln!("- {command}");
+        }
+    }
+
+    if install_system || install_only_system {
+        install_system_dependencies(plan)
+            .unwrap_or_else(|error| panic!("failed to install system dependencies: {error}"));
+        if install_only_system {
+            println!("Installed system dependencies");
+            return false;
+        }
+        return true;
+    }
+
+    if !std::io::stdin().is_terminal() || !std::io::stderr().is_terminal() {
+        eprintln!("warning: continuing with R package sync without installing system dependencies");
+        return !install_only_system;
+    }
+
+    match prompt_for_system_dependency_action() {
+        SyncSystemChoice::InstallAndContinue => {
+            install_system_dependencies(plan)
+                .unwrap_or_else(|error| panic!("failed to install system dependencies: {error}"));
+            true
+        }
+        SyncSystemChoice::TryROnly => true,
+        SyncSystemChoice::Cancel => {
+            println!("Canceled");
+            std::process::exit(1);
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SyncSystemChoice {
+    InstallAndContinue,
+    TryROnly,
+    Cancel,
+}
+
+fn prompt_for_system_dependency_action() -> SyncSystemChoice {
+    eprintln!("Choose an action:");
+    eprintln!("1. Install system deps and continue");
+    eprintln!("2. Try to install R packages only");
+    eprintln!("3. Cancel");
+    eprint!("> ");
+    std::io::stderr().flush().expect("failed to flush prompt");
+
+    let mut input = String::new();
+    if std::io::stdin().read_line(&mut input).is_err() {
+        return SyncSystemChoice::TryROnly;
+    }
+
+    match input.trim() {
+        "1" | "y" | "Y" => SyncSystemChoice::InstallAndContinue,
+        "2" | "r" | "R" => SyncSystemChoice::TryROnly,
+        _ => SyncSystemChoice::Cancel,
+    }
+}
+
+fn locked_system_requirements(
+    resolved: &[ResolvedPackage],
+    sysreq_db: &sysreqs::SysreqDbSnapshot,
+) -> LockedSystemRequirements {
+    let packages = resolved
+        .iter()
+        .filter_map(|package| {
+            let rules = sysreqs::match_rules(package.system_requirements.as_deref(), sysreq_db);
+            (!rules.is_empty()).then(|| (package.name.clone(), rules))
+        })
+        .collect::<BTreeMap<_, _>>();
+    let rules = packages
+        .values()
+        .flatten()
+        .cloned()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect();
+
+    LockedSystemRequirements {
+        db_commit: sysreq_db.commit.clone(),
+        rules,
+        packages,
+    }
 }
 
 fn validate_runtime_for_sync(lockfile: &Lockfile) {
@@ -1640,10 +1834,14 @@ mod tests {
     use crate::description::RDescription;
     use crate::{
         description::DescriptionExt,
-        lockfile::{LOCKFILE_VERSION, LockedDependency, LockedPackage, LockedR, Lockfile},
+        lockfile::{
+            LOCKFILE_VERSION, LockedDependency, LockedPackage, LockedR, LockedSystemRequirements,
+            Lockfile,
+        },
         r::RuntimeInfo,
         registry::ResolutionRoot,
         resolver::{ResolvedDependency, ResolvedPackage},
+        sysreqs::SysreqDbSnapshot,
     };
     use std::collections::BTreeMap;
     use std::{
@@ -1718,6 +1916,7 @@ mod tests {
                             max_version_exclusive: None,
                         },
                     ],
+                    system_requirements: None,
                 },
                 ResolvedPackage {
                     name: "digest".to_string(),
@@ -1725,8 +1924,10 @@ mod tests {
                     source_url: "https://api.rrepo.org/packages/digest/versions/0.6.37/source"
                         .to_string(),
                     dependencies: vec![],
+                    system_requirements: None,
                 },
             ],
+            &empty_sysreq_db(),
         );
 
         assert_eq!(lockfile.registry, "https://api.rrepo.org");
@@ -1821,6 +2022,7 @@ mod tests {
                 source_url: "https://api.rrepo.org/packages/digest/versions/0.6.37/source"
                     .to_string(),
                 dependencies: vec![],
+                system_requirements: None,
             }],
         )
         .expect("constraints should derive");
@@ -1851,6 +2053,7 @@ mod tests {
             }],
             "https://api.rrepo.org",
             &[],
+            &empty_sysreq_db(),
         );
 
         assert_eq!(lockfile.r.base_packages, vec!["grid"]);
@@ -1890,6 +2093,7 @@ mod tests {
             version: LOCKFILE_VERSION,
             registry: "https://api.rrepo.org".to_string(),
             r: LockedR::default(),
+            sysreqs: LockedSystemRequirements::default(),
             roots: vec![],
             packages: BTreeMap::from([
                 (
@@ -1960,6 +2164,7 @@ mod tests {
             version: LOCKFILE_VERSION,
             registry: "https://api.rrepo.org".to_string(),
             r: LockedR::default(),
+            sysreqs: LockedSystemRequirements::default(),
             roots: vec![],
             packages: BTreeMap::from([
                 (
@@ -2110,5 +2315,13 @@ mod tests {
             compiled_cache_key("jsonlite", "2.0.0", &source_runtime),
             compiled_cache_key("jsonlite", "2.0.0", &binary_runtime)
         );
+    }
+
+    fn empty_sysreq_db() -> SysreqDbSnapshot {
+        SysreqDbSnapshot {
+            commit: "test-commit".to_string(),
+            rules: vec![],
+            scripts: BTreeMap::new(),
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,9 @@ use sysreqs::{
     SystemDependencyPlan, cached_latest_snapshot, current_host_platform,
     empty_snapshot as empty_sysreq_snapshot, install as install_system_dependencies,
     latest_snapshot as latest_sysreq_snapshot, preview_commands as sysreq_preview_commands,
+    refresh_metadata as refresh_system_metadata,
+    refresh_preview_command as system_metadata_refresh_preview,
+    recheck_missing_packages as recheck_system_missing_packages,
     resolve_plan as resolve_system_plan,
 };
 use ui::{InstallKind, SyncUi};
@@ -1176,6 +1179,7 @@ fn system_plan_without_db(lockfile: &Lockfile) -> SystemDependencyPlan {
         install_supported: false,
         can_auto_install: false,
         installed_query_error: None,
+        needs_metadata_refresh: false,
     }
 }
 
@@ -1186,6 +1190,7 @@ fn handle_system_requirements(
 ) -> bool {
     let explicit_install = install_system || install_only_system;
     let interactive = std::io::stdin().is_terminal() && std::io::stderr().is_terminal();
+    let mut plan = plan.clone();
 
     if !plan.unsupported_rules.is_empty() {
         eprintln!(
@@ -1195,8 +1200,35 @@ fn handle_system_requirements(
         );
     }
 
+    if plan.needs_metadata_refresh && explicit_install {
+        if interactive {
+            prompt_for_metadata_refresh(&plan);
+        }
+
+        refresh_system_metadata(&plan)
+            .unwrap_or_else(|error| panic!("failed to refresh package metadata: {error}"));
+        match recheck_system_missing_packages(&plan) {
+            Ok(missing_packages) => {
+                plan.missing_packages = missing_packages;
+                plan.installed_query_error = None;
+                plan.needs_metadata_refresh = false;
+            }
+            Err(error) => {
+                plan.installed_query_error = Some(error);
+                plan.needs_metadata_refresh = false;
+            }
+        }
+    }
+
     if let Some(error) = &plan.installed_query_error {
-        eprintln!("warning: {error}");
+        if explicit_install {
+            eprintln!("rpx could not verify system package availability with apt.");
+            eprintln!();
+            eprintln!("Apt reported:");
+            eprintln!("{error}");
+        } else {
+            eprintln!("warning: {error}");
+        }
     }
 
     if plan.missing_packages.is_empty() {
@@ -1206,14 +1238,24 @@ fn handle_system_requirements(
         return !install_only_system;
     }
 
-    eprintln!(
-        "warning: missing system packages for {}: {}",
-        plan.host.label(),
-        plan.missing_packages.join(", ")
-    );
-    let preview = sysreq_preview_commands(plan);
+    if plan.installed_query_error.is_some() {
+        print_system_package_summary(
+            "Requested system packages for this project:",
+            &plan.install_packages,
+        );
+    } else {
+        print_system_package_summary(
+            &format!("Missing system packages for {}:", plan.host.label()),
+            &plan.missing_packages,
+        );
+    }
+    let preview = sysreq_preview_commands(&plan);
     if !preview.is_empty() {
-        eprintln!("System install commands:");
+        if plan.installed_query_error.is_some() {
+            eprintln!("rpx can still try to install them now:");
+        } else {
+            eprintln!("rpx can run:");
+        }
         for command in &preview {
             eprintln!("- {command}");
         }
@@ -1225,7 +1267,7 @@ fn handle_system_requirements(
     }
 
     if explicit_install {
-        install_system_dependencies(plan)
+        install_system_dependencies(&plan)
             .unwrap_or_else(|error| panic!("failed to install system dependencies: {error}"));
         if install_only_system {
             println!("Installed system dependencies");
@@ -1241,7 +1283,7 @@ fn handle_system_requirements(
 
     match prompt_for_system_dependency_action() {
         SyncSystemChoice::InstallAndContinue => {
-            install_system_dependencies(plan)
+            install_system_dependencies(&plan)
                 .unwrap_or_else(|error| panic!("failed to install system dependencies: {error}"));
             true
         }
@@ -1264,6 +1306,42 @@ fn prompt_for_install_confirmation() -> bool {
     }
 
     matches!(input.trim(), "y" | "Y" | "yes" | "YES" | "Yes")
+}
+
+fn print_system_package_summary(title: &str, packages: &[String]) {
+    eprintln!("{title}");
+    let shown = packages.iter().take(8).collect::<Vec<_>>();
+    for package in shown {
+        eprintln!("- {package}");
+    }
+    if packages.len() > 8 {
+        eprintln!("- ... and {} more", packages.len() - 8);
+    }
+}
+
+fn prompt_for_metadata_refresh(plan: &SystemDependencyPlan) {
+    eprintln!("rpx could not verify which system packages are missing yet.");
+    eprintln!();
+    eprintln!("rpx can run:");
+    if let Some(command) = system_metadata_refresh_preview(plan) {
+        eprintln!("- {command}");
+    }
+    eprintln!("to refresh apt package information and check what is missing.");
+    eprintln!();
+    eprintln!("Run package metadata refresh now? [y/N]");
+    eprint!("> ");
+    std::io::stderr().flush().expect("failed to flush prompt");
+
+    let mut input = String::new();
+    if std::io::stdin().read_line(&mut input).is_err() {
+        println!("Canceled");
+        std::process::exit(1);
+    }
+
+    if !matches!(input.trim(), "y" | "Y" | "yes" | "YES" | "Yes") {
+        println!("Canceled");
+        std::process::exit(1);
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1184,6 +1184,9 @@ fn handle_system_requirements(
     install_system: bool,
     install_only_system: bool,
 ) -> bool {
+    let explicit_install = install_system || install_only_system;
+    let interactive = std::io::stdin().is_terminal() && std::io::stderr().is_terminal();
+
     if !plan.unsupported_rules.is_empty() {
         eprintln!(
             "warning: some system requirement rules do not have an install mapping for {}: {}",
@@ -1216,7 +1219,12 @@ fn handle_system_requirements(
         }
     }
 
-    if install_system || install_only_system {
+    if explicit_install && interactive && !prompt_for_install_confirmation() {
+        println!("Canceled");
+        std::process::exit(1);
+    }
+
+    if explicit_install {
         install_system_dependencies(plan)
             .unwrap_or_else(|error| panic!("failed to install system dependencies: {error}"));
         if install_only_system {
@@ -1226,7 +1234,7 @@ fn handle_system_requirements(
         return true;
     }
 
-    if !std::io::stdin().is_terminal() || !std::io::stderr().is_terminal() {
+    if !interactive {
         eprintln!("warning: continuing with R package sync without installing system dependencies");
         return !install_only_system;
     }
@@ -1243,6 +1251,19 @@ fn handle_system_requirements(
             std::process::exit(1);
         }
     }
+}
+
+fn prompt_for_install_confirmation() -> bool {
+    eprintln!("Proceed with system package installation? [y/N]");
+    eprint!("> ");
+    std::io::stderr().flush().expect("failed to flush prompt");
+
+    let mut input = String::new();
+    if std::io::stdin().read_line(&mut input).is_err() {
+        return false;
+    }
+
+    matches!(input.trim(), "y" | "Y" | "yes" | "YES" | "Yes")
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,7 +293,9 @@ fn cmd_lock() {
 
 fn cmd_sync(install_system: bool, install_only_system: bool) {
     if (install_system || install_only_system) && !host_supports_system_sync() {
-        eprintln!("System dependency installation is currently supported only on Linux.");
+        eprintln!(
+            "System dependency installation is currently supported only on supported Linux distributions/package managers."
+        );
         std::process::exit(1);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,8 @@ use repository::{
 };
 use resolver::{ResolvedPackage, is_base_package, resolve_from_registry};
 use sysreqs::{
-    SystemDependencyPlan, current_host_platform, install as install_system_dependencies,
+    SystemDependencyPlan, cached_latest_snapshot, current_host_platform,
+    empty_snapshot as empty_sysreq_snapshot, install as install_system_dependencies,
     latest_snapshot as latest_sysreq_snapshot, preview_commands as sysreq_preview_commands,
     resolve_plan as resolve_system_plan,
 };
@@ -94,8 +95,7 @@ fn cmd_add(packages: &[String]) {
     }
 
     if !new_packages.is_empty() {
-        let sysreq_db =
-            latest_sysreq_snapshot().expect("failed to load system requirements database");
+        let sysreq_db = load_sysreq_snapshot_for_lock(lockfile.as_ref());
         let resolved_addition = resolve_additions_from_latest(
             &project.description,
             lockfile.as_ref(),
@@ -709,7 +709,7 @@ fn lock_from_description() -> LockOutcome {
     let registry = default_registry_base_url();
     let repositories = configured_repositories(&project);
     let existing_lockfile = read_lockfile_optional().expect("failed to read lockfile");
-    let sysreq_db = latest_sysreq_snapshot().expect("failed to load system requirements database");
+    let sysreq_db = load_sysreq_snapshot_for_lock(existing_lockfile.as_ref());
 
     if roots.is_empty() {
         let lockfile = lockfile_from_resolution(vec![], &registry, &[], &sysreq_db);
@@ -725,6 +725,36 @@ fn lock_from_description() -> LockOutcome {
     let changed = existing_lockfile.as_ref() != Some(&lockfile);
     write_lockfile(lockfile);
     LockOutcome { changed }
+}
+
+fn load_sysreq_snapshot_for_lock(
+    existing_lockfile: Option<&Lockfile>,
+) -> sysreqs::SysreqDbSnapshot {
+    if let Ok(snapshot) = latest_sysreq_snapshot() {
+        return snapshot;
+    }
+
+    if let Ok(Some(snapshot)) = cached_latest_snapshot() {
+        eprintln!("warning: using cached system requirements database snapshot");
+        return snapshot;
+    }
+
+    if let Some(commit) = existing_lockfile
+        .map(|lockfile| lockfile.sysreqs.db_commit.as_str())
+        .filter(|commit| !commit.is_empty())
+    {
+        if let Ok(snapshot) = sysreqs::snapshot_for_commit(commit) {
+            eprintln!(
+                "warning: using system requirements database pinned by the existing lockfile ({commit})"
+            );
+            return snapshot;
+        }
+    }
+
+    eprintln!(
+        "warning: system requirements database unavailable; continuing without updating locked system dependency rules"
+    );
+    empty_sysreq_snapshot()
 }
 
 fn sync_from_lockfile(install_system: bool, install_only_system: bool) -> SyncOutcome {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,9 +47,9 @@ use sysreqs::{
     SystemDependencyPlan, cached_latest_snapshot, current_host_platform,
     empty_snapshot as empty_sysreq_snapshot, install as install_system_dependencies,
     latest_snapshot as latest_sysreq_snapshot, preview_commands as sysreq_preview_commands,
+    recheck_missing_packages as recheck_system_missing_packages,
     refresh_metadata as refresh_system_metadata,
     refresh_preview_command as system_metadata_refresh_preview,
-    recheck_missing_packages as recheck_system_missing_packages,
     resolve_plan as resolve_system_plan,
 };
 use ui::{InstallKind, SyncUi};
@@ -1205,6 +1205,7 @@ fn handle_system_requirements(
             prompt_for_metadata_refresh(&plan);
         }
 
+        eprintln!("Refreshing system package information...");
         refresh_system_metadata(&plan)
             .unwrap_or_else(|error| panic!("failed to refresh package metadata: {error}"));
         match recheck_system_missing_packages(&plan) {
@@ -1267,10 +1268,11 @@ fn handle_system_requirements(
     }
 
     if explicit_install {
+        eprintln!("Installing system dependencies...");
         install_system_dependencies(&plan)
             .unwrap_or_else(|error| panic!("failed to install system dependencies: {error}"));
         if install_only_system {
-            println!("Installed system dependencies");
+            println!("System dependency sync complete.");
             return false;
         }
         return true;
@@ -1283,6 +1285,7 @@ fn handle_system_requirements(
 
     match prompt_for_system_dependency_action() {
         SyncSystemChoice::InstallAndContinue => {
+            eprintln!("Installing system dependencies...");
             install_system_dependencies(&plan)
                 .unwrap_or_else(|error| panic!("failed to install system dependencies: {error}"));
             true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,9 @@ use sysreqs::{
 };
 use ui::{InstallKind, SyncUi};
 
-const SYNC_WORKERS: usize = 4;
+const DOWNLOAD_WORKERS: usize = 8;
+const INSTALL_WORKERS: usize = 8;
+const MAX_SOURCE_BUILDS: usize = 4;
 
 pub fn run() {
     let cli = Cli::parse();
@@ -549,6 +551,14 @@ struct DownloadedInstall {
 }
 
 #[derive(Debug)]
+enum InstallEvent {
+    Finished {
+        package: PendingInstall,
+        result: Result<CompletedBuild, InstallFailure>,
+    },
+}
+
+#[derive(Debug)]
 enum DownloadEvent {
     Started {
         name: String,
@@ -855,64 +865,14 @@ fn sync_from_lockfile(install_system: bool, install_only_system: bool) -> SyncOu
         .count();
     let source_builds = downloaded.len().saturating_sub(binary_installs);
     ui.start_installs(binary_installs, source_builds);
-    while !pending.is_empty() {
-        let ready_names = ready_install_batch(&pending, &satisfied, SYNC_WORKERS);
-        if ready_names.is_empty() {
-            let blocked = pending.keys().cloned().collect::<Vec<_>>();
-            panic!(
-                "no installable packages remain after dependency resolution: {}",
-                blocked.join(", ")
-            );
-        }
-
-        let batch = ready_names
-            .into_iter()
-            .map(|name| {
-                pending
-                    .remove(&name)
-                    .expect("ready package should be pending")
-            })
-            .collect::<Vec<_>>();
-        ui.start_install_batch(batch.iter().map(|package| {
-            let downloaded = downloaded
-                .get(&package.name)
-                .expect("artifact should exist for pending package");
-            (
-                package.name.clone(),
-                package.version.clone(),
-                downloaded.install_kind,
-            )
-        }));
-        let results = build_batch(&batch, &downloaded, &project_library);
-        for result in results {
-            match result {
-                Ok(completed) => {
-                    finalize_built_package(&completed, &project_library).unwrap_or_else(|error| {
-                        panic!(
-                            "failed to cache built package {}@{}: {error}",
-                            completed.package.name, completed.package.version
-                        )
-                    });
-                    satisfied.insert(completed.package.name.clone());
-                    outcome.installed += 1;
-                    let install_kind = downloaded
-                        .get(&completed.package.name)
-                        .expect("artifact should exist for completed package")
-                        .install_kind;
-                    ui.finish_install(
-                        &completed.package.name,
-                        &completed.package.version,
-                        install_kind,
-                    );
-                }
-                Err((package, error)) => {
-                    ui.fail_install(&package.name, &package.version);
-                    report_install_failure(&package.name, &package.version, &error);
-                    std::process::exit(error.exit_code.unwrap_or(1));
-                }
-            }
-        }
-    }
+    install_downloaded_packages_in_parallel(
+        &mut pending,
+        &mut satisfied,
+        &downloaded,
+        &project_library,
+        &ui,
+        &mut outcome,
+    );
     ui.finish_installs();
 
     let locked_names = locked_package_names(&lockfile);
@@ -1604,7 +1564,7 @@ fn download_artifacts_in_parallel(
     let queue = Arc::new(Mutex::new(VecDeque::from(packages.to_vec())));
     let (sender, receiver) = mpsc::channel();
 
-    for _ in 0..SYNC_WORKERS.min(packages.len()) {
+    for _ in 0..DOWNLOAD_WORKERS.min(packages.len()) {
         let queue = Arc::clone(&queue);
         let sender = sender.clone();
         let repositories = repositories.clone();
@@ -1750,10 +1710,9 @@ fn download_artifacts_in_parallel(
     Ok(downloaded)
 }
 
-fn ready_install_batch(
+fn ready_install_names(
     pending: &BTreeMap<String, PendingInstall>,
     satisfied: &BTreeSet<String>,
-    concurrency: usize,
 ) -> Vec<String> {
     pending
         .values()
@@ -1763,55 +1722,140 @@ fn ready_install_batch(
                 .iter()
                 .all(|dependency| satisfied.contains(dependency))
         })
-        .take(concurrency)
         .map(|package| package.name.clone())
         .collect()
 }
 
-fn build_batch(
-    batch: &[PendingInstall],
+fn install_downloaded_packages_in_parallel(
+    pending: &mut BTreeMap<String, PendingInstall>,
+    satisfied: &mut BTreeSet<String>,
+    artifacts: &BTreeMap<String, DownloadedInstall>,
+    project_library: &Path,
+    ui: &SyncUi,
+    outcome: &mut SyncOutcome,
+) {
+    let (sender, receiver) = mpsc::channel();
+    let mut active_installs = 0;
+    let mut active_source_builds = 0;
+
+    while !pending.is_empty() || active_installs > 0 {
+        let ready_names = ready_install_names(pending, satisfied);
+        let mut dispatched = Vec::new();
+
+        for name in ready_names {
+            if active_installs >= INSTALL_WORKERS {
+                break;
+            }
+
+            let install_kind = effective_install_kind(artifacts, &name);
+            if install_kind == InstallKind::Source && active_source_builds >= MAX_SOURCE_BUILDS {
+                continue;
+            }
+
+            let package = pending
+                .remove(&name)
+                .expect("ready package should still be pending");
+            spawn_install_worker(package.clone(), artifacts, project_library, &sender);
+            active_installs += 1;
+            if install_kind == InstallKind::Source {
+                active_source_builds += 1;
+            }
+            dispatched.push((package.name, package.version, install_kind));
+        }
+
+        if !dispatched.is_empty() {
+            ui.start_install_batch(dispatched);
+        }
+
+        if active_installs == 0 {
+            let blocked = pending.keys().cloned().collect::<Vec<_>>();
+            panic!(
+                "no installable packages remain after dependency resolution: {}",
+                blocked.join(", ")
+            );
+        }
+
+        match receiver
+            .recv()
+            .expect("install worker should return a result")
+        {
+            InstallEvent::Finished { package, result } => {
+                active_installs -= 1;
+                let install_kind = effective_install_kind(artifacts, &package.name);
+                if install_kind == InstallKind::Source {
+                    active_source_builds -= 1;
+                }
+
+                match result {
+                    Ok(completed) => {
+                        finalize_built_package(&completed, project_library).unwrap_or_else(
+                            |error| {
+                                panic!(
+                                    "failed to cache built package {}@{}: {error}",
+                                    completed.package.name, completed.package.version
+                                )
+                            },
+                        );
+                        satisfied.insert(completed.package.name.clone());
+                        outcome.installed += 1;
+                        ui.finish_install(
+                            &completed.package.name,
+                            &completed.package.version,
+                            install_kind,
+                        );
+                    }
+                    Err(error) => {
+                        ui.fail_install(&package.name, &package.version);
+                        report_install_failure(&package.name, &package.version, &error);
+                        std::process::exit(error.exit_code.unwrap_or(1));
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn spawn_install_worker(
+    package: PendingInstall,
     artifacts: &BTreeMap<String, DownloadedInstall>,
     dependency_library: &Path,
-) -> Vec<Result<CompletedBuild, (PendingInstall, InstallFailure)>> {
-    let (sender, receiver) = mpsc::channel();
+    sender: &mpsc::Sender<InstallEvent>,
+) {
+    let sender = sender.clone();
+    let downloaded = artifacts
+        .get(&package.name)
+        .expect("artifact should exist for pending package");
+    let artifact_path = downloaded.artifact.path().to_path_buf();
+    let install_type = downloaded.install_type.clone();
+    let dependency_library = dependency_library.to_path_buf();
 
-    for package in batch.iter().cloned() {
-        let sender = sender.clone();
-        let downloaded = artifacts
-            .get(&package.name)
-            .expect("artifact should exist for pending package");
-        let artifact_path = downloaded.artifact.path().to_path_buf();
-        let install_type = downloaded.install_type.clone();
-        let dependency_library = dependency_library.to_path_buf();
-        thread::spawn(move || {
-            let temp_library = build_temp_library_path(&package.name, &unique_build_token());
-            let package_for_success = package.clone();
-            let package_for_error = package.clone();
-            let result = install_local_package(
-                &artifact_path,
-                &package.name,
-                &package.version,
-                &install_type,
-                &temp_library,
-                &[dependency_library],
-            )
-            .map(|_| CompletedBuild {
-                package: package_for_success,
-                temp_library,
-            })
-            .map_err(|error| (package_for_error, error));
-            let _ = sender.send(result);
+    thread::spawn(move || {
+        let temp_library = build_temp_library_path(&package.name, &unique_build_token());
+        let package_for_success = package.clone();
+        let result = install_local_package(
+            &artifact_path,
+            &package.name,
+            &package.version,
+            &install_type,
+            &temp_library,
+            &[dependency_library],
+        )
+        .map(|_| CompletedBuild {
+            package: package_for_success,
+            temp_library,
         });
-    }
-    drop(sender);
+        let _ = sender.send(InstallEvent::Finished { package, result });
+    });
+}
 
-    (0..batch.len())
-        .map(|_| {
-            receiver
-                .recv()
-                .expect("build worker should return a result")
-        })
-        .collect()
+fn effective_install_kind(
+    artifacts: &BTreeMap<String, DownloadedInstall>,
+    package_name: &str,
+) -> InstallKind {
+    artifacts
+        .get(package_name)
+        .expect("artifact should exist for pending package")
+        .install_kind
 }
 
 fn finalize_built_package(completed: &CompletedBuild, target_library: &Path) -> Result<(), String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ use sysreqs::{
     refresh_preview_command as system_metadata_refresh_preview,
     resolve_plan as resolve_system_plan,
 };
-use ui::{InstallKind, SyncUi};
+use ui::{InstallKind, SyncUi, SystemDepsUi};
 
 const DOWNLOAD_WORKERS: usize = 8;
 const INSTALL_WORKERS: usize = 8;
@@ -1223,9 +1223,12 @@ fn handle_system_requirements(
     }
 
     if explicit_install {
-        eprintln!("Installing system dependencies...");
-        install_system_dependencies(&plan)
-            .unwrap_or_else(|error| panic!("failed to install system dependencies: {error}"));
+        let ui = SystemDepsUi::start();
+        if let Err(error) = install_system_dependencies(&plan) {
+            ui.fail();
+            panic!("failed to install system dependencies: {error}");
+        }
+        ui.finish();
         if install_only_system {
             println!("System dependency sync complete.");
             return false;
@@ -1240,9 +1243,12 @@ fn handle_system_requirements(
 
     match prompt_for_system_dependency_action() {
         SyncSystemChoice::InstallAndContinue => {
-            eprintln!("Installing system dependencies...");
-            install_system_dependencies(&plan)
-                .unwrap_or_else(|error| panic!("failed to install system dependencies: {error}"));
+            let ui = SystemDepsUi::start();
+            if let Err(error) = install_system_dependencies(&plan) {
+                ui.fail();
+                panic!("failed to install system dependencies: {error}");
+            }
+            ui.finish();
             true
         }
         SyncSystemChoice::TryROnly => true,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1196,17 +1196,6 @@ fn handle_system_requirements(
         }
     }
 
-    if let Some(error) = &plan.installed_query_error {
-        if explicit_install {
-            eprintln!("rpx could not verify system package availability with apt.");
-            eprintln!();
-            eprintln!("Apt reported:");
-            eprintln!("{error}");
-        } else {
-            eprintln!("warning: {error}");
-        }
-    }
-
     if plan.missing_packages.is_empty() {
         if install_only_system {
             println!("System dependencies are already installed");
@@ -1214,12 +1203,7 @@ fn handle_system_requirements(
         return !install_only_system;
     }
 
-    if plan.installed_query_error.is_some() {
-        print_system_package_summary(
-            "Requested system packages for this project:",
-            &plan.install_packages,
-        );
-    } else {
+    if plan.installed_query_error.is_none() {
         print_system_package_summary(
             &format!("Missing system packages for {}:", plan.host.label()),
             &plan.missing_packages,
@@ -1227,11 +1211,7 @@ fn handle_system_requirements(
     }
     let preview = sysreq_preview_commands(&plan);
     if !preview.is_empty() {
-        if plan.installed_query_error.is_some() {
-            eprintln!("rpx can still try to install them now:");
-        } else {
-            eprintln!("rpx can run:");
-        }
+        eprintln!("rpx will run:");
         for command in &preview {
             eprintln!("- {command}");
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -290,6 +290,11 @@ fn cmd_lock() {
 }
 
 fn cmd_sync(install_system: bool, install_only_system: bool) {
+    if (install_system || install_only_system) && !host_supports_system_sync() {
+        eprintln!("System dependency installation is currently supported only on Linux.");
+        std::process::exit(1);
+    }
+
     let outcome = sync_from_lockfile(install_system, install_only_system);
     if install_only_system {
         return;
@@ -349,7 +354,11 @@ fn cmd_status() {
         .collect::<std::collections::BTreeMap<_, _>>();
     let locked_names = locked_package_names(&lockfile);
     let runtime_status = runtime_status(&lockfile);
-    let system_plan = system_plan_from_lockfile(&lockfile).ok();
+    let system_plan = if host_supports_system_sync() {
+        system_plan_from_lockfile(&lockfile).ok()
+    } else {
+        None
+    };
 
     let missing_from_lockfile = manifest_requirements
         .difference(&lock_requirements)
@@ -770,14 +779,16 @@ fn sync_from_lockfile(install_system: bool, install_only_system: bool) -> SyncOu
     let lockfile = read_lockfile().expect("failed to read lockfile");
     validate_lockfile_version_for_sync(&lockfile);
     validate_runtime_for_sync(&lockfile);
-    let system_plan = system_plan_from_lockfile(&lockfile).unwrap_or_else(|error| {
-        eprintln!("warning: failed to prepare system dependency plan: {error}");
-        system_plan_without_db(&lockfile)
-    });
-    let proceed_with_r =
-        handle_system_requirements(&system_plan, install_system, install_only_system);
-    if install_only_system || !proceed_with_r {
-        return SyncOutcome::default();
+    if host_supports_system_sync() {
+        let system_plan = system_plan_from_lockfile(&lockfile).unwrap_or_else(|error| {
+            eprintln!("warning: failed to prepare system dependency plan: {error}");
+            system_plan_without_db(&lockfile)
+        });
+        let proceed_with_r =
+            handle_system_requirements(&system_plan, install_system, install_only_system);
+        if install_only_system || !proceed_with_r {
+            return SyncOutcome::default();
+        }
     }
     let lock_requirements = lockfile
         .roots
@@ -1181,6 +1192,10 @@ fn system_plan_without_db(lockfile: &Lockfile) -> SystemDependencyPlan {
         installed_query_error: None,
         needs_metadata_refresh: false,
     }
+}
+
+fn host_supports_system_sync() -> bool {
+    matches!(current_host_platform(), sysreqs::HostPlatform::Linux { .. })
 }
 
 fn handle_system_requirements(

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -2,7 +2,7 @@ use crate::project::{LOCKFILE_NAME, lockfile_path};
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, fs};
 
-pub const LOCKFILE_VERSION: u32 = 2;
+pub const LOCKFILE_VERSION: u32 = 3;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Lockfile {
@@ -10,6 +10,8 @@ pub struct Lockfile {
     pub registry: String,
     #[serde(default)]
     pub r: LockedR,
+    #[serde(default)]
+    pub sysreqs: LockedSystemRequirements,
     pub roots: Vec<LockedRoot>,
     pub packages: BTreeMap<String, LockedPackage>,
 }
@@ -20,6 +22,16 @@ pub struct LockedR {
     pub version: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub base_packages: Vec<String>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct LockedSystemRequirements {
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub db_commit: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub rules: Vec<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub packages: BTreeMap<String, Vec<String>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -75,7 +87,10 @@ pub fn write_lockfile(lockfile: Lockfile) {
 mod tests {
     use std::collections::BTreeMap;
 
-    use super::{LOCKFILE_VERSION, LockedDependency, LockedPackage, LockedR, LockedRoot, Lockfile};
+    use super::{
+        LOCKFILE_VERSION, LockedDependency, LockedPackage, LockedR, LockedRoot,
+        LockedSystemRequirements, Lockfile,
+    };
 
     #[test]
     fn serializes_new_registry_lockfile_shape() {
@@ -85,6 +100,11 @@ mod tests {
             r: LockedR {
                 version: "4.4.1".to_string(),
                 base_packages: vec!["utils".to_string()],
+            },
+            sysreqs: LockedSystemRequirements {
+                db_commit: "abc123".to_string(),
+                rules: vec!["libcurl".to_string()],
+                packages: BTreeMap::from([("digest".to_string(), vec!["libcurl".to_string()])]),
             },
             roots: vec![LockedRoot {
                 package: "digest".to_string(),
@@ -111,10 +131,12 @@ mod tests {
 
         let json = serde_json::to_string_pretty(&lockfile).expect("lockfile should serialize");
 
-        assert!(json.contains("\"version\": 2"));
+        assert!(json.contains("\"version\": 3"));
         assert!(json.contains("\"registry\": \"https://api.rrepo.org\""));
         assert!(json.contains("\"r\""));
+        assert!(json.contains("\"sysreqs\""));
         assert!(json.contains("\"base_packages\""));
+        assert!(json.contains("\"db_commit\""));
         assert!(json.contains("\"roots\""));
         assert!(json.contains("\"source_url\""));
         assert!(json.contains("\"dependencies\""));
@@ -150,5 +172,6 @@ mod tests {
         let lockfile: Lockfile = serde_json::from_str(json).expect("lockfile should parse");
 
         assert_eq!(lockfile.r, LockedR::default());
+        assert_eq!(lockfile.sysreqs, LockedSystemRequirements::default());
     }
 }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -24,14 +24,6 @@ pub struct ResolutionRoot {
 pub struct IngestingResponse {}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-pub struct LatestVersionResponse {
-    pub package: String,
-    pub version: String,
-    #[serde(rename = "sourceUrl")]
-    pub source_url: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PackageVersionsResponse {
     pub package: String,
     pub versions: Vec<VersionSummary>,
@@ -59,13 +51,6 @@ pub struct VersionSummary {
     pub version: String,
     #[serde(rename = "sourceUrl")]
     pub source_url: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
-#[serde(untagged)]
-enum LatestVersionEnvelope {
-    Complete(LatestVersionResponse),
-    Ingesting(IngestingResponse),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -100,12 +85,7 @@ impl Default for PollConfig {
     }
 }
 
-impl PollConfig {
-    #[cfg(test)]
-    pub fn from_delays(delays: Vec<Duration>) -> Self {
-        Self { delays }
-    }
-}
+impl PollConfig {}
 
 #[derive(Debug)]
 pub struct RegistryClient {
@@ -150,10 +130,6 @@ impl RegistryClient {
         Self::with_token_and_poll_config(base_url, token, PollConfig::default())
     }
 
-    pub fn with_poll_config(base_url: impl AsRef<str>, poll_config: PollConfig) -> Self {
-        Self::with_token_and_poll_config(base_url, None, poll_config)
-    }
-
     pub fn with_token_and_poll_config(
         base_url: impl AsRef<str>,
         token: Option<String>,
@@ -177,15 +153,6 @@ impl RegistryClient {
         }
     }
 
-    #[cfg(test)]
-    fn with_cache_ttl(base_url: impl AsRef<str>, ttl: Duration) -> Self {
-        Self::with_config(base_url, None, PollConfig::default(), ttl)
-    }
-
-    pub fn base_url(&self) -> &str {
-        &self.base_url
-    }
-
     pub fn fetch_repository_packages(&self) -> Result<RepositoryPackagesResponse, String> {
         let response = self
             .request(reqwest::Method::GET, format!("{}/packages", self.base_url))
@@ -193,47 +160,6 @@ impl RegistryClient {
             .map_err(|error| format!("failed to contact registry: {error}"))?;
 
         decode_json_response(response, "failed to decode repository packages response")
-    }
-
-    #[cfg(test)]
-    fn fetch_latest_version(&self, package: &str) -> Result<LatestVersionResponse, String> {
-        match self.fetch_latest_version_once(package)? {
-            LatestVersionEnvelope::Complete(response) => Ok(response),
-            LatestVersionEnvelope::Ingesting(_) => {
-                Err("registry is still hydrating dependencies; wait a bit and retry".to_string())
-            }
-        }
-    }
-
-    pub fn fetch_latest_version_with_retry(
-        &self,
-        package: &str,
-    ) -> Result<LatestVersionResponse, String> {
-        for (attempt, delay) in self.poll_config.delays.iter().enumerate() {
-            match self.fetch_latest_version_once(package)? {
-                LatestVersionEnvelope::Complete(response) => return Ok(response),
-                LatestVersionEnvelope::Ingesting(_) => {
-                    if attempt == self.poll_config.delays.len() - 1 {
-                        break;
-                    }
-                    thread::sleep(*delay);
-                }
-            }
-        }
-
-        Err("registry is still hydrating dependencies; wait a bit and retry".to_string())
-    }
-
-    fn fetch_latest_version_once(&self, package: &str) -> Result<LatestVersionEnvelope, String> {
-        let response = self
-            .request(
-                reqwest::Method::GET,
-                format!("{}/packages/{package}/versions/latest", self.base_url),
-            )
-            .send()
-            .map_err(|error| format!("failed to contact registry: {error}"))?;
-
-        decode_json_response(response, "failed to decode latest version response")
     }
 
     #[cfg(test)]
@@ -389,15 +315,6 @@ impl RegistryClient {
             .join("descriptions")
             .join(package)
             .join(format!("{version}.dcf"))
-    }
-
-    pub fn download_artifact(
-        &self,
-        package: &str,
-        version: &str,
-        artifact: &ArtifactRequest,
-    ) -> Result<DownloadedArtifact, String> {
-        self.download_artifact_with_progress(package, version, artifact, |_| {})
     }
 
     pub fn download_artifact_with_progress(
@@ -635,14 +552,6 @@ mod tests {
 }"#
     }
 
-    fn sample_latest_version_body() -> &'static str {
-        r#"{
-  "package": "dplyr",
-  "version": "1.1.4",
-  "sourceUrl": "https://api.rrepo.org/packages/dplyr/versions/1.1.4/source"
-}"#
-    }
-
     fn sample_package_versions_body() -> &'static str {
         r#"{
   "package": "dplyr",
@@ -670,59 +579,6 @@ mod tests {
         if path.exists() {
             fs::remove_dir_all(path).expect("metadata cache should be removable");
         }
-    }
-
-    #[test]
-    fn fetches_latest_package_version() {
-        let mut server = Server::new();
-        let mock = server
-            .mock("GET", "/packages/dplyr/versions/latest")
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(sample_latest_version_body())
-            .create();
-
-        let client = RegistryClient::new(server.url());
-        let response = client
-            .fetch_latest_version("dplyr")
-            .expect("latest version fetch should succeed");
-
-        mock.assert();
-        assert_eq!(response.version, "1.1.4");
-        assert_eq!(
-            response.source_url,
-            "https://api.rrepo.org/packages/dplyr/versions/1.1.4/source"
-        );
-    }
-
-    #[test]
-    fn polls_until_latest_version_is_ready() {
-        let mut server = Server::new();
-        let _first = server
-            .mock("GET", "/packages/dplyr/versions/latest")
-            .with_status(202)
-            .with_header("content-type", "application/json")
-            .with_body(sample_ingesting_body())
-            .expect(1)
-            .create();
-        let second = server
-            .mock("GET", "/packages/dplyr/versions/latest")
-            .with_status(200)
-            .with_header("content-type", "application/json")
-            .with_body(sample_latest_version_body())
-            .expect(1)
-            .create();
-
-        let client = RegistryClient::with_poll_config(
-            server.url(),
-            PollConfig::from_delays(vec![Duration::ZERO, Duration::ZERO, Duration::ZERO]),
-        );
-        let response = client
-            .fetch_latest_version_with_retry("dplyr")
-            .expect("latest version fetch should succeed");
-
-        second.assert();
-        assert_eq!(response.version, "1.1.4");
     }
 
     #[test]
@@ -764,9 +620,13 @@ mod tests {
             .expect(1)
             .create();
 
-        let client = RegistryClient::with_poll_config(
+        let client = RegistryClient::with_config(
             server.url(),
-            PollConfig::from_delays(vec![Duration::ZERO, Duration::ZERO, Duration::ZERO]),
+            None,
+            PollConfig {
+                delays: vec![Duration::ZERO, Duration::ZERO, Duration::ZERO],
+            },
+            VERSION_CACHE_TTL,
         );
         let response = client
             .fetch_package_versions_with_retry("dplyr")
@@ -798,7 +658,7 @@ mod tests {
 
         mock.assert();
         assert_eq!(first, second);
-        clear_registry_metadata_cache(client.base_url());
+        clear_registry_metadata_cache(&client.base_url);
     }
 
     #[test]
@@ -813,7 +673,8 @@ mod tests {
             .expect(2)
             .create();
 
-        let client = RegistryClient::with_cache_ttl(server.url(), Duration::ZERO);
+        let client =
+            RegistryClient::with_config(server.url(), None, PollConfig::default(), Duration::ZERO);
         let first = client
             .fetch_package_versions_with_retry("dplyr")
             .expect("initial package versions fetch should succeed");
@@ -823,7 +684,7 @@ mod tests {
 
         mock.assert();
         assert_eq!(first, second);
-        clear_registry_metadata_cache(client.base_url());
+        clear_registry_metadata_cache(&client.base_url);
     }
 
     #[test]
@@ -851,7 +712,7 @@ mod tests {
         mock.assert();
         assert_eq!(first, second);
         assert!(first.contains("package missingpkg not found"));
-        clear_registry_metadata_cache(client.base_url());
+        clear_registry_metadata_cache(&client.base_url);
     }
 
     #[test]
@@ -896,7 +757,7 @@ mod tests {
 
         mock.assert();
         assert_eq!(first, second);
-        clear_registry_metadata_cache(client.base_url());
+        clear_registry_metadata_cache(&client.base_url);
     }
 
     #[test]
@@ -917,9 +778,13 @@ mod tests {
             .expect(1)
             .create();
 
-        let client = RegistryClient::with_poll_config(
+        let client = RegistryClient::with_config(
             server.url(),
-            PollConfig::from_delays(vec![Duration::ZERO, Duration::ZERO, Duration::ZERO]),
+            None,
+            PollConfig {
+                delays: vec![Duration::ZERO, Duration::ZERO, Duration::ZERO],
+            },
+            VERSION_CACHE_TTL,
         );
         let response = client
             .fetch_description_with_retry("dplyr", "1.1.4")
@@ -927,53 +792,6 @@ mod tests {
 
         second.assert();
         assert!(response.contains("Version: 1.1.4"));
-    }
-
-    #[test]
-    fn returns_friendly_error_when_latest_version_keeps_ingesting() {
-        let mut server = Server::new();
-        let mock = server
-            .mock("GET", "/packages/dplyr/versions/latest")
-            .with_status(202)
-            .with_header("content-type", "application/json")
-            .with_body(sample_ingesting_body())
-            .expect(3)
-            .create();
-
-        let client = RegistryClient::with_poll_config(
-            server.url(),
-            PollConfig::from_delays(vec![Duration::ZERO, Duration::ZERO, Duration::ZERO]),
-        );
-        let error = client
-            .fetch_latest_version_with_retry("dplyr")
-            .expect_err("latest version fetch should time out");
-
-        mock.assert();
-        assert_eq!(
-            error,
-            "registry is still hydrating dependencies; wait a bit and retry"
-        );
-    }
-
-    #[test]
-    fn surfaces_registry_server_errors() {
-        let mut server = Server::new();
-        let mock = server
-            .mock("GET", "/packages/dplyr/versions/latest")
-            .with_status(500)
-            .with_body("registry exploded")
-            .create();
-
-        let client = RegistryClient::with_poll_config(
-            server.url(),
-            PollConfig::from_delays(vec![Duration::ZERO]),
-        );
-        let error = client
-            .fetch_latest_version_with_retry("dplyr")
-            .expect_err("latest version fetch should fail");
-
-        mock.assert();
-        assert!(error.contains("registry error (500 Internal Server Error): registry exploded"));
     }
 
     #[test]
@@ -990,7 +808,7 @@ mod tests {
 
         let client = RegistryClient::new(server.url());
         let artifact = client
-            .download_artifact(
+            .download_artifact_with_progress(
                 "digest",
                 "0.6.37",
                 &ArtifactRequest {
@@ -998,6 +816,7 @@ mod tests {
                     url: format!("{}/packages/digest/versions/0.6.37/source", server.url()),
                     cache_file_name: "digest_0.6.37_download.tar.gz".to_string(),
                 },
+                |_| {},
             )
             .expect("download should succeed");
 
@@ -1020,7 +839,7 @@ mod tests {
 
         let client = RegistryClient::new(server.url());
         let error = client
-            .download_artifact(
+            .download_artifact_with_progress(
                 "digest",
                 "0.6.37",
                 &ArtifactRequest {
@@ -1028,6 +847,7 @@ mod tests {
                     url: format!("{}/packages/digest/versions/0.6.37/source", server.url()),
                     cache_file_name: "digest_0.6.37_error.tar.gz".to_string(),
                 },
+                |_| {},
             )
             .expect_err("download should fail");
 
@@ -1054,7 +874,7 @@ mod tests {
 
         let client = RegistryClient::new(server.url());
         let artifact = client
-            .download_artifact(
+            .download_artifact_with_progress(
                 "digest",
                 "0.6.37",
                 &ArtifactRequest {
@@ -1065,6 +885,7 @@ mod tests {
                     ),
                     cache_file_name: "digest_0.6.37.zip".to_string(),
                 },
+                |_| {},
             )
             .expect("download should succeed");
 

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -1,6 +1,6 @@
 use crate::registry::{
-    LatestVersionResponse, PackageVersionsResponse, RegistryClient, RepositoryPackagesResponse,
-    is_not_found_error, is_unauthorized_error,
+    PackageVersionsResponse, RegistryClient, RepositoryPackagesResponse, is_not_found_error,
+    is_unauthorized_error,
 };
 use keyring::Entry;
 use std::{
@@ -15,12 +15,6 @@ const KEYRING_SERVICE: &str = "rpx";
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RepositorySource {
     base_url: String,
-}
-
-#[derive(Debug, Clone)]
-pub struct SourcedLatestVersion {
-    pub source: RepositorySource,
-    pub response: LatestVersionResponse,
 }
 
 #[derive(Debug, Clone)]
@@ -117,30 +111,6 @@ impl RepositorySet {
         self.with_authorized_client(source, |client| client.fetch_repository_packages())
     }
 
-    pub fn fetch_latest_version_with_retry(
-        &self,
-        package: &str,
-    ) -> Result<SourcedLatestVersion, String> {
-        for source in &self.sources {
-            match self.with_authorized_client(source, |client| {
-                client.fetch_latest_version_with_retry(package)
-            }) {
-                Ok(response) => {
-                    return Ok(SourcedLatestVersion {
-                        source: source.clone(),
-                        response,
-                    });
-                }
-                Err(error) if is_not_found_error(&error) => continue,
-                Err(error) => return Err(error),
-            }
-        }
-
-        Err(format!(
-            "package {package} not found in configured repositories"
-        ))
-    }
-
     pub fn fetch_package_versions_with_retry(
         &self,
         package: &str,
@@ -176,18 +146,6 @@ impl RepositorySet {
         })
     }
 
-    pub fn download_artifact(
-        &self,
-        source: &RepositorySource,
-        package: &str,
-        version: &str,
-        artifact: &crate::registry::ArtifactRequest,
-    ) -> Result<crate::registry::DownloadedArtifact, String> {
-        self.with_authorized_client(source, |client| {
-            client.download_artifact(package, version, artifact)
-        })
-    }
-
     pub fn download_artifact_with_progress(
         &self,
         source: &RepositorySource,
@@ -203,10 +161,6 @@ impl RepositorySet {
 
     pub fn has_stored_credential(&self, source: &RepositorySource) -> Result<bool, String> {
         Ok(self.credentials.get(source)?.is_some())
-    }
-
-    pub fn store_api_key(&self, source: &RepositorySource, token: &str) -> Result<(), String> {
-        self.credentials.set(source, token)
     }
 
     pub fn remove_api_key(&self, source: &RepositorySource) -> Result<(), String> {

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -112,6 +112,7 @@ pub struct ResolvedPackage {
     pub version: String,
     pub source_url: String,
     pub dependencies: Vec<ResolvedDependency>,
+    pub system_requirements: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -133,6 +134,7 @@ struct PackageMetadata {
     version: String,
     source_url: String,
     dependencies: Vec<PackageDependency>,
+    system_requirements: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -276,6 +278,7 @@ impl<'a> RegistryDependencyProvider<'a> {
             version: version_entry.version.clone(),
             source_url: version_entry.source_url,
             dependencies: description_dependencies(&description)?,
+            system_requirements: description.system_requirements(),
         };
         self.metadata_by_package_version
             .borrow_mut()
@@ -298,6 +301,7 @@ impl<'a> RegistryDependencyProvider<'a> {
                 .into_iter()
                 .map(|dependency| dependency.resolved)
                 .collect(),
+            system_requirements: metadata.system_requirements,
         })
     }
 

--- a/src/sysreqs.rs
+++ b/src/sysreqs.rs
@@ -549,14 +549,7 @@ fn missing_packages_for_host(
 ) -> Result<Vec<String>, String> {
     if matches!(host, HostPlatform::Linux { distribution, .. } if distribution == "ubuntu" || distribution == "debian")
     {
-        return packages
-            .iter()
-            .filter_map(|package| match apt_requirement_satisfied(package) {
-                Ok(true) => None,
-                Ok(false) => Some(Ok(package.clone())),
-                Err(error) => Some(Err(error)),
-            })
-            .collect();
+        return apt_missing_packages(packages);
     }
 
     let installed = installed_packages(host)?;
@@ -567,36 +560,75 @@ fn missing_packages_for_host(
         .collect())
 }
 
-fn apt_requirement_satisfied(requirement: &str) -> Result<bool, String> {
+fn apt_missing_packages(packages: &[String]) -> Result<Vec<String>, String> {
+    let output = apt_simulation_output(packages)?;
+    Ok(apt_simulation_missing_packages(packages, &output))
+}
+
+fn apt_simulation_output(packages: &[String]) -> Result<String, String> {
     let output = Command::new("apt-get")
-        .args([
-            "-s",
-            "install",
-            "-y",
-            "--no-install-recommends",
-            requirement,
-        ])
+        .arg("-s")
+        .arg("install")
+        .arg("-y")
+        .arg("--no-install-recommends")
+        .args(packages)
         .output()
-        .map_err(|error| format!("failed to inspect apt package `{requirement}`: {error}"))?;
+        .map_err(|error| format!("failed to inspect apt packages: {error}"))?;
 
     if !output.status.success() {
         return Err(format!(
-            "failed to inspect apt package `{requirement}` ({})",
+            "failed to inspect apt packages ({})",
             output.status
         ));
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
-    let combined = format!("{stdout}\n{stderr}");
-
-    Ok(!apt_simulation_requires_changes(&combined))
+    Ok(format!("{stdout}\n{stderr}"))
 }
 
-fn apt_simulation_requires_changes(output: &str) -> bool {
-    output
+fn apt_simulation_missing_packages(packages: &[String], output: &str) -> Vec<String> {
+    let selected_aliases = output
         .lines()
-        .any(|line| line.trim_start().starts_with("Inst "))
+        .filter_map(parse_apt_alias_selection)
+        .collect::<BTreeMap<_, _>>();
+    let packages_to_install = output
+        .lines()
+        .filter_map(parse_apt_installed_package)
+        .collect::<BTreeSet<_>>();
+
+    packages
+        .iter()
+        .filter(|package| {
+            let candidate = selected_aliases
+                .get(package.as_str())
+                .map(String::as_str)
+                .unwrap_or(package.as_str());
+            packages_to_install.contains(candidate)
+        })
+        .cloned()
+        .collect()
+}
+
+fn parse_apt_alias_selection(line: &str) -> Option<(String, String)> {
+    let line = line.trim();
+    let prefix = "Note, selecting '";
+    let middle = "' instead of '";
+    if !line.starts_with(prefix) {
+        return None;
+    }
+
+    let rest = &line[prefix.len()..];
+    let (selected, rest) = rest.split_once(middle)?;
+    let requested = rest.strip_suffix('"').or_else(|| rest.strip_suffix('\''))?;
+    Some((requested.to_string(), selected.to_string()))
+}
+
+fn parse_apt_installed_package(line: &str) -> Option<String> {
+    let line = line.trim_start();
+    let rest = line.strip_prefix("Inst ")?;
+    let package = rest.split_whitespace().next()?;
+    Some(package.to_string())
 }
 
 fn package_manager_for_host(host: &HostPlatform) -> Option<&'static str> {
@@ -817,7 +849,7 @@ fn now_unix() -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use super::apt_simulation_requires_changes;
+    use super::apt_simulation_missing_packages;
 
     #[test]
     fn apt_simulation_recognizes_alias_as_already_satisfied() {
@@ -828,7 +860,9 @@ Note, selecting 'libfreetype-dev' instead of 'libfreetype6-dev'\n\
 libfreetype-dev is already the newest version (2.14.3+dfsg-1).\n\
 0 upgraded, 0 newly installed, 0 to remove and 75 not upgraded.\n";
 
-        assert!(!apt_simulation_requires_changes(output));
+        assert!(
+            apt_simulation_missing_packages(&["libfreetype6-dev".to_string()], output).is_empty()
+        );
     }
 
     #[test]
@@ -841,6 +875,29 @@ The following NEW packages will be installed:\n\
 Inst libfreetype6-dev (2.14.3+dfsg-1 Debian:testing [amd64])\n\
 Conf libfreetype6-dev (2.14.3+dfsg-1 Debian:testing [amd64])\n";
 
-        assert!(apt_simulation_requires_changes(output));
+        assert_eq!(
+            apt_simulation_missing_packages(&["libfreetype6-dev".to_string()], output),
+            vec!["libfreetype6-dev".to_string()]
+        );
+    }
+
+    #[test]
+    fn apt_simulation_batches_missing_and_satisfied_packages() {
+        let output = "Reading package lists... Done\n\
+Building dependency tree... Done\n\
+Reading state information... Done\n\
+Note, selecting 'libfreetype-dev' instead of 'libfreetype6-dev'\n\
+The following NEW packages will be installed:\n\
+  libxml2-dev\n\
+Inst libxml2-dev (2.14.3+dfsg-1 Debian:testing [amd64])\n\
+Conf libxml2-dev (2.14.3+dfsg-1 Debian:testing [amd64])\n";
+
+        assert_eq!(
+            apt_simulation_missing_packages(
+                &["libfreetype6-dev".to_string(), "libxml2-dev".to_string()],
+                output,
+            ),
+            vec!["libxml2-dev".to_string()]
+        );
     }
 }

--- a/src/sysreqs.rs
+++ b/src/sysreqs.rs
@@ -233,17 +233,11 @@ pub(crate) fn resolve_plan(
     let install_supported = package_manager_for_host(&host).is_some();
     let can_auto_install = install_supported && install_prefix().is_some();
 
-    let (missing_packages, installed_query_error) = match installed_packages(&host) {
-        Ok(installed) => (
-            install_packages
-                .iter()
-                .filter(|package| !installed.contains(*package))
-                .cloned()
-                .collect(),
-            None,
-        ),
-        Err(error) => (install_packages.clone(), Some(error)),
-    };
+    let (missing_packages, installed_query_error) =
+        match missing_packages_for_host(&host, &install_packages) {
+            Ok(missing_packages) => (missing_packages, None),
+            Err(error) => (install_packages.clone(), Some(error)),
+        };
 
     SystemDependencyPlan {
         host,
@@ -472,7 +466,13 @@ fn detect_linux_platform() -> HostPlatform {
         .collect::<BTreeMap<_, _>>();
 
     let id = values.get("ID").cloned().unwrap_or_default();
-    let version = values.get("VERSION_ID").cloned().unwrap_or_default();
+    let version = values
+        .get("VERSION_ID")
+        .cloned()
+        .or_else(|| values.get("VERSION_CODENAME").cloned())
+        .or_else(|| values.get("DEBIAN_CODENAME").cloned())
+        .or_else(|| values.get("VERSION").cloned())
+        .unwrap_or_default();
     let distribution = match id.as_str() {
         "ubuntu" => Some("ubuntu"),
         "debian" => Some("debian"),
@@ -541,6 +541,62 @@ fn installed_packages(host: &HostPlatform) -> Result<BTreeSet<String>, String> {
         .filter(|line| !line.is_empty())
         .map(ToString::to_string)
         .collect())
+}
+
+fn missing_packages_for_host(
+    host: &HostPlatform,
+    packages: &[String],
+) -> Result<Vec<String>, String> {
+    if matches!(host, HostPlatform::Linux { distribution, .. } if distribution == "ubuntu" || distribution == "debian")
+    {
+        return packages
+            .iter()
+            .filter_map(|package| match apt_requirement_satisfied(package) {
+                Ok(true) => None,
+                Ok(false) => Some(Ok(package.clone())),
+                Err(error) => Some(Err(error)),
+            })
+            .collect();
+    }
+
+    let installed = installed_packages(host)?;
+    Ok(packages
+        .iter()
+        .filter(|package| !installed.contains(*package))
+        .cloned()
+        .collect())
+}
+
+fn apt_requirement_satisfied(requirement: &str) -> Result<bool, String> {
+    let output = Command::new("apt-get")
+        .args([
+            "-s",
+            "install",
+            "-y",
+            "--no-install-recommends",
+            requirement,
+        ])
+        .output()
+        .map_err(|error| format!("failed to inspect apt package `{requirement}`: {error}"))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "failed to inspect apt package `{requirement}` ({})",
+            output.status
+        ));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}\n{stderr}");
+
+    Ok(!apt_simulation_requires_changes(&combined))
+}
+
+fn apt_simulation_requires_changes(output: &str) -> bool {
+    output
+        .lines()
+        .any(|line| line.trim_start().starts_with("Inst "))
 }
 
 fn package_manager_for_host(host: &HostPlatform) -> Option<&'static str> {
@@ -757,4 +813,34 @@ fn now_unix() -> u64 {
         .duration_since(UNIX_EPOCH)
         .expect("system time should be after unix epoch")
         .as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::apt_simulation_requires_changes;
+
+    #[test]
+    fn apt_simulation_recognizes_alias_as_already_satisfied() {
+        let output = "Reading package lists... Done\n\
+Building dependency tree... Done\n\
+Reading state information... Done\n\
+Note, selecting 'libfreetype-dev' instead of 'libfreetype6-dev'\n\
+libfreetype-dev is already the newest version (2.14.3+dfsg-1).\n\
+0 upgraded, 0 newly installed, 0 to remove and 75 not upgraded.\n";
+
+        assert!(!apt_simulation_requires_changes(output));
+    }
+
+    #[test]
+    fn apt_simulation_recognizes_pending_install() {
+        let output = "Reading package lists... Done\n\
+Building dependency tree... Done\n\
+Reading state information... Done\n\
+The following NEW packages will be installed:\n\
+  libfreetype6-dev\n\
+Inst libfreetype6-dev (2.14.3+dfsg-1 Debian:testing [amd64])\n\
+Conf libfreetype6-dev (2.14.3+dfsg-1 Debian:testing [amd64])\n";
+
+        assert!(apt_simulation_requires_changes(output));
+    }
 }

--- a/src/sysreqs.rs
+++ b/src/sysreqs.rs
@@ -1,0 +1,732 @@
+use flate2::read::GzDecoder;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    env, fs,
+    io::Read,
+    path::PathBuf,
+    process::Command,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+use tar::Archive;
+
+use crate::project::cache_dir_path;
+
+const SYSREQS_API_BASE: &str = "https://api.github.com/repos/rstudio/r-system-requirements";
+const SYSREQS_CACHE_TTL: Duration = Duration::from_secs(15 * 60);
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct SysreqDbSnapshot {
+    pub commit: String,
+    pub rules: Vec<SysreqRule>,
+    #[serde(default)]
+    pub scripts: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct SysreqRule {
+    pub id: String,
+    pub patterns: Vec<String>,
+    #[serde(default)]
+    pub dependencies: Vec<SysreqDependency>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct SysreqDependency {
+    #[serde(default)]
+    pub packages: Vec<String>,
+    #[serde(default)]
+    pub apt_satisfy: Vec<String>,
+    #[serde(default)]
+    pub constraints: Vec<SysreqConstraint>,
+    #[serde(default)]
+    pub pre_install: Vec<SysreqAction>,
+    #[serde(default)]
+    pub post_install: Vec<SysreqAction>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct SysreqConstraint {
+    pub os: String,
+    #[serde(default)]
+    pub distribution: String,
+    #[serde(default)]
+    pub versions: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) struct SysreqAction {
+    #[serde(default)]
+    pub command: String,
+    #[serde(default)]
+    pub script: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum HostPlatform {
+    Linux {
+        distribution: String,
+        version: String,
+    },
+    Macos,
+    Windows,
+    Unknown(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SystemDependencyPlan {
+    pub host: HostPlatform,
+    pub missing_packages: Vec<String>,
+    pub install_packages: Vec<String>,
+    pub pre_install_commands: Vec<String>,
+    pub post_install_commands: Vec<String>,
+    pub unsupported_rules: Vec<String>,
+    pub package_rules: BTreeMap<String, Vec<String>>,
+    pub install_supported: bool,
+    pub can_auto_install: bool,
+    pub installed_query_error: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CommitResponse {
+    sha: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct LatestSnapshotCache {
+    commit: String,
+    fetched_at_unix: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawSysreqRule {
+    patterns: Vec<String>,
+    #[serde(default)]
+    dependencies: Vec<SysreqDependency>,
+}
+
+pub(crate) fn latest_snapshot() -> Result<SysreqDbSnapshot, String> {
+    let cache_path = latest_snapshot_cache_path();
+    if let Some(cached) =
+        read_json_cache_fresh::<LatestSnapshotCache>(&cache_path, SYSREQS_CACHE_TTL)
+    {
+        return snapshot_for_commit(&cached.commit);
+    }
+
+    let commit = latest_commit_hash()?;
+    let snapshot = snapshot_for_commit(&commit)?;
+    write_json(
+        &cache_path,
+        &LatestSnapshotCache {
+            commit,
+            fetched_at_unix: now_unix(),
+        },
+    )?;
+    Ok(snapshot)
+}
+
+pub(crate) fn snapshot_for_commit(commit: &str) -> Result<SysreqDbSnapshot, String> {
+    let cache_path = db_snapshot_cache_path(commit);
+    if cache_path.exists() {
+        return read_json(&cache_path);
+    }
+
+    let snapshot = download_snapshot(commit)?;
+    write_json(&cache_path, &snapshot)?;
+    Ok(snapshot)
+}
+
+pub(crate) fn match_rules(spec: Option<&str>, db: &SysreqDbSnapshot) -> Vec<String> {
+    let Some(spec) = spec.map(str::trim).filter(|value| !value.is_empty()) else {
+        return vec![];
+    };
+
+    let mut matches = BTreeSet::new();
+    for rule in &db.rules {
+        if rule.patterns.iter().any(|pattern| {
+            Regex::new(&format!("(?i){pattern}"))
+                .map(|regex| regex.is_match(spec))
+                .unwrap_or(false)
+        }) {
+            matches.insert(rule.id.clone());
+        }
+    }
+
+    matches.into_iter().collect()
+}
+
+pub(crate) fn current_host_platform() -> HostPlatform {
+    match env::consts::OS {
+        "macos" => HostPlatform::Macos,
+        "windows" => HostPlatform::Windows,
+        "linux" => detect_linux_platform(),
+        other => HostPlatform::Unknown(other.to_string()),
+    }
+}
+
+pub(crate) fn resolve_plan(
+    db: &SysreqDbSnapshot,
+    package_rules: &BTreeMap<String, Vec<String>>,
+) -> SystemDependencyPlan {
+    let host = current_host_platform();
+    let mut install_packages = BTreeSet::new();
+    let mut pre_install = Vec::new();
+    let mut post_install = Vec::new();
+    let mut unsupported_rules = BTreeSet::new();
+
+    for rules in package_rules.values() {
+        for rule_id in rules {
+            let Some(rule) = db.rules.iter().find(|rule| rule.id == *rule_id) else {
+                unsupported_rules.insert(rule_id.clone());
+                continue;
+            };
+
+            let matching_dependencies = rule
+                .dependencies
+                .iter()
+                .filter(|dependency| dependency_matches_host(dependency, &host))
+                .collect::<Vec<_>>();
+            if matching_dependencies.is_empty() {
+                unsupported_rules.insert(rule_id.clone());
+                continue;
+            }
+
+            for dependency in matching_dependencies {
+                for package in &dependency.packages {
+                    install_packages.insert(package.clone());
+                }
+                for action in &dependency.pre_install {
+                    if let Ok(command) = action_command(action, db) {
+                        pre_install.push(command);
+                    }
+                }
+                for action in &dependency.post_install {
+                    if let Ok(command) = action_command(action, db) {
+                        post_install.push(command);
+                    }
+                }
+            }
+        }
+    }
+
+    pre_install = dedupe_keep_order(pre_install);
+    post_install = dedupe_keep_order(post_install);
+    let install_packages = install_packages.into_iter().collect::<Vec<_>>();
+    let install_supported = package_manager_for_host(&host).is_some();
+    let can_auto_install = install_supported && install_prefix().is_some();
+
+    let (missing_packages, installed_query_error) = match installed_packages(&host) {
+        Ok(installed) => (
+            install_packages
+                .iter()
+                .filter(|package| !installed.contains(*package))
+                .cloned()
+                .collect(),
+            None,
+        ),
+        Err(error) => (install_packages.clone(), Some(error)),
+    };
+
+    SystemDependencyPlan {
+        host,
+        missing_packages,
+        install_packages,
+        pre_install_commands: pre_install,
+        post_install_commands: post_install,
+        unsupported_rules: unsupported_rules.into_iter().collect(),
+        package_rules: package_rules.clone(),
+        install_supported,
+        can_auto_install,
+        installed_query_error,
+    }
+}
+
+pub(crate) fn preview_commands(plan: &SystemDependencyPlan) -> Vec<String> {
+    let mut commands = Vec::new();
+    commands.extend(
+        plan.pre_install_commands
+            .iter()
+            .cloned()
+            .map(prefix_command),
+    );
+    if !plan.missing_packages.is_empty() {
+        if let Some(command) = package_install_command(&plan.host, &plan.missing_packages) {
+            commands.push(prefix_command(command));
+        }
+    }
+    commands.extend(
+        plan.post_install_commands
+            .iter()
+            .cloned()
+            .map(prefix_command),
+    );
+    commands
+}
+
+pub(crate) fn install(plan: &SystemDependencyPlan) -> Result<(), String> {
+    if plan.missing_packages.is_empty()
+        && plan.pre_install_commands.is_empty()
+        && plan.post_install_commands.is_empty()
+    {
+        return Ok(());
+    }
+
+    if !plan.install_supported {
+        return Err(format!(
+            "automatic system dependency installation is not supported on {}",
+            plan.host.label()
+        ));
+    }
+
+    let Some(prefix) = install_prefix() else {
+        return Err(
+            "need root privileges or passwordless sudo to install system dependencies".to_string(),
+        );
+    };
+
+    for command in &plan.pre_install_commands {
+        run_shell_command(&prefix, command)?;
+    }
+    if !plan.missing_packages.is_empty() {
+        let command =
+            package_install_command(&plan.host, &plan.missing_packages).ok_or_else(|| {
+                format!(
+                    "automatic system dependency installation is not supported on {}",
+                    plan.host.label()
+                )
+            })?;
+        run_shell_command(&prefix, &command)?;
+    }
+    for command in &plan.post_install_commands {
+        run_shell_command(&prefix, command)?;
+    }
+
+    Ok(())
+}
+
+impl HostPlatform {
+    pub(crate) fn label(&self) -> String {
+        match self {
+            Self::Linux {
+                distribution,
+                version,
+            } => format!("linux/{distribution}-{version}"),
+            Self::Macos => "macos".to_string(),
+            Self::Windows => "windows".to_string(),
+            Self::Unknown(value) => value.clone(),
+        }
+    }
+}
+
+fn latest_commit_hash() -> Result<String, String> {
+    let client = github_client()?;
+    let response = client
+        .get(format!("{SYSREQS_API_BASE}/commits/main"))
+        .send()
+        .map_err(|error| format!("failed to fetch sysreq database commit: {error}"))?;
+    if !response.status().is_success() {
+        return Err(format!(
+            "failed to fetch sysreq database commit ({})",
+            response.status()
+        ));
+    }
+
+    response
+        .json::<CommitResponse>()
+        .map(|response| response.sha)
+        .map_err(|error| format!("failed to decode sysreq database commit: {error}"))
+}
+
+fn download_snapshot(commit: &str) -> Result<SysreqDbSnapshot, String> {
+    let client = github_client()?;
+    let mut response = client
+        .get(format!("{SYSREQS_API_BASE}/tarball/{commit}"))
+        .send()
+        .map_err(|error| format!("failed to download sysreq database snapshot: {error}"))?;
+    if !response.status().is_success() {
+        return Err(format!(
+            "failed to download sysreq database snapshot ({})",
+            response.status()
+        ));
+    }
+
+    let mut bytes = Vec::new();
+    response
+        .read_to_end(&mut bytes)
+        .map_err(|error| format!("failed to read sysreq database snapshot: {error}"))?;
+
+    let decoder = GzDecoder::new(bytes.as_slice());
+    let mut archive = Archive::new(decoder);
+    let mut rules = Vec::new();
+    let mut scripts = BTreeMap::new();
+
+    for entry in archive
+        .entries()
+        .map_err(|error| format!("failed to read sysreq database archive: {error}"))?
+    {
+        let mut entry =
+            entry.map_err(|error| format!("failed to read sysreq archive entry: {error}"))?;
+        let path = entry
+            .path()
+            .map_err(|error| format!("failed to read sysreq archive path: {error}"))?;
+        let components = path.components().collect::<Vec<_>>();
+        if components.len() < 3 {
+            continue;
+        }
+
+        let top = components[1].as_os_str().to_string_lossy();
+        let name = components[2].as_os_str().to_string_lossy().to_string();
+        if top == "rules" && name.ends_with(".json") {
+            let mut contents = String::new();
+            entry
+                .read_to_string(&mut contents)
+                .map_err(|error| format!("failed to read sysreq rule {name}: {error}"))?;
+            let raw = serde_json::from_str::<RawSysreqRule>(&contents)
+                .map_err(|error| format!("failed to parse sysreq rule {name}: {error}"))?;
+            rules.push(SysreqRule {
+                id: name.trim_end_matches(".json").to_string(),
+                patterns: raw.patterns,
+                dependencies: raw.dependencies,
+            });
+            continue;
+        }
+
+        if top == "scripts" {
+            let mut contents = String::new();
+            entry
+                .read_to_string(&mut contents)
+                .map_err(|error| format!("failed to read sysreq script {name}: {error}"))?;
+            scripts.insert(name, contents);
+        }
+    }
+
+    rules.sort_by(|left, right| left.id.cmp(&right.id));
+    Ok(SysreqDbSnapshot {
+        commit: commit.to_string(),
+        rules,
+        scripts,
+    })
+}
+
+fn dependency_matches_host(dependency: &SysreqDependency, host: &HostPlatform) -> bool {
+    if dependency.constraints.is_empty() {
+        return true;
+    }
+
+    dependency
+        .constraints
+        .iter()
+        .any(|constraint| constraint_matches_host(constraint, host))
+}
+
+fn constraint_matches_host(constraint: &SysreqConstraint, host: &HostPlatform) -> bool {
+    match host {
+        HostPlatform::Linux {
+            distribution,
+            version,
+        } => {
+            if constraint.os != "linux" || constraint.distribution != *distribution {
+                return false;
+            }
+            constraint.versions.is_empty()
+                || constraint.versions.iter().any(|value| value == version)
+        }
+        HostPlatform::Windows => constraint.os == "windows",
+        HostPlatform::Macos => constraint.os == "macos",
+        HostPlatform::Unknown(_) => false,
+    }
+}
+
+fn detect_linux_platform() -> HostPlatform {
+    let Ok(contents) = fs::read_to_string("/etc/os-release") else {
+        return HostPlatform::Unknown("linux".to_string());
+    };
+
+    let values = contents
+        .lines()
+        .filter_map(|line| line.split_once('='))
+        .map(|(key, value)| {
+            (
+                key.trim().to_string(),
+                value.trim().trim_matches('"').to_string(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+
+    let id = values.get("ID").cloned().unwrap_or_default();
+    let version = values.get("VERSION_ID").cloned().unwrap_or_default();
+    let distribution = match id.as_str() {
+        "ubuntu" => Some("ubuntu"),
+        "debian" => Some("debian"),
+        "centos" => Some("centos"),
+        "rhel" => Some("redhat"),
+        "rocky" | "rockylinux" => Some("rockylinux"),
+        "opensuse-leap" | "opensuse" => Some("opensuse"),
+        "sles" | "sle_hpc" => Some("sle"),
+        "fedora" => Some("fedora"),
+        "alpine" => Some("alpine"),
+        _ => None,
+    };
+
+    match distribution {
+        Some(distribution) => HostPlatform::Linux {
+            distribution: distribution.to_string(),
+            version,
+        },
+        None => HostPlatform::Unknown(format!("linux/{id}-{version}")),
+    }
+}
+
+fn installed_packages(host: &HostPlatform) -> Result<BTreeSet<String>, String> {
+    let output = match host {
+        HostPlatform::Linux { distribution, .. }
+            if distribution == "ubuntu" || distribution == "debian" =>
+        {
+            Command::new("dpkg-query")
+                .args(["-W", "-f=${Package}\n"])
+                .output()
+        }
+        HostPlatform::Linux { distribution, .. }
+            if distribution == "centos"
+                || distribution == "rockylinux"
+                || distribution == "redhat"
+                || distribution == "fedora"
+                || distribution == "opensuse"
+                || distribution == "sle" =>
+        {
+            Command::new("rpm")
+                .args(["-qa", "--qf", "%{NAME}\n"])
+                .output()
+        }
+        HostPlatform::Linux { distribution, .. } if distribution == "alpine" => {
+            Command::new("apk").args(["info"]).output()
+        }
+        _ => {
+            return Err(format!(
+                "installed package detection is not supported on {}",
+                host.label()
+            ));
+        }
+    }
+    .map_err(|error| format!("failed to inspect installed system packages: {error}"))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "failed to inspect installed system packages ({})",
+            output.status
+        ));
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(str::trim)
+        .filter(|line| !line.is_empty())
+        .map(ToString::to_string)
+        .collect())
+}
+
+fn package_manager_for_host(host: &HostPlatform) -> Option<&'static str> {
+    match host {
+        HostPlatform::Linux { distribution, .. }
+            if distribution == "ubuntu" || distribution == "debian" =>
+        {
+            Some("apt-get")
+        }
+        HostPlatform::Linux { distribution, .. }
+            if distribution == "centos" || distribution == "redhat" =>
+        {
+            Some("yum")
+        }
+        HostPlatform::Linux { distribution, .. }
+            if distribution == "rockylinux" || distribution == "fedora" =>
+        {
+            Some("dnf")
+        }
+        HostPlatform::Linux { distribution, .. }
+            if distribution == "opensuse" || distribution == "sle" =>
+        {
+            Some("zypper")
+        }
+        HostPlatform::Linux { distribution, .. } if distribution == "alpine" => Some("apk"),
+        _ => None,
+    }
+}
+
+fn package_install_command(host: &HostPlatform, packages: &[String]) -> Option<String> {
+    if packages.is_empty() {
+        return None;
+    }
+
+    let joined = packages.join(" ");
+    match host {
+        HostPlatform::Linux { distribution, .. }
+            if distribution == "ubuntu" || distribution == "debian" =>
+        {
+            Some(format!("apt-get update && apt-get install -y {joined}"))
+        }
+        HostPlatform::Linux { distribution, .. }
+            if distribution == "centos" || distribution == "redhat" =>
+        {
+            Some(format!("yum install -y {joined}"))
+        }
+        HostPlatform::Linux { distribution, .. }
+            if distribution == "rockylinux" || distribution == "fedora" =>
+        {
+            Some(format!("dnf install -y {joined}"))
+        }
+        HostPlatform::Linux { distribution, .. }
+            if distribution == "opensuse" || distribution == "sle" =>
+        {
+            Some(format!("zypper --non-interactive install {joined}"))
+        }
+        HostPlatform::Linux { distribution, .. } if distribution == "alpine" => {
+            Some(format!("apk add --no-cache {joined}"))
+        }
+        _ => None,
+    }
+}
+
+fn action_command(action: &SysreqAction, db: &SysreqDbSnapshot) -> Result<String, String> {
+    if !action.command.trim().is_empty() {
+        return Ok(action.command.trim().to_string());
+    }
+    if !action.script.trim().is_empty() {
+        let script = db
+            .scripts
+            .get(action.script.trim())
+            .ok_or_else(|| format!("missing sysreq helper script: {}", action.script.trim()))?;
+        return Ok(script.trim().to_string());
+    }
+    Err("invalid sysreq action: missing command or script".to_string())
+}
+
+fn install_prefix() -> Option<Vec<String>> {
+    if current_uid().as_deref() == Some("0") {
+        return Some(vec![]);
+    }
+
+    let sudo_ok = Command::new("sudo")
+        .args(["-n", "true"])
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false);
+    sudo_ok.then(|| vec!["sudo".to_string()])
+}
+
+fn current_uid() -> Option<String> {
+    Command::new("id")
+        .arg("-u")
+        .output()
+        .ok()
+        .filter(|output| output.status.success())
+        .map(|output| String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn run_shell_command(prefix: &[String], command: &str) -> Result<(), String> {
+    let mut process = if prefix.is_empty() {
+        let mut process = Command::new("sh");
+        process.args(["-c", command]);
+        process
+    } else {
+        let mut process = Command::new(&prefix[0]);
+        process.args(&prefix[1..]);
+        process.args(["sh", "-c", command]);
+        process
+    };
+
+    let status = process
+        .status()
+        .map_err(|error| format!("failed to run system command `{command}`: {error}"))?;
+    if status.success() {
+        return Ok(());
+    }
+
+    Err(format!("system command failed ({status}): {command}"))
+}
+
+fn prefix_command(command: String) -> String {
+    install_prefix()
+        .filter(|prefix| !prefix.is_empty())
+        .map(|prefix| format!("{} {command}", prefix.join(" ")))
+        .unwrap_or(command)
+}
+
+fn github_client() -> Result<reqwest::blocking::Client, String> {
+    reqwest::blocking::Client::builder()
+        .user_agent("rpx")
+        .build()
+        .map_err(|error| format!("failed to create sysreq database client: {error}"))
+}
+
+fn latest_snapshot_cache_path() -> PathBuf {
+    let path = cache_dir_path().join("sysreqs").join("latest.json");
+    ensure_parent_dir(&path);
+    path
+}
+
+fn db_snapshot_cache_path(commit: &str) -> PathBuf {
+    let path = cache_dir_path()
+        .join("sysreqs")
+        .join("snapshots")
+        .join(format!("{commit}.json"));
+    ensure_parent_dir(&path);
+    path
+}
+
+fn ensure_parent_dir(path: &PathBuf) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("failed to create sysreq cache directory");
+    }
+}
+
+fn read_json_cache_fresh<T>(path: &PathBuf, ttl: Duration) -> Option<T>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let metadata = fs::metadata(path).ok()?;
+    let modified = metadata.modified().ok()?;
+    let age = SystemTime::now().duration_since(modified).ok()?;
+    if age > ttl {
+        return None;
+    }
+    read_json(path).ok()
+}
+
+fn read_json<T>(path: &PathBuf) -> Result<T, String>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    let contents = fs::read_to_string(path)
+        .map_err(|error| format!("failed to read sysreq cache {}: {error}", path.display()))?;
+    serde_json::from_str(&contents)
+        .map_err(|error| format!("failed to parse sysreq cache {}: {error}", path.display()))
+}
+
+fn write_json<T>(path: &PathBuf, value: &T) -> Result<(), String>
+where
+    T: Serialize,
+{
+    let contents = serde_json::to_string_pretty(value)
+        .map_err(|error| format!("failed to serialize sysreq cache: {error}"))?;
+    fs::write(path, format!("{contents}\n"))
+        .map_err(|error| format!("failed to write sysreq cache {}: {error}", path.display()))
+}
+
+fn dedupe_keep_order(values: Vec<String>) -> Vec<String> {
+    let mut seen = BTreeSet::new();
+    let mut deduped = Vec::new();
+    for value in values {
+        if seen.insert(value.clone()) {
+            deduped.push(value);
+        }
+    }
+    deduped
+}
+
+fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after unix epoch")
+        .as_secs()
+}

--- a/src/sysreqs.rs
+++ b/src/sysreqs.rs
@@ -86,6 +86,7 @@ pub(crate) struct SystemDependencyPlan {
     pub install_supported: bool,
     pub can_auto_install: bool,
     pub installed_query_error: Option<String>,
+    pub needs_metadata_refresh: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -233,10 +234,14 @@ pub(crate) fn resolve_plan(
     let install_supported = package_manager_for_host(&host).is_some();
     let can_auto_install = install_supported && install_prefix().is_some();
 
-    let (missing_packages, installed_query_error) =
+    let (missing_packages, installed_query_error, needs_metadata_refresh) =
         match missing_packages_for_host(&host, &install_packages) {
-            Ok(missing_packages) => (missing_packages, None),
-            Err(error) => (install_packages.clone(), Some(error)),
+            Ok(missing_packages) => (missing_packages, None, false),
+            Err(error) => (
+                install_packages.clone(),
+                Some(error.to_string()),
+                error.needs_metadata_refresh(),
+            ),
         };
 
     SystemDependencyPlan {
@@ -250,6 +255,7 @@ pub(crate) fn resolve_plan(
         install_supported,
         can_auto_install,
         installed_query_error,
+        needs_metadata_refresh,
     }
 }
 
@@ -314,6 +320,30 @@ pub(crate) fn install(plan: &SystemDependencyPlan) -> Result<(), String> {
     }
 
     Ok(())
+}
+
+pub(crate) fn refresh_metadata(plan: &SystemDependencyPlan) -> Result<(), String> {
+    let Some(command) = package_update_command(&plan.host) else {
+        return Err(format!(
+            "automatic system dependency installation is not supported on {}",
+            plan.host.label()
+        ));
+    };
+    let Some(prefix) = install_prefix() else {
+        return Err(
+            "need root privileges or passwordless sudo to install system dependencies".to_string(),
+        );
+    };
+
+    run_shell_command(&prefix, &command)
+}
+
+pub(crate) fn refresh_preview_command(plan: &SystemDependencyPlan) -> Option<String> {
+    package_update_command(&plan.host).map(prefix_command)
+}
+
+pub(crate) fn recheck_missing_packages(plan: &SystemDependencyPlan) -> Result<Vec<String>, String> {
+    missing_packages_for_host(&plan.host, &plan.install_packages).map_err(|error| error.to_string())
 }
 
 impl HostPlatform {
@@ -546,13 +576,13 @@ fn installed_packages(host: &HostPlatform) -> Result<BTreeSet<String>, String> {
 fn missing_packages_for_host(
     host: &HostPlatform,
     packages: &[String],
-) -> Result<Vec<String>, String> {
+) -> Result<Vec<String>, AvailabilityCheckError> {
     if matches!(host, HostPlatform::Linux { distribution, .. } if distribution == "ubuntu" || distribution == "debian")
     {
         return apt_missing_packages(packages);
     }
 
-    let installed = installed_packages(host)?;
+    let installed = installed_packages(host).map_err(AvailabilityCheckError::other)?;
     Ok(packages
         .iter()
         .filter(|package| !installed.contains(*package))
@@ -560,12 +590,12 @@ fn missing_packages_for_host(
         .collect())
 }
 
-fn apt_missing_packages(packages: &[String]) -> Result<Vec<String>, String> {
+fn apt_missing_packages(packages: &[String]) -> Result<Vec<String>, AvailabilityCheckError> {
     let output = apt_simulation_output(packages)?;
     Ok(apt_simulation_missing_packages(packages, &output))
 }
 
-fn apt_simulation_output(packages: &[String]) -> Result<String, String> {
+fn apt_simulation_output(packages: &[String]) -> Result<String, AvailabilityCheckError> {
     let output = Command::new("apt-get")
         .arg("-s")
         .arg("install")
@@ -573,17 +603,15 @@ fn apt_simulation_output(packages: &[String]) -> Result<String, String> {
         .arg("--no-install-recommends")
         .args(packages)
         .output()
-        .map_err(|error| format!("failed to inspect apt packages: {error}"))?;
-
-    if !output.status.success() {
-        return Err(format!(
-            "failed to inspect apt packages ({})",
-            output.status
-        ));
-    }
+        .map_err(|error| AvailabilityCheckError::other(format!("failed to inspect apt packages: {error}")))?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stdout}\n{stderr}");
+
+    if !output.status.success() {
+        return Err(classify_apt_failure(output.status.code(), &combined));
+    }
     Ok(format!("{stdout}\n{stderr}"))
 }
 
@@ -631,6 +659,60 @@ fn parse_apt_installed_package(line: &str) -> Option<String> {
     Some(package.to_string())
 }
 
+#[derive(Debug, Clone)]
+struct AvailabilityCheckError {
+    message: String,
+    needs_metadata_refresh: bool,
+}
+
+impl AvailabilityCheckError {
+    fn other(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            needs_metadata_refresh: false,
+        }
+    }
+
+    fn metadata_refresh(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            needs_metadata_refresh: true,
+        }
+    }
+
+    fn needs_metadata_refresh(&self) -> bool {
+        self.needs_metadata_refresh
+    }
+}
+
+impl std::fmt::Display for AvailabilityCheckError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+fn classify_apt_failure(exit_code: Option<i32>, output: &str) -> AvailabilityCheckError {
+    let trimmed = output.trim();
+    if apt_failure_likely_needs_metadata_refresh(trimmed) {
+        return AvailabilityCheckError::metadata_refresh(format!(
+            "failed to inspect apt packages (exit status: {})",
+            exit_code.unwrap_or(1)
+        ));
+    }
+
+    AvailabilityCheckError::other(format!(
+        "failed to inspect apt packages (exit status: {}): {trimmed}",
+        exit_code.unwrap_or(1)
+    ))
+}
+
+fn apt_failure_likely_needs_metadata_refresh(output: &str) -> bool {
+    let lowered = output.to_ascii_lowercase();
+    lowered.contains("unable to locate package")
+        || lowered.contains("has no installation candidate")
+        || lowered.contains("package information")
+}
+
 fn package_manager_for_host(host: &HostPlatform) -> Option<&'static str> {
     match host {
         HostPlatform::Linux { distribution, .. }
@@ -654,6 +736,31 @@ fn package_manager_for_host(host: &HostPlatform) -> Option<&'static str> {
             Some("zypper")
         }
         HostPlatform::Linux { distribution, .. } if distribution == "alpine" => Some("apk"),
+        _ => None,
+    }
+}
+
+fn package_update_command(host: &HostPlatform) -> Option<String> {
+    match host {
+        HostPlatform::Linux { distribution, .. }
+            if distribution == "ubuntu" || distribution == "debian" => {
+                Some("apt-get update".to_string())
+            }
+        HostPlatform::Linux { distribution, .. }
+            if distribution == "rockylinux" || distribution == "fedora" => {
+                Some("dnf makecache".to_string())
+            }
+        HostPlatform::Linux { distribution, .. }
+            if distribution == "centos" || distribution == "redhat" => {
+                Some("yum makecache".to_string())
+            }
+        HostPlatform::Linux { distribution, .. }
+            if distribution == "opensuse" || distribution == "sle" => {
+                Some("zypper --non-interactive refresh".to_string())
+            }
+        HostPlatform::Linux { distribution, .. } if distribution == "alpine" => {
+            Some("apk update".to_string())
+        }
         _ => None,
     }
 }
@@ -849,7 +956,7 @@ fn now_unix() -> u64 {
 
 #[cfg(test)]
 mod tests {
-    use super::apt_simulation_missing_packages;
+    use super::{apt_failure_likely_needs_metadata_refresh, apt_simulation_missing_packages};
 
     #[test]
     fn apt_simulation_recognizes_alias_as_already_satisfied() {
@@ -899,5 +1006,15 @@ Conf libxml2-dev (2.14.3+dfsg-1 Debian:testing [amd64])\n";
             ),
             vec!["libxml2-dev".to_string()]
         );
+    }
+
+    #[test]
+    fn detects_metadata_refresh_needed_for_apt_resolution_failure() {
+        let output = "Reading package lists... Done\n\
+Building dependency tree... Done\n\
+Reading state information... Done\n\
+E: Unable to locate package libxml2-dev\n";
+
+        assert!(apt_failure_likely_needs_metadata_refresh(output));
     }
 }

--- a/src/sysreqs.rs
+++ b/src/sysreqs.rs
@@ -126,6 +126,15 @@ pub(crate) fn latest_snapshot() -> Result<SysreqDbSnapshot, String> {
     Ok(snapshot)
 }
 
+pub(crate) fn cached_latest_snapshot() -> Result<Option<SysreqDbSnapshot>, String> {
+    let cache_path = latest_snapshot_cache_path();
+    let Some(cached) = read_json_cache::<LatestSnapshotCache>(&cache_path)? else {
+        return Ok(None);
+    };
+
+    snapshot_for_commit(&cached.commit).map(Some)
+}
+
 pub(crate) fn snapshot_for_commit(commit: &str) -> Result<SysreqDbSnapshot, String> {
     let cache_path = db_snapshot_cache_path(commit);
     if cache_path.exists() {
@@ -135,6 +144,14 @@ pub(crate) fn snapshot_for_commit(commit: &str) -> Result<SysreqDbSnapshot, Stri
     let snapshot = download_snapshot(commit)?;
     write_json(&cache_path, &snapshot)?;
     Ok(snapshot)
+}
+
+pub(crate) fn empty_snapshot() -> SysreqDbSnapshot {
+    SysreqDbSnapshot {
+        commit: String::new(),
+        rules: vec![],
+        scripts: BTreeMap::new(),
+    }
 }
 
 pub(crate) fn match_rules(spec: Option<&str>, db: &SysreqDbSnapshot) -> Vec<String> {
@@ -701,6 +718,17 @@ where
         .map_err(|error| format!("failed to read sysreq cache {}: {error}", path.display()))?;
     serde_json::from_str(&contents)
         .map_err(|error| format!("failed to parse sysreq cache {}: {error}", path.display()))
+}
+
+fn read_json_cache<T>(path: &PathBuf) -> Result<Option<T>, String>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    read_json(path).map(Some)
 }
 
 fn write_json<T>(path: &PathBuf, value: &T) -> Result<(), String>

--- a/src/sysreqs.rs
+++ b/src/sysreqs.rs
@@ -603,7 +603,9 @@ fn apt_simulation_output(packages: &[String]) -> Result<String, AvailabilityChec
         .arg("--no-install-recommends")
         .args(packages)
         .output()
-        .map_err(|error| AvailabilityCheckError::other(format!("failed to inspect apt packages: {error}")))?;
+        .map_err(|error| {
+            AvailabilityCheckError::other(format!("failed to inspect apt packages: {error}"))
+        })?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
@@ -743,21 +745,25 @@ fn package_manager_for_host(host: &HostPlatform) -> Option<&'static str> {
 fn package_update_command(host: &HostPlatform) -> Option<String> {
     match host {
         HostPlatform::Linux { distribution, .. }
-            if distribution == "ubuntu" || distribution == "debian" => {
-                Some("apt-get update".to_string())
-            }
+            if distribution == "ubuntu" || distribution == "debian" =>
+        {
+            Some("apt-get update".to_string())
+        }
         HostPlatform::Linux { distribution, .. }
-            if distribution == "rockylinux" || distribution == "fedora" => {
-                Some("dnf makecache".to_string())
-            }
+            if distribution == "rockylinux" || distribution == "fedora" =>
+        {
+            Some("dnf makecache".to_string())
+        }
         HostPlatform::Linux { distribution, .. }
-            if distribution == "centos" || distribution == "redhat" => {
-                Some("yum makecache".to_string())
-            }
+            if distribution == "centos" || distribution == "redhat" =>
+        {
+            Some("yum makecache".to_string())
+        }
         HostPlatform::Linux { distribution, .. }
-            if distribution == "opensuse" || distribution == "sle" => {
-                Some("zypper --non-interactive refresh".to_string())
-            }
+            if distribution == "opensuse" || distribution == "sle" =>
+        {
+            Some("zypper --non-interactive refresh".to_string())
+        }
         HostPlatform::Linux { distribution, .. } if distribution == "alpine" => {
             Some("apk update".to_string())
         }
@@ -847,14 +853,39 @@ fn run_shell_command(prefix: &[String], command: &str) -> Result<(), String> {
         process
     };
 
-    let status = process
-        .status()
+    let output = process
+        .output()
         .map_err(|error| format!("failed to run system command `{command}`: {error}"))?;
-    if status.success() {
+    if output.status.success() {
         return Ok(());
     }
 
-    Err(format!("system command failed ({status}): {command}"))
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = [stdout.as_ref().trim(), stderr.as_ref().trim()]
+        .into_iter()
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let tail = command_output_tail(&combined, 40);
+
+    if tail.is_empty() {
+        return Err(format!(
+            "system command failed ({}): {command}",
+            output.status
+        ));
+    }
+
+    Err(format!(
+        "system command failed ({}): {command}\n{tail}",
+        output.status
+    ))
+}
+
+fn command_output_tail(output: &str, max_lines: usize) -> String {
+    let lines = output.lines().collect::<Vec<_>>();
+    let start = lines.len().saturating_sub(max_lines);
+    lines[start..].join("\n")
 }
 
 fn prefix_command(command: String) -> String {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -35,15 +35,17 @@ impl InstallKind {
 pub(crate) struct SyncUi {
     interactive: bool,
     _multi: Option<MultiProgress>,
-    downloads: ProgressBar,
-    binary_installs: ProgressBar,
-    source_builds: ProgressBar,
-    status: ProgressBar,
+    downloads: RefCell<Option<ProgressBar>>,
+    binary_installs: RefCell<Option<ProgressBar>>,
+    source_builds: RefCell<Option<ProgressBar>>,
     active_downloads: RefCell<BTreeMap<String, ProgressBar>>,
     active_installs: RefCell<BTreeMap<String, ProgressBar>>,
+    restored_packages: Cell<u64>,
     downloaded_packages: Cell<u64>,
     downloaded_bytes: Cell<u64>,
     total_download_bytes: Cell<Option<u64>>,
+    binary_finished: Cell<u64>,
+    source_finished: Cell<u64>,
 }
 
 impl SyncUi {
@@ -52,63 +54,37 @@ impl SyncUi {
 
         if interactive {
             let multi = MultiProgress::with_draw_target(ProgressDrawTarget::stderr());
-            let downloads = multi.add(ProgressBar::new(0));
-            downloads.set_style(
-                ProgressStyle::with_template(
-                    "downloads          [{bar:30.cyan/blue}] {pos}/{len} {msg}",
-                )
-                .expect("progress template should parse")
-                .progress_chars("##-"),
-            );
-            let binary_installs = multi.add(ProgressBar::new(0));
-            binary_installs.set_style(
-                ProgressStyle::with_template(
-                    "installing binaries [{bar:30.green/blue}] {pos}/{len}",
-                )
-                .expect("progress template should parse")
-                .progress_chars("##-"),
-            );
-            let source_builds = multi.add(ProgressBar::new(0));
-            source_builds.set_style(
-                ProgressStyle::with_template(
-                    "compiling source    [{bar:30.yellow/blue}] {pos}/{len}",
-                )
-                .expect("progress template should parse")
-                .progress_chars("##-"),
-            );
-            let status = multi.add(ProgressBar::new_spinner());
-            status.set_style(
-                ProgressStyle::with_template("{spinner} {msg}")
-                    .expect("progress template should parse"),
-            );
-            status.enable_steady_tick(std::time::Duration::from_millis(100));
 
             Self {
                 interactive,
                 _multi: Some(multi),
-                downloads,
-                binary_installs,
-                source_builds,
-                status,
+                downloads: RefCell::new(None),
+                binary_installs: RefCell::new(None),
+                source_builds: RefCell::new(None),
                 active_downloads: RefCell::new(BTreeMap::new()),
                 active_installs: RefCell::new(BTreeMap::new()),
+                restored_packages: Cell::new(0),
                 downloaded_packages: Cell::new(0),
                 downloaded_bytes: Cell::new(0),
                 total_download_bytes: Cell::new(Some(0)),
+                binary_finished: Cell::new(0),
+                source_finished: Cell::new(0),
             }
         } else {
             Self {
                 interactive,
                 _multi: None,
-                downloads: ProgressBar::hidden(),
-                binary_installs: ProgressBar::hidden(),
-                source_builds: ProgressBar::hidden(),
-                status: ProgressBar::hidden(),
+                downloads: RefCell::new(None),
+                binary_installs: RefCell::new(None),
+                source_builds: RefCell::new(None),
                 active_downloads: RefCell::new(BTreeMap::new()),
                 active_installs: RefCell::new(BTreeMap::new()),
+                restored_packages: Cell::new(0),
                 downloaded_packages: Cell::new(0),
                 downloaded_bytes: Cell::new(0),
                 total_download_bytes: Cell::new(Some(0)),
+                binary_finished: Cell::new(0),
+                source_finished: Cell::new(0),
             }
         }
     }
@@ -118,42 +94,59 @@ impl SyncUi {
             return;
         }
 
+        self.restored_packages.set(0);
+
         if self.interactive {
-            self.downloads.set_length(total as u64);
-            self.downloads.set_position(0);
-            self.downloads.set_message("from cache");
-            self.status.set_message("restoring cached packages");
+            let bar = self
+                .create_aggregate_bar("downloads          [{bar:30.cyan/blue}] {pos}/{len} {msg}");
+            bar.set_length(total as u64);
+            bar.set_position(0);
+            bar.set_message("from cache");
+            self.downloads.replace(Some(bar));
         } else {
             eprintln!("Restoring {total} cached packages");
         }
     }
 
     pub(crate) fn finish_restore(&self, name: &str, version: &str) {
-        self.downloads.inc(1);
-        if self.interactive {
-            self.status
-                .set_message(format!("restored {name}@{version} from cache"));
-        } else {
+        self.restored_packages
+            .set(self.restored_packages.get().saturating_add(1));
+        if let Some(bar) = self.downloads.borrow().as_ref() {
+            bar.inc(1);
+        }
+        if !self.interactive {
             eprintln!("Restored {name}@{version} from cache");
         }
     }
 
     pub(crate) fn finish_restores(&self) {
-        if self.interactive && self.downloads.length().unwrap_or(0) > 0 {
-            self.downloads.finish_and_clear();
+        if self.interactive {
+            if let Some(bar) = self.downloads.borrow_mut().take() {
+                bar.finish_with_message(format!(
+                    "Restored {} {} from cache",
+                    self.restored_packages.get(),
+                    pluralize(self.restored_packages.get(), "package", "packages")
+                ));
+            }
         }
     }
 
     pub(crate) fn start_downloads(&self, total: usize) {
+        if total == 0 {
+            return;
+        }
+
         self.downloaded_packages.set(0);
         self.downloaded_bytes.set(0);
         self.total_download_bytes.set(Some(0));
 
         if self.interactive {
-            self.downloads.set_length(total as u64);
-            self.downloads.set_position(0);
+            let bar = self
+                .create_aggregate_bar("downloads          [{bar:30.cyan/blue}] {pos}/{len} {msg}");
+            bar.set_length(total as u64);
+            bar.set_position(0);
+            self.downloads.replace(Some(bar));
             self.update_download_message();
-            self.status.set_message("downloading package artifacts");
         } else {
             eprintln!("Downloading {total} packages");
         }
@@ -169,7 +162,7 @@ impl SyncUi {
                 ._multi
                 .as_ref()
                 .map_or_else(ProgressBar::hidden, |multi| {
-                    let bar = multi.insert_before(&self.status, ProgressBar::new(0));
+                    let bar = multi.add(ProgressBar::new(0));
                     bar.set_style(
                         ProgressStyle::with_template(
                             "  {msg:28} [{bar:24.cyan/blue}] {bytes}/{total_bytes} {bytes_per_sec}",
@@ -183,8 +176,6 @@ impl SyncUi {
             self.active_downloads
                 .borrow_mut()
                 .insert(name.to_string(), bar);
-            self.status
-                .set_message(format!("downloading {name}@{version}"));
         } else {
             eprintln!("Downloading {name}@{version} {}", artifact_label(kind));
         }
@@ -213,11 +204,7 @@ impl SyncUi {
     }
 
     pub(crate) fn fallback_to_source(&self, name: &str, version: &str) {
-        if self.interactive {
-            self.status.set_message(format!(
-                "{name}@{version} binary unavailable; falling back to source"
-            ));
-        } else {
+        if !self.interactive {
             eprintln!("{name}@{version} binary unavailable; falling back to source");
         }
     }
@@ -225,16 +212,15 @@ impl SyncUi {
     pub(crate) fn finish_download(&self, name: &str, version: &str, kind: InstallKind) {
         self.downloaded_packages
             .set(self.downloaded_packages.get().saturating_add(1));
-        self.downloads.inc(1);
+        if let Some(bar) = self.downloads.borrow().as_ref() {
+            bar.inc(1);
+        }
         if let Some(bar) = self.active_downloads.borrow_mut().remove(name) {
             bar.finish_and_clear();
         }
         self.update_download_message();
 
-        if self.interactive {
-            self.status
-                .set_message(format!("downloaded {name}@{version} {}", kind.label()));
-        } else {
+        if !self.interactive {
             eprintln!("Downloaded {name}@{version} {}", kind.label());
         }
     }
@@ -244,17 +230,36 @@ impl SyncUi {
             for (_, bar) in self.active_downloads.borrow_mut().split_off("") {
                 bar.finish_and_clear();
             }
-            self.downloads.finish_and_clear();
+            if let Some(bar) = self.downloads.borrow_mut().take() {
+                bar.finish_with_message(format!(
+                    "Downloaded {} {} ({})",
+                    self.downloaded_packages.get(),
+                    pluralize(self.downloaded_packages.get(), "package", "packages"),
+                    HumanBytes(self.downloaded_bytes.get())
+                ));
+            }
         }
     }
 
     pub(crate) fn start_installs(&self, binary_total: usize, source_total: usize) {
+        self.binary_finished.set(0);
+        self.source_finished.set(0);
+
         if self.interactive {
-            self.binary_installs.set_length(binary_total as u64);
-            self.binary_installs.set_position(0);
-            self.source_builds.set_length(source_total as u64);
-            self.source_builds.set_position(0);
-            self.status.set_message("installing locked packages");
+            if binary_total > 0 {
+                let bar = self
+                    .create_aggregate_bar("installing binaries[{bar:30.green/blue}] {pos}/{len}");
+                bar.set_length(binary_total as u64);
+                bar.set_position(0);
+                self.binary_installs.replace(Some(bar));
+            }
+            if source_total > 0 {
+                let bar = self
+                    .create_aggregate_bar("compiling source   [{bar:30.yellow/blue}] {pos}/{len}");
+                bar.set_length(source_total as u64);
+                bar.set_position(0);
+                self.source_builds.replace(Some(bar));
+            }
         } else {
             if binary_total > 0 {
                 eprintln!("Installing {binary_total} binary packages");
@@ -275,7 +280,7 @@ impl SyncUi {
                     ._multi
                     .as_ref()
                     .map_or_else(ProgressBar::hidden, |multi| {
-                        let bar = multi.insert_before(&self.status, ProgressBar::new_spinner());
+                        let bar = multi.add(ProgressBar::new_spinner());
                         bar.set_style(
                             ProgressStyle::with_template("  {spinner} {msg}")
                                 .expect("progress template should parse"),
@@ -285,8 +290,6 @@ impl SyncUi {
                         bar
                     });
                 self.active_installs.borrow_mut().insert(name.clone(), bar);
-                self.status
-                    .set_message(format!("{} {name}@{version}", kind.active_label()));
             } else {
                 eprintln!("{} {name}@{version}", sentence_case(kind.active_label()));
             }
@@ -295,27 +298,33 @@ impl SyncUi {
 
     pub(crate) fn finish_install(&self, name: &str, version: &str, kind: InstallKind) {
         match kind {
-            InstallKind::Binary => self.binary_installs.inc(1),
-            InstallKind::Source => self.source_builds.inc(1),
+            InstallKind::Binary => {
+                self.binary_finished
+                    .set(self.binary_finished.get().saturating_add(1));
+                if let Some(bar) = self.binary_installs.borrow().as_ref() {
+                    bar.inc(1);
+                }
+            }
+            InstallKind::Source => {
+                self.source_finished
+                    .set(self.source_finished.get().saturating_add(1));
+                if let Some(bar) = self.source_builds.borrow().as_ref() {
+                    bar.inc(1);
+                }
+            }
         }
         if let Some(bar) = self.active_installs.borrow_mut().remove(name) {
             bar.finish_and_clear();
         }
 
-        if self.interactive {
-            self.status
-                .set_message(format!("finished {name}@{version} {}", kind.label()));
-        } else {
+        if !self.interactive {
             eprintln!("Finished {name}@{version} {}", kind.label());
         }
     }
 
-    pub(crate) fn fail_install(&self, name: &str, version: &str) {
+    pub(crate) fn fail_install(&self, name: &str, _version: &str) {
         if let Some(bar) = self.active_installs.borrow_mut().remove(name) {
             bar.finish_and_clear();
-        }
-        if self.interactive {
-            self.status.set_message(format!("failed {name}@{version}"));
         }
     }
 
@@ -324,8 +333,20 @@ impl SyncUi {
             for (_, bar) in self.active_installs.borrow_mut().split_off("") {
                 bar.finish_and_clear();
             }
-            self.binary_installs.finish_and_clear();
-            self.source_builds.finish_and_clear();
+            if let Some(bar) = self.binary_installs.borrow_mut().take() {
+                bar.finish_with_message(format!(
+                    "Installed {} {}",
+                    self.binary_finished.get(),
+                    pluralize(self.binary_finished.get(), "binary", "binaries")
+                ));
+            }
+            if let Some(bar) = self.source_builds.borrow_mut().take() {
+                bar.finish_with_message(format!(
+                    "Compiled {} {} from source",
+                    self.source_finished.get(),
+                    pluralize(self.source_finished.get(), "package", "packages")
+                ));
+            }
         }
     }
 
@@ -334,24 +355,14 @@ impl SyncUi {
             return;
         }
 
-        if self.interactive {
-            self.status.set_message("removing extra packages");
-        } else {
+        if !self.interactive {
             eprintln!("Removing {total} extra packages");
         }
     }
 
-    pub(crate) fn finish_removals(&self) {
-        if self.interactive {
-            self.status.set_message("removed extra packages");
-        }
-    }
+    pub(crate) fn finish_removals(&self) {}
 
-    pub(crate) fn finish(&self) {
-        if self.interactive {
-            self.status.finish_and_clear();
-        }
-    }
+    pub(crate) fn finish(&self) {}
 
     fn update_download_message(&self) {
         if !self.interactive {
@@ -363,7 +374,65 @@ impl SyncUi {
             Some(0) | None => format!("{downloaded}"),
             Some(total) => format!("{downloaded}/{}", HumanBytes(total)),
         };
-        self.downloads.set_message(message);
+        if let Some(bar) = self.downloads.borrow().as_ref() {
+            bar.set_message(message);
+        }
+    }
+
+    fn create_aggregate_bar(&self, template: &str) -> ProgressBar {
+        self._multi
+            .as_ref()
+            .map_or_else(ProgressBar::hidden, |multi| {
+                let bar = multi.add(ProgressBar::new(0));
+                bar.set_style(
+                    ProgressStyle::with_template(template)
+                        .expect("progress template should parse")
+                        .progress_chars("##-"),
+                );
+                bar
+            })
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct SystemDepsUi {
+    interactive: bool,
+    bar: ProgressBar,
+}
+
+impl SystemDepsUi {
+    pub(crate) fn start() -> Self {
+        let interactive = std::io::stderr().is_terminal();
+        let bar = if interactive {
+            let bar = ProgressBar::new_spinner();
+            bar.set_style(
+                ProgressStyle::with_template("{spinner} {msg}")
+                    .expect("progress template should parse"),
+            );
+            bar.enable_steady_tick(std::time::Duration::from_millis(100));
+            bar.set_message("installing system dependencies");
+            bar
+        } else {
+            eprintln!("Installing system dependencies...");
+            ProgressBar::hidden()
+        };
+
+        Self { interactive, bar }
+    }
+
+    pub(crate) fn finish(self) {
+        if self.interactive {
+            self.bar
+                .finish_with_message("Installed system dependencies".to_string());
+        } else {
+            eprintln!("Installed system dependencies");
+        }
+    }
+
+    pub(crate) fn fail(self) {
+        if self.interactive {
+            self.bar.finish_and_clear();
+        }
     }
 }
 
@@ -380,6 +449,10 @@ fn sentence_case(value: &str) -> String {
         return String::new();
     };
     first.to_uppercase().chain(chars).collect()
+}
+
+fn pluralize<'a>(count: u64, singular: &'a str, plural: &'a str) -> &'a str {
+    if count == 1 { singular } else { plural }
 }
 
 #[derive(Debug)]

--- a/tests/status.rs
+++ b/tests/status.rs
@@ -31,7 +31,7 @@ fn runs_rpx_status_for_lockfile_drift() {
     assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
 
     let seed_lockfile = format!(
-        "mkdir -p {project_path} && cd {project_path} && cat > rpx.lock <<'EOF'\n{{\n  \"version\": 2,\n  \"registry\": \"https://api.rrepo.org\",\n  \"roots\": [],\n  \"packages\": {{}}\n}}\nEOF"
+        "mkdir -p {project_path} && cd {project_path} && cat > rpx.lock <<'EOF'\n{{\n  \"version\": 3,\n  \"registry\": \"https://api.rrepo.org\",\n  \"roots\": [],\n  \"packages\": {{}}\n}}\nEOF"
     );
     let (exit_code, stdout, stderr) = run_shell_command(&container, &seed_lockfile);
     assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -165,7 +165,7 @@ fn runs_rpx_sync_restores_locked_versions() {
     assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
 
     let seed_lockfile = format!(
-        "mkdir -p {project_path} && cd {project_path} && cat > rpx.lock <<'EOF'\n{{\n  \"version\": 2,\n  \"registry\": \"https://api.rrepo.org\",\n  \"roots\": [\n    {{\n      \"package\": \"digest\",\n      \"constraint\": \"*\"\n    }}\n  ],\n  \"packages\": {{\n    \"digest\": {{\n      \"package\": \"digest\",\n      \"version\": \"0.6.37\",\n      \"source\": \"registry\",\n      \"source_url\": \"https://api.rrepo.org/packages/digest/versions/0.6.37/source\"\n    }}\n  }}\n}}\nEOF"
+        "mkdir -p {project_path} && cd {project_path} && cat > rpx.lock <<'EOF'\n{{\n  \"version\": 3,\n  \"registry\": \"https://api.rrepo.org\",\n  \"roots\": [\n    {{\n      \"package\": \"digest\",\n      \"constraint\": \"*\"\n    }}\n  ],\n  \"packages\": {{\n    \"digest\": {{\n      \"package\": \"digest\",\n      \"version\": \"0.6.37\",\n      \"source\": \"registry\",\n      \"source_url\": \"https://api.rrepo.org/packages/digest/versions/0.6.37/source\"\n    }}\n  }}\n}}\nEOF"
     );
     let (exit_code, stdout, stderr) = run_shell_command(&container, &seed_lockfile);
     assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");


### PR DESCRIPTION
This pull request introduces support for tracking and managing system requirements for R packages, updates the lockfile format, and improves the user interface for progress reporting during package synchronization. The main changes are grouped below:

**System Requirements Tracking:**

* Added new fields to the lockfile (`Lockfile`, `LockedSystemRequirements`) to record system requirements for R packages, incrementing the lockfile version to 3. (`src/lockfile.rs`, `Cargo.toml`) [[1]](diffhunk://#diff-0b742865f84d423347a6e004c290a3882ed8ada12f9f78a24877ea90a99ed72fL5-R14) [[2]](diffhunk://#diff-0b742865f84d423347a6e004c290a3882ed8ada12f9f78a24877ea90a99ed72fR27-R36) [[3]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3)
* Updated the resolver to extract and propagate `SystemRequirements` from package metadata and descriptions. (`src/resolver.rs`, `src/description.rs`) [[1]](diffhunk://#diff-cbb50fec325653fd70e0bcb9f84525b95fc31231915716c70457695941f3951dR115) [[2]](diffhunk://#diff-cbb50fec325653fd70e0bcb9f84525b95fc31231915716c70457695941f3951dR137) [[3]](diffhunk://#diff-cbb50fec325653fd70e0bcb9f84525b95fc31231915716c70457695941f3951dR281) [[4]](diffhunk://#diff-cbb50fec325653fd70e0bcb9f84525b95fc31231915716c70457695941f3951dR304) [[5]](diffhunk://#diff-71fe06bb227f438db6b7f38478bb5e1bc2e8e8b8a09d117ca6976f10c4d5433bR109-R116)

**CLI and User Interface Improvements:**

* Enhanced the `Sync` command to support new flags for installing system dependencies: `--install-system` and `--install-only-system`. (`src/cli.rs`)
* Refactored the progress bar logic in `SyncUi` to improve reporting for downloads, restores, and installs, including more informative messages and better handling of interactive/non-interactive modes. (`src/ui.rs`) [[1]](diffhunk://#diff-acf9ca25b7b2d13e11c1035ebbda4140466603739b73a371b67a9a267d0ce626L38-R48) [[2]](diffhunk://#diff-acf9ca25b7b2d13e11c1035ebbda4140466603739b73a371b67a9a267d0ce626L55-R87) [[3]](diffhunk://#diff-acf9ca25b7b2d13e11c1035ebbda4140466603739b73a371b67a9a267d0ce626R97-L156) [[4]](diffhunk://#diff-acf9ca25b7b2d13e11c1035ebbda4140466603739b73a371b67a9a267d0ce626L172-R165) [[5]](diffhunk://#diff-acf9ca25b7b2d13e11c1035ebbda4140466603739b73a371b67a9a267d0ce626L186-L187) [[6]](diffhunk://#diff-acf9ca25b7b2d13e11c1035ebbda4140466603739b73a371b67a9a267d0ce626L216-R223) [[7]](diffhunk://#diff-acf9ca25b7b2d13e11c1035ebbda4140466603739b73a371b67a9a267d0ce626L247-R262) [[8]](diffhunk://#diff-acf9ca25b7b2d13e11c1035ebbda4140466603739b73a371b67a9a267d0ce626L278-R283) [[9]](diffhunk://#diff-acf9ca25b7b2d13e11c1035ebbda4140466603739b73a371b67a9a267d0ce626L288-L289)