### PR TITLE
Enhance CRAN-like repository support and optimize fetching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2029,6 +2029,7 @@ dependencies = [
  "tar",
  "testcontainers",
  "thiserror",
+ "tokio",
  "tracing",
  "tracing-indicatif",
  "tracing-subscriber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2009,7 +2009,7 @@ dependencies = [
 
 [[package]]
 name = "rpx"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "clap",
  "deb822-fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpx"
-version = "1.2.1"
+version = "1.3.0"
 edition = "2024"
 description = "Rust CLI for managing R package project dependencies"
 repository = "https://github.com/scalerail-solutions/rpx"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tar = "0.4.44"
 thiserror = "2.0.17"
+tokio = { version = "1.51.1", features = ["rt-multi-thread"] }
 tracing = "0.1.41"
 tracing-indicatif = "0.3.13"
 tracing-subscriber = "0.3.19"

--- a/README.md
+++ b/README.md
@@ -119,17 +119,26 @@ If local package state becomes confusing, remove the project library and caches:
 rpx clean
 ```
 
-## Additional Repositories
+## Repository Management
 
-The public rrepo registry is configured by default. Projects can add private or internal rrepo-compatible repositories:
+The public rrepo registry is enabled by default. It is the preferred primary source because it exposes package metadata through a low-latency API, which keeps dependency resolution fast.
+
+Projects can add additional repositories. `rpx repo add` detects whether a repository exposes the rrepo API or a CRAN-like `src/contrib/PACKAGES` index:
 
 ```bash
 rpx repo add https://<org-slug>.rrepo.dev/<repo-slug>
+rpx repo add https://packagemanager.posit.co/cran/latest
 rpx repo list
-rpx repo remove https://<org-slug>.rrepo.dev/<repo-slug>
+rpx repo remove https://packagemanager.posit.co/cran/latest
 ```
 
-Additional repositories must expose the rrepo package metadata API. `rpx repo add` does not support CRAN-like repositories, `PACKAGES` indexes, or CRAN-style Posit Package Manager URLs.
+A useful setup is to keep the default rrepo registry enabled and add Posit Package Manager's latest CRAN repository as a fallback for binary artifacts:
+
+```bash
+rpx repo add https://packagemanager.posit.co/cran/latest
+```
+
+During locking, `rpx` merges versions across enabled repositories. Existing locked versions are preferred when they are still available from enabled repositories. If the same version is available from multiple repositories, the earlier repository wins for the locked source URL.
 
 When a repository requires authentication, `rpx` prompts for an API key and stores it in the operating system keyring for that repository URL.
 
@@ -139,13 +148,16 @@ You can override the default public registry root with `RPX_REGISTRY_BASE_URL`:
 RPX_REGISTRY_BASE_URL=https://example.rrepo.dev/cran rpx lock
 ```
 
+To lock without the default public registry, use `rpx lock --no-default-repo`. The default-repo choice is recorded in `rpx.lock`; use `--default-repo` to enable it again when regenerating the lockfile.
+
 ## How It Works
 
 - `DESCRIPTION` is the dependency manifest.
 - `rpx.lock` records the resolved package set, package sources, and R runtime metadata.
-- `rpx lock` resolves dependencies and writes `rpx.lock`; it does not install packages.
+- `rpx lock` resolves dependencies from enabled repositories and writes `rpx.lock`; it does not install packages.
+- `rpx` prefers existing locked versions when they are still available from enabled repositories.
 - `rpx sync` installs exactly what `rpx.lock` records into the project library.
-- `rpx sync` uses Windows and macOS binary artifacts when available, then falls back to source artifacts.
+- `rpx sync` tries Windows and macOS binary artifacts from enabled repositories when available, then falls back to the locked source artifact.
 - `rpx run` sets the R library path for the command it runs.
 
 ## Local Development

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,6 +26,20 @@ pub enum Commands {
     )]
     Add {
         #[arg(
+            long,
+            conflicts_with = "no_default_repo",
+            help = "Use the built-in default repository during resolution"
+        )]
+        default_repo: bool,
+
+        #[arg(
+            long,
+            conflicts_with = "default_repo",
+            help = "Do not use the built-in default repository during resolution"
+        )]
+        no_default_repo: bool,
+
+        #[arg(
             help = "Package names to add to the project's dependencies",
             value_name = "PACKAGE",
             required = true
@@ -38,6 +52,20 @@ pub enum Commands {
         long_about = "Remove one or more packages from this project. The packages are removed from DESCRIPTION, the project library is synced, and rpx regenerates rpx.lock."
     )]
     Remove {
+        #[arg(
+            long,
+            conflicts_with = "no_default_repo",
+            help = "Use the built-in default repository during resolution"
+        )]
+        default_repo: bool,
+
+        #[arg(
+            long,
+            conflicts_with = "default_repo",
+            help = "Do not use the built-in default repository during resolution"
+        )]
+        no_default_repo: bool,
+
         #[arg(
             help = "Package names to remove from the project's dependencies",
             value_name = "PACKAGE",
@@ -65,7 +93,21 @@ pub enum Commands {
         about = "Resolve project dependencies",
         long_about = "Resolve project dependencies from DESCRIPTION and write the resolved package set to rpx.lock without installing packages."
     )]
-    Lock,
+    Lock {
+        #[arg(
+            long,
+            conflicts_with = "no_default_repo",
+            help = "Use the built-in default repository during resolution"
+        )]
+        default_repo: bool,
+
+        #[arg(
+            long,
+            conflicts_with = "default_repo",
+            help = "Do not use the built-in default repository during resolution"
+        )]
+        no_default_repo: bool,
+    },
 
     #[command(
         about = "Check project dependency state",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -553,10 +553,12 @@ fn classify_repository_source(url: &str) -> Result<RepositorySource, String> {
             match cran_like_set.fetch_repository_packages(&cran_like) {
                 Ok(_) => {
                     let archive_support = detect_cran_like_archive_support(&cran_like)?;
-                    Ok(RepositorySource::cran_like_with_archive_support(
-                        url,
-                        archive_support,
-                    ))
+                    Ok(match archive_support {
+                        Some(archive_support) => {
+                            RepositorySource::cran_like_with_archive_support(url, archive_support)
+                        }
+                        None => RepositorySource::cran_like(url),
+                    })
                 }
                 Err(cran_error) => Err(format!(
                     "not an rrepo API ({rrepo_error}) or CRAN-like repository ({cran_error})"
@@ -2095,6 +2097,11 @@ fn r_minor_version(version: &str) -> Option<String> {
     Some(format!("{}.{}", parts.next()?, parts.next()?))
 }
 
+fn should_fallback_to_source(error: &str) -> bool {
+    error.contains("artifact download failed (404 ")
+        || error.contains("artifact download failed (502 ")
+}
+
 fn collect_pending_installs(
     lockfile: &Lockfile,
     installed: &BTreeMap<String, r::InstalledPackage>,
@@ -2206,6 +2213,15 @@ fn download_artifacts_in_parallel(
                     package.install_kind,
                     package.install_type.clone(),
                 );
+                let mut source_fallback_allowed = result
+                    .as_ref()
+                    .err()
+                    .is_none_or(|error| should_fallback_to_source(error));
+                let mut first_non_fallback_error = result
+                    .as_ref()
+                    .err()
+                    .filter(|error| !should_fallback_to_source(error))
+                    .cloned();
 
                 for artifact in &package.binary_fallback_artifacts {
                     if result.is_ok() {
@@ -2219,9 +2235,20 @@ fn download_artifacts_in_parallel(
                         InstallKind::Binary,
                         package.install_type.clone(),
                     );
+                    if let Err(error) = &result
+                        && !should_fallback_to_source(error)
+                    {
+                        source_fallback_allowed = false;
+                        if first_non_fallback_error.is_none() {
+                            first_non_fallback_error = Some(error.clone());
+                        }
+                    }
                 }
 
                 let result = result.or_else(|error| {
+                    if !source_fallback_allowed {
+                        return Err(first_non_fallback_error.unwrap_or(error));
+                    }
                     let Some(fallback) = &package.fallback_artifact else {
                         return Err(error);
                     };
@@ -2655,7 +2682,8 @@ mod tests {
         cran_like_binary_artifact_request, default_registry_base_url, locked_install_order,
         lockfile_from_resolution, persisted_constraints, preferred_artifact,
         preferred_locked_versions, r_minor_version, repository_sources_from_project,
-        resolve_use_default_repository, semver_add_constraint, validate_lockfile_compatibility,
+        resolve_use_default_repository, semver_add_constraint, should_fallback_to_source,
+        validate_lockfile_compatibility,
     };
     use crate::description::{ProjectDescription, RDescription};
     use crate::{
@@ -3462,6 +3490,22 @@ mod tests {
         assert_eq!(r_minor_version("4.5.2"), Some("4.5".to_string()));
         assert_eq!(r_minor_version("4.4"), Some("4.4".to_string()));
         assert_eq!(r_minor_version("4"), None);
+    }
+
+    #[test]
+    fn source_fallback_statuses_are_limited_to_missing_or_upstream_binary_errors() {
+        assert!(should_fallback_to_source(
+            "artifact download failed (404 Not Found): missing"
+        ));
+        assert!(should_fallback_to_source(
+            "artifact download failed (502 Bad Gateway): upstream failed"
+        ));
+        assert!(!should_fallback_to_source(
+            "artifact download failed (403 Forbidden): forbidden"
+        ));
+        assert!(!should_fallback_to_source(
+            "failed to read binary artifact: corrupt body"
+        ));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ mod lockfile;
 mod output;
 mod project;
 mod r;
+mod r_version;
 mod registry;
 mod repository;
 mod resolver;
@@ -26,8 +27,9 @@ mod ui;
 use cli::{Cli, Commands, RepoCommands};
 use description::{DescriptionExt, init_description, read_description, write_description};
 use lockfile::{
-    LOCKFILE_REVISION, LOCKFILE_VERSION, LockedR, LockedSystemRequirements, Lockfile,
-    read_lockfile, read_lockfile_optional, write_lockfile,
+    LOCKFILE_REVISION, LOCKFILE_VERSION, LockedCranArchiveSupport, LockedR, LockedRepository,
+    LockedRepositoryKind, LockedSystemRequirements, Lockfile, read_lockfile,
+    read_lockfile_optional, write_lockfile,
 };
 use output::{blank_note_line, blank_status_line, note, prompt, status, warning};
 use project::{
@@ -44,8 +46,9 @@ use registry::{
     ResolutionRoot,
 };
 use repository::{
-    RepositoryKind, RepositorySet, RepositorySource, cran_like_source_from_package_url,
-    detect_cran_like_archive_support, normalize_repository_url, repository_source_from_package_url,
+    CranArchiveSupport, RepositoryKind, RepositorySet, RepositorySource,
+    cran_like_source_from_package_url, detect_cran_like_archive_support, normalize_repository_url,
+    repository_source_from_package_url,
 };
 use resolver::{ResolvedPackage, is_base_package, resolve_from_registry};
 use sysreqs::{
@@ -442,7 +445,7 @@ fn cmd_add(packages: &[String], default_repo: bool, no_default_repo: bool) -> Rp
     let mut lockfile = read_project_lockfile_optional()?;
     let use_default_repository =
         resolve_use_default_repository(lockfile.as_ref(), default_repo, no_default_repo);
-    let repositories = configured_repositories(&project, use_default_repository)
+    let repositories = configured_repositories(&project, use_default_repository, lockfile.as_ref())
         .map_err(|details| LockError::ResolveFailed { details })?;
     let mut new_packages = Vec::new();
 
@@ -481,6 +484,7 @@ fn cmd_add(packages: &[String], default_repo: bool, no_default_repo: bool) -> Rp
             use_default_repository,
             &resolved_addition.resolved,
             &sysreq_db,
+            repositories.sources(),
             None,
         ));
     }
@@ -562,6 +566,38 @@ fn classify_repository_source(url: &str) -> Result<RepositorySource, String> {
     }
 }
 
+fn repository_source_from_lockfile(lockfile: &Lockfile, url: &str) -> Option<RepositorySource> {
+    let normalized = normalize_repository_url(url);
+    lockfile
+        .repositories
+        .iter()
+        .find(|repository| repository.url == normalized)
+        .map(repository_source_from_locked)
+}
+
+fn repository_source_from_locked(repository: &LockedRepository) -> RepositorySource {
+    match repository.kind {
+        LockedRepositoryKind::Rrepo => RepositorySource::new(&repository.url),
+        LockedRepositoryKind::CranLike => match repository.cran_archive_support {
+            Some(support) => RepositorySource::cran_like_with_archive_support(
+                &repository.url,
+                cran_archive_support_from_locked(support),
+            ),
+            None => RepositorySource::cran_like(&repository.url),
+        },
+    }
+}
+
+fn repository_kind_label(lockfile: Option<&Lockfile>, url: &str) -> &'static str {
+    match lockfile.and_then(|lockfile| repository_source_from_lockfile(lockfile, url)) {
+        Some(source) => match source.kind() {
+            RepositoryKind::Rrepo => "rrepo",
+            RepositoryKind::CranLike => "CRAN-like",
+        },
+        None => "unknown",
+    }
+}
+
 fn cmd_repo_remove(url: &str, remove_credential: bool) -> RpxResult<()> {
     let mut project = read_project_description()?;
     let source = RepositorySource::new(url);
@@ -592,6 +628,7 @@ fn cmd_repo_remove(url: &str, remove_credential: bool) -> RpxResult<()> {
 
 fn cmd_repo_list() -> RpxResult<()> {
     let project = read_project_description()?;
+    let lockfile = read_project_lockfile_optional()?;
 
     if project.additional_repositories.is_empty() {
         status("No additional repositories configured");
@@ -599,21 +636,18 @@ fn cmd_repo_list() -> RpxResult<()> {
     }
 
     for url in &project.additional_repositories {
-        let source = classify_repository_source(url).map_err(|details| RepoError::Add {
-            url: normalize_repository_url(url),
-            details,
-        })?;
+        let source = lockfile
+            .as_ref()
+            .and_then(|lockfile| repository_source_from_lockfile(lockfile, url))
+            .unwrap_or_else(|| RepositorySource::new(url));
         let repositories = RepositorySet::new(vec![source.clone()]);
         let credential = repositories
             .has_stored_credential(&source)
             .map_err(|details| RepoError::CredentialInspect { details })?;
         status(format_args!(
             "{} [{}; {}]",
-            source.base_url(),
-            match source.kind() {
-                RepositoryKind::Rrepo => "rrepo",
-                RepositoryKind::CranLike => "CRAN-like",
-            },
+            normalize_repository_url(url),
+            repository_kind_label(lockfile.as_ref(), url),
             if credential {
                 "credential stored"
             } else {
@@ -1114,8 +1148,9 @@ fn lock_from_description(default_repo: bool, no_default_repo: bool) -> RpxResult
     let existing_lockfile = read_project_lockfile_optional()?;
     let use_default_repository =
         resolve_use_default_repository(existing_lockfile.as_ref(), default_repo, no_default_repo);
-    let repositories = configured_repositories(&project, use_default_repository)
-        .map_err(|details| LockError::ResolveFailed { details })?;
+    let repositories =
+        configured_repositories(&project, use_default_repository, existing_lockfile.as_ref())
+            .map_err(|details| LockError::ResolveFailed { details })?;
     if let Some(lockfile) = &existing_lockfile
         && lockfile.version > LOCKFILE_VERSION
     {
@@ -1130,6 +1165,7 @@ fn lock_from_description(default_repo: bool, no_default_repo: bool) -> RpxResult
             use_default_repository,
             &[],
             &sysreq_db,
+            repositories.sources(),
             None,
         );
         let changed = existing_lockfile.as_ref() != Some(&lockfile);
@@ -1157,6 +1193,7 @@ fn lock_from_description(default_repo: bool, no_default_repo: bool) -> RpxResult
         use_default_repository,
         &resolved,
         &sysreq_db,
+        repositories.sources(),
         None,
     );
     let changed = existing_lockfile.as_ref() != Some(&lockfile);
@@ -1378,22 +1415,32 @@ fn default_registry_base_url() -> String {
 fn configured_repositories(
     project: &description::ProjectDescription,
     use_default_repository: bool,
+    lockfile: Option<&Lockfile>,
 ) -> Result<RepositorySet, String> {
     Ok(RepositorySet::new(repository_sources_from_project(
         project,
         use_default_repository,
+        lockfile,
     )?))
 }
 
 fn repository_sources_from_project(
     project: &description::ProjectDescription,
     use_default_repository: bool,
+    lockfile: Option<&Lockfile>,
 ) -> Result<Vec<RepositorySource>, String> {
     let mut sources = Vec::new();
     if use_default_repository {
         sources.push(RepositorySource::new(default_registry_base_url()));
     }
     for url in &project.additional_repositories {
+        if let Some(source) =
+            lockfile.and_then(|lockfile| repository_source_from_lockfile(lockfile, url))
+        {
+            sources.push(source);
+            continue;
+        }
+
         sources.push(classify_repository_source(url).map_err(|details| {
             format!(
                 "failed to classify configured repository {}: {details}",
@@ -1408,7 +1455,8 @@ fn repositories_for_sync(
     project: &description::ProjectDescription,
     lockfile: &Lockfile,
 ) -> Result<RepositorySet, String> {
-    let mut sources = repository_sources_from_project(project, lockfile.use_default_repository)?;
+    let mut sources =
+        repository_sources_from_project(project, lockfile.use_default_repository, Some(lockfile))?;
     sources.extend(lockfile.packages.values().filter_map(|package| {
         let source_url = package.source_url.as_deref()?;
         repository_source_from_package_url(source_url)
@@ -1442,6 +1490,7 @@ fn lockfile_from_resolution(
     use_default_repository: bool,
     resolved: &[ResolvedPackage],
     sysreq_db: &sysreqs::SysreqDbSnapshot,
+    repositories: &[RepositorySource],
     r_version: Option<&str>,
 ) -> Lockfile {
     let required_base_packages = locked_base_packages(&roots, resolved);
@@ -1451,6 +1500,7 @@ fn lockfile_from_resolution(
         revision: LOCKFILE_REVISION,
         registry: registry.to_string(),
         use_default_repository,
+        repositories: locked_repositories(repositories),
         r: LockedR {
             version: r_version
                 .map(ToString::to_string)
@@ -1489,6 +1539,40 @@ fn lockfile_from_resolution(
                 )
             })
             .collect(),
+    }
+}
+
+fn locked_repositories(repositories: &[RepositorySource]) -> Vec<LockedRepository> {
+    repositories
+        .iter()
+        .map(|source| LockedRepository {
+            url: source.base_url().to_string(),
+            kind: locked_repository_kind(source.kind()),
+            cran_archive_support: source
+                .cran_archive_support()
+                .map(locked_cran_archive_support),
+        })
+        .collect()
+}
+
+fn locked_repository_kind(kind: RepositoryKind) -> LockedRepositoryKind {
+    match kind {
+        RepositoryKind::Rrepo => LockedRepositoryKind::Rrepo,
+        RepositoryKind::CranLike => LockedRepositoryKind::CranLike,
+    }
+}
+
+fn locked_cran_archive_support(support: CranArchiveSupport) -> LockedCranArchiveSupport {
+    match support {
+        CranArchiveSupport::Available => LockedCranArchiveSupport::Available,
+        CranArchiveSupport::Unavailable => LockedCranArchiveSupport::Unavailable,
+    }
+}
+
+fn cran_archive_support_from_locked(support: LockedCranArchiveSupport) -> CranArchiveSupport {
+    match support {
+        LockedCranArchiveSupport::Available => CranArchiveSupport::Available,
+        LockedCranArchiveSupport::Unavailable => CranArchiveSupport::Unavailable,
     }
 }
 
@@ -2011,11 +2095,6 @@ fn r_minor_version(version: &str) -> Option<String> {
     Some(format!("{}.{}", parts.next()?, parts.next()?))
 }
 
-fn should_fallback_to_source(error: &str) -> bool {
-    error.contains("artifact download failed (404 ")
-        || error.contains("artifact download failed (502 ")
-}
-
 fn collect_pending_installs(
     lockfile: &Lockfile,
     installed: &BTreeMap<String, r::InstalledPackage>,
@@ -2132,12 +2211,6 @@ fn download_artifacts_in_parallel(
                     if result.is_ok() {
                         break;
                     }
-                    let Err(error) = &result else {
-                        continue;
-                    };
-                    if !should_fallback_to_source(error) {
-                        break;
-                    }
                     result = download_artifact_candidate(
                         &repositories,
                         &sender,
@@ -2152,9 +2225,6 @@ fn download_artifacts_in_parallel(
                     let Some(fallback) = &package.fallback_artifact else {
                         return Err(error);
                     };
-                    if !should_fallback_to_source(&error) {
-                        return Err(error);
-                    }
                     let _ = sender.send(DownloadEvent::FallbackToSource {
                         name: package.name.clone(),
                         version: package.version.clone(),
@@ -2585,8 +2655,7 @@ mod tests {
         cran_like_binary_artifact_request, default_registry_base_url, locked_install_order,
         lockfile_from_resolution, persisted_constraints, preferred_artifact,
         preferred_locked_versions, r_minor_version, repository_sources_from_project,
-        resolve_use_default_repository, semver_add_constraint, should_fallback_to_source,
-        validate_lockfile_compatibility,
+        resolve_use_default_repository, semver_add_constraint, validate_lockfile_compatibility,
     };
     use crate::description::{ProjectDescription, RDescription};
     use crate::{
@@ -2688,6 +2757,7 @@ mod tests {
                 },
             ],
             &empty_sysreq_db(),
+            &[],
             Some("4.5.2"),
         );
 
@@ -2755,6 +2825,7 @@ mod tests {
             revision: LOCKFILE_REVISION,
             registry: "https://api.rrepo.org".to_string(),
             use_default_repository: false,
+            repositories: vec![],
             r: LockedR::default(),
             sysreqs: LockedSystemRequirements::default(),
             roots: vec![],
@@ -2784,7 +2855,7 @@ mod tests {
         };
 
         let sources =
-            repository_sources_from_project(&project, false).expect("sources should build");
+            repository_sources_from_project(&project, false, None).expect("sources should build");
 
         assert!(sources.is_empty());
     }
@@ -2877,7 +2948,7 @@ mod tests {
         };
 
         let sources =
-            repository_sources_from_project(&project, false).expect("sources should build");
+            repository_sources_from_project(&project, false, None).expect("sources should build");
 
         assert_eq!(sources.len(), 1);
         assert_eq!(sources[0].kind(), RepositoryKind::CranLike);
@@ -2955,6 +3026,7 @@ mod tests {
             true,
             &[],
             &empty_sysreq_db(),
+            &[],
             Some("4.5.2"),
         );
 
@@ -2999,6 +3071,7 @@ mod tests {
             revision: LOCKFILE_REVISION,
             registry: "https://api.rrepo.org".to_string(),
             use_default_repository: true,
+            repositories: vec![],
             r: LockedR::default(),
             sysreqs: LockedSystemRequirements::default(),
             roots: vec![],
@@ -3056,6 +3129,7 @@ mod tests {
             revision: LOCKFILE_REVISION + 1,
             registry: "https://api.rrepo.org".to_string(),
             use_default_repository: true,
+            repositories: vec![],
             r: LockedR::default(),
             sysreqs: LockedSystemRequirements::default(),
             roots: vec![],
@@ -3079,6 +3153,7 @@ mod tests {
             revision: LOCKFILE_REVISION,
             registry: "https://api.rrepo.org".to_string(),
             use_default_repository: true,
+            repositories: vec![],
             r: LockedR::default(),
             sysreqs: LockedSystemRequirements::default(),
             roots: vec![],
@@ -3152,6 +3227,7 @@ mod tests {
             revision: LOCKFILE_REVISION,
             registry: "https://api.rrepo.org".to_string(),
             use_default_repository: true,
+            repositories: vec![],
             r: LockedR::default(),
             sysreqs: LockedSystemRequirements::default(),
             roots: vec![],
@@ -3386,19 +3462,6 @@ mod tests {
         assert_eq!(r_minor_version("4.5.2"), Some("4.5".to_string()));
         assert_eq!(r_minor_version("4.4"), Some("4.4".to_string()));
         assert_eq!(r_minor_version("4"), None);
-    }
-
-    #[test]
-    fn fallback_statuses_are_limited_to_missing_or_upstream_binary_errors() {
-        assert!(should_fallback_to_source(
-            "artifact download failed (404 Not Found): missing"
-        ));
-        assert!(should_fallback_to_source(
-            "artifact download failed (502 Bad Gateway): upstream failed"
-        ));
-        assert!(!should_fallback_to_source(
-            "artifact download failed (500 Internal Server Error): nope"
-        ));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -481,6 +481,7 @@ fn cmd_add(packages: &[String], default_repo: bool, no_default_repo: bool) -> Rp
             use_default_repository,
             &resolved_addition.resolved,
             &sysreq_db,
+            None,
         ));
     }
 
@@ -1123,8 +1124,14 @@ fn lock_from_description(default_repo: bool, no_default_repo: bool) -> RpxResult
     let sysreq_db = load_sysreq_snapshot_for_lock(existing_lockfile.as_ref());
 
     if roots.is_empty() {
-        let lockfile =
-            lockfile_from_resolution(vec![], &registry, use_default_repository, &[], &sysreq_db);
+        let lockfile = lockfile_from_resolution(
+            vec![],
+            &registry,
+            use_default_repository,
+            &[],
+            &sysreq_db,
+            None,
+        );
         let changed = existing_lockfile.as_ref() != Some(&lockfile);
         write_project_lockfile(lockfile)?;
         return Ok(LockOutcome { changed });
@@ -1150,6 +1157,7 @@ fn lock_from_description(default_repo: bool, no_default_repo: bool) -> RpxResult
         use_default_repository,
         &resolved,
         &sysreq_db,
+        None,
     );
     let changed = existing_lockfile.as_ref() != Some(&lockfile);
     write_project_lockfile(lockfile)?;
@@ -1434,6 +1442,7 @@ fn lockfile_from_resolution(
     use_default_repository: bool,
     resolved: &[ResolvedPackage],
     sysreq_db: &sysreqs::SysreqDbSnapshot,
+    r_version: Option<&str>,
 ) -> Lockfile {
     let required_base_packages = locked_base_packages(&roots, resolved);
     let sysreqs = locked_system_requirements(resolved, sysreq_db);
@@ -1443,7 +1452,9 @@ fn lockfile_from_resolution(
         registry: registry.to_string(),
         use_default_repository,
         r: LockedR {
-            version: runtime_info().version,
+            version: r_version
+                .map(ToString::to_string)
+                .unwrap_or_else(|| runtime_info().version),
             base_packages: required_base_packages,
         },
         sysreqs,
@@ -2677,6 +2688,7 @@ mod tests {
                 },
             ],
             &empty_sysreq_db(),
+            Some("4.5.2"),
         );
 
         assert_eq!(lockfile.registry, "https://api.rrepo.org");
@@ -2943,6 +2955,7 @@ mod tests {
             true,
             &[],
             &empty_sysreq_db(),
+            Some("4.5.2"),
         );
 
         assert_eq!(lockfile.r.base_packages, vec!["grid"]);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1023,7 +1023,7 @@ fn add_resolution_roots(
 }
 
 fn preferred_locked_versions(
-    description: &description::RDescription,
+    _description: &description::RDescription,
     lockfile: Option<&Lockfile>,
     excluded_packages: &BTreeMap<String, String>,
 ) -> Result<BTreeMap<String, String>, String> {
@@ -1031,25 +1031,12 @@ fn preferred_locked_versions(
         return Ok(BTreeMap::new());
     };
 
-    let mut preferred_versions: BTreeMap<String, String> = description
-        .requirements()
-        .into_iter()
-        .filter(|name| !excluded_packages.contains_key(name))
-        .filter_map(|name| {
-            lockfile
-                .packages
-                .get(&name)
-                .map(|package| (name, package.version.clone()))
-        })
-        .collect();
-
-    for package in excluded_packages.keys() {
-        if let Some(locked_package) = lockfile.packages.get(package) {
-            preferred_versions.insert(package.clone(), locked_package.version.clone());
-        }
-    }
-
-    Ok(preferred_versions)
+    Ok(lockfile
+        .packages
+        .iter()
+        .filter(|(name, _)| !excluded_packages.contains_key(name.as_str()))
+        .map(|(name, package)| (name.clone(), package.version.clone()))
+        .collect())
 }
 
 fn semver_add_constraint(version: &str) -> Result<String, String> {
@@ -1137,8 +1124,14 @@ fn lock_from_description(default_repo: bool, no_default_repo: bool) -> RpxResult
         return Ok(LockOutcome { changed });
     }
 
+    let preferred_versions = preferred_locked_versions(
+        &project.description,
+        existing_lockfile.as_ref(),
+        &BTreeMap::new(),
+    )
+    .map_err(|details| LockError::ResolveFailed { details })?;
     let resolved =
-        resolve_from_registry(&repositories, &roots, &BTreeMap::new()).map_err(|details| {
+        resolve_from_registry(&repositories, &roots, &preferred_versions).map_err(|details| {
             LockError::ResolveFailed {
                 details: details.to_string(),
             }
@@ -2573,9 +2566,10 @@ mod tests {
         LockfileCompatibilityError, add_resolution_roots, binary_artifact_request,
         classify_repository_source, compiled_cache_key, constraints_from_resolved_roots,
         cran_like_binary_artifact_request, default_registry_base_url, locked_install_order,
-        lockfile_from_resolution, persisted_constraints, preferred_artifact, r_minor_version,
-        repository_sources_from_project, resolve_use_default_repository, semver_add_constraint,
-        should_fallback_to_source, validate_lockfile_compatibility,
+        lockfile_from_resolution, persisted_constraints, preferred_artifact,
+        preferred_locked_versions, r_minor_version, repository_sources_from_project,
+        resolve_use_default_repository, semver_add_constraint, should_fallback_to_source,
+        validate_lockfile_compatibility,
     };
     use crate::description::{ProjectDescription, RDescription};
     use crate::{
@@ -2954,6 +2948,66 @@ mod tests {
                     constraint: ">= 0.6.37, < 1.0.0".to_string(),
                 },
             ]
+        );
+    }
+
+    #[test]
+    fn prefers_all_existing_locked_versions_except_new_additions() {
+        let description =
+            RDescription::from_str("Package: test\nVersion: 0.1.0\nImports: direct\n")
+                .expect("description should parse");
+        let lockfile = Lockfile {
+            version: LOCKFILE_VERSION,
+            revision: LOCKFILE_REVISION,
+            registry: "https://api.rrepo.org".to_string(),
+            use_default_repository: true,
+            r: LockedR::default(),
+            sysreqs: LockedSystemRequirements::default(),
+            roots: vec![],
+            packages: BTreeMap::from([
+                (
+                    "direct".to_string(),
+                    LockedPackage {
+                        package: "direct".to_string(),
+                        version: "1.0.0".to_string(),
+                        source: Some("registry".to_string()),
+                        source_url: None,
+                        dependencies: vec![],
+                    },
+                ),
+                (
+                    "transitive".to_string(),
+                    LockedPackage {
+                        package: "transitive".to_string(),
+                        version: "2.0.0".to_string(),
+                        source: Some("registry".to_string()),
+                        source_url: None,
+                        dependencies: vec![],
+                    },
+                ),
+                (
+                    "newpkg".to_string(),
+                    LockedPackage {
+                        package: "newpkg".to_string(),
+                        version: "3.0.0".to_string(),
+                        source: Some("registry".to_string()),
+                        source_url: None,
+                        dependencies: vec![],
+                    },
+                ),
+            ]),
+        };
+        let excluded = BTreeMap::from([("newpkg".to_string(), "*".to_string())]);
+
+        let preferred = preferred_locked_versions(&description, Some(&lockfile), &excluded)
+            .expect("preferred versions should build");
+
+        assert_eq!(
+            preferred,
+            BTreeMap::from([
+                ("direct".to_string(), "1.0.0".to_string()),
+                ("transitive".to_string(), "2.0.0".to_string()),
+            ])
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -442,7 +442,8 @@ fn cmd_add(packages: &[String], default_repo: bool, no_default_repo: bool) -> Rp
     let mut lockfile = read_project_lockfile_optional()?;
     let use_default_repository =
         resolve_use_default_repository(lockfile.as_ref(), default_repo, no_default_repo);
-    let repositories = configured_repositories(&project, use_default_repository);
+    let repositories = configured_repositories(&project, use_default_repository)
+        .map_err(|details| LockError::ResolveFailed { details })?;
     let mut new_packages = Vec::new();
 
     for package in packages {
@@ -533,6 +534,10 @@ fn cmd_repo_add(url: &str) -> RpxResult<()> {
 }
 
 fn detect_repository_source(url: &str) -> Result<RepositorySource, String> {
+    classify_repository_source(url)
+}
+
+fn classify_repository_source(url: &str) -> Result<RepositorySource, String> {
     let rrepo = RepositorySource::new(url);
     let rrepo_set = RepositorySet::new(vec![rrepo.clone()]);
     match rrepo_set.fetch_repository_packages(&rrepo) {
@@ -543,7 +548,7 @@ fn detect_repository_source(url: &str) -> Result<RepositorySource, String> {
             match cran_like_set.fetch_repository_packages(&cran_like) {
                 Ok(_) => Ok(cran_like),
                 Err(cran_error) => Err(format!(
-                    "not an rrepo API ({rrepo_error}) or CRAN-like directory listing ({cran_error})"
+                    "not an rrepo API ({rrepo_error}) or CRAN-like repository ({cran_error})"
                 )),
             }
         }
@@ -586,22 +591,22 @@ fn cmd_repo_list() -> RpxResult<()> {
         return Ok(());
     }
 
-    let repositories = RepositorySet::new(
-        project
-            .additional_repositories
-            .iter()
-            .cloned()
-            .map(RepositorySource::new)
-            .collect(),
-    );
-
-    for source in repositories.sources() {
+    for url in &project.additional_repositories {
+        let source = classify_repository_source(url).map_err(|details| RepoError::Add {
+            url: normalize_repository_url(url),
+            details,
+        })?;
+        let repositories = RepositorySet::new(vec![source.clone()]);
         let credential = repositories
-            .has_stored_credential(source)
+            .has_stored_credential(&source)
             .map_err(|details| RepoError::CredentialInspect { details })?;
         status(format_args!(
-            "{} [{}]",
+            "{} [{}; {}]",
             source.base_url(),
+            match source.kind() {
+                RepositoryKind::Rrepo => "rrepo",
+                RepositoryKind::CranLike => "CRAN-like",
+            },
             if credential {
                 "credential stored"
             } else {
@@ -1115,7 +1120,8 @@ fn lock_from_description(default_repo: bool, no_default_repo: bool) -> RpxResult
     let existing_lockfile = read_project_lockfile_optional()?;
     let use_default_repository =
         resolve_use_default_repository(existing_lockfile.as_ref(), default_repo, no_default_repo);
-    let repositories = configured_repositories(&project, use_default_repository);
+    let repositories = configured_repositories(&project, use_default_repository)
+        .map_err(|details| LockError::ResolveFailed { details })?;
     if let Some(lockfile) = &existing_lockfile
         && lockfile.version > LOCKFILE_VERSION
     {
@@ -1217,7 +1223,8 @@ fn sync_from_lockfile(install_system: bool, install_only_system: bool) -> RpxRes
 
     let installed = installed_packages_by_name();
     let runtime = runtime_info();
-    let repositories = repositories_for_sync(&project, &lockfile);
+    let repositories = repositories_for_sync(&project, &lockfile)
+        .map_err(|details| SyncError::DownloadArtifactsFailed { details })?;
     let mut outcome = SyncOutcome::default();
     let ui = SyncUi::new();
     let mut satisfied = installed
@@ -1364,35 +1371,37 @@ fn default_registry_base_url() -> String {
 fn configured_repositories(
     project: &description::ProjectDescription,
     use_default_repository: bool,
-) -> RepositorySet {
-    RepositorySet::new(repository_sources_from_project(
+) -> Result<RepositorySet, String> {
+    Ok(RepositorySet::new(repository_sources_from_project(
         project,
         use_default_repository,
-    ))
+    )?))
 }
 
 fn repository_sources_from_project(
     project: &description::ProjectDescription,
     use_default_repository: bool,
-) -> Vec<RepositorySource> {
+) -> Result<Vec<RepositorySource>, String> {
     let mut sources = Vec::new();
     if use_default_repository {
         sources.push(RepositorySource::new(default_registry_base_url()));
     }
-    sources.extend(
-        project
-            .additional_repositories
-            .iter()
-            .flat_map(|url| [RepositorySource::new(url), RepositorySource::cran_like(url)]),
-    );
-    sources
+    for url in &project.additional_repositories {
+        sources.push(classify_repository_source(url).map_err(|details| {
+            format!(
+                "failed to classify configured repository {}: {details}",
+                normalize_repository_url(url)
+            )
+        })?);
+    }
+    Ok(sources)
 }
 
 fn repositories_for_sync(
     project: &description::ProjectDescription,
     lockfile: &Lockfile,
-) -> RepositorySet {
-    let mut sources = repository_sources_from_project(project, lockfile.use_default_repository);
+) -> Result<RepositorySet, String> {
+    let mut sources = repository_sources_from_project(project, lockfile.use_default_repository)?;
     sources.extend(lockfile.packages.values().filter_map(|package| {
         let source_url = package.source_url.as_deref()?;
         repository_source_from_package_url(source_url)
@@ -1401,7 +1410,7 @@ fn repositories_for_sync(
                 cran_like_source_from_package_url(source_url).map(RepositorySource::cran_like)
             })
     }));
-    RepositorySet::new(sources)
+    Ok(RepositorySet::new(sources))
 }
 
 fn resolve_use_default_repository(
@@ -2562,9 +2571,9 @@ fn read_log_tail(path: &Path, max_lines: usize) -> String {
 mod tests {
     use super::{
         LockfileCompatibilityError, add_resolution_roots, binary_artifact_request,
-        compiled_cache_key, constraints_from_resolved_roots, cran_like_binary_artifact_request,
-        default_registry_base_url, locked_install_order, lockfile_from_resolution,
-        persisted_constraints, preferred_artifact, r_minor_version,
+        classify_repository_source, compiled_cache_key, constraints_from_resolved_roots,
+        cran_like_binary_artifact_request, default_registry_base_url, locked_install_order,
+        lockfile_from_resolution, persisted_constraints, preferred_artifact, r_minor_version,
         repository_sources_from_project, resolve_use_default_repository, semver_add_constraint,
         should_fallback_to_source, validate_lockfile_compatibility,
     };
@@ -2577,10 +2586,11 @@ mod tests {
         },
         r::RuntimeInfo,
         registry::ResolutionRoot,
-        repository::{RepositorySet, RepositorySource},
+        repository::{RepositoryKind, RepositorySet, RepositorySource},
         resolver::{ResolvedDependency, ResolvedPackage},
         sysreqs::SysreqDbSnapshot,
     };
+    use mockito::Server;
     use std::collections::BTreeMap;
     use std::{
         env,
@@ -2758,17 +2768,92 @@ mod tests {
         let project = ProjectDescription {
             description: RDescription::from_str("Package: test\nVersion: 0.1.0\n")
                 .expect("description should parse"),
-            additional_repositories: vec!["https://cran.example".to_string()],
+            additional_repositories: vec![],
         };
 
-        let sources = repository_sources_from_project(&project, false);
+        let sources =
+            repository_sources_from_project(&project, false).expect("sources should build");
 
-        assert_eq!(sources.len(), 2);
-        assert!(
-            sources
-                .iter()
-                .all(|source| source.base_url() == "https://cran.example")
-        );
+        assert!(sources.is_empty());
+    }
+
+    #[test]
+    fn classifies_rrepo_repository_sources_up_front() {
+        let mut server = Server::new();
+        let packages_mock = server
+            .mock("GET", "/packages")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"repositorySlug":"test","packages":[]}"#)
+            .expect(1)
+            .create();
+
+        let source = classify_repository_source(&server.url()).expect("rrepo should classify");
+
+        assert_eq!(source.kind(), RepositoryKind::Rrepo);
+        packages_mock.assert();
+    }
+
+    #[test]
+    fn classifies_cran_like_repository_sources_up_front() {
+        let mut server = Server::new();
+        let rrepo_mock = server
+            .mock("GET", "/packages")
+            .with_status(404)
+            .expect(1)
+            .create();
+        let gz_mock = server
+            .mock("GET", "/src/contrib/PACKAGES.gz")
+            .with_status(404)
+            .expect(1)
+            .create();
+        let packages_mock = server
+            .mock("GET", "/src/contrib/PACKAGES")
+            .with_status(200)
+            .with_header("content-type", "text/plain")
+            .with_body("Package: digest\nVersion: 0.6.38\n")
+            .expect(1)
+            .create();
+
+        let source = classify_repository_source(&server.url()).expect("CRAN-like should classify");
+
+        assert_eq!(source.kind(), RepositoryKind::CranLike);
+        rrepo_mock.assert();
+        gz_mock.assert();
+        packages_mock.assert();
+    }
+
+    #[test]
+    fn project_sources_include_classified_additional_repositories_once() {
+        let mut server = Server::new();
+        server
+            .mock("GET", "/packages")
+            .with_status(404)
+            .expect(1)
+            .create();
+        server
+            .mock("GET", "/src/contrib/PACKAGES.gz")
+            .with_status(404)
+            .expect(1)
+            .create();
+        server
+            .mock("GET", "/src/contrib/PACKAGES")
+            .with_status(200)
+            .with_header("content-type", "text/plain")
+            .with_body("Package: digest\nVersion: 0.6.38\n")
+            .expect(1)
+            .create();
+        let project = ProjectDescription {
+            description: RDescription::from_str("Package: test\nVersion: 0.1.0\n")
+                .expect("description should parse"),
+            additional_repositories: vec![server.url()],
+        };
+
+        let sources =
+            repository_sources_from_project(&project, false).expect("sources should build");
+
+        assert_eq!(sources.len(), 1);
+        assert_eq!(sources[0].kind(), RepositoryKind::CranLike);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -910,6 +910,7 @@ struct PendingInstall {
     name: String,
     version: String,
     artifact: ArtifactRequest,
+    binary_fallback_artifacts: Vec<ArtifactRequest>,
     fallback_artifact: Option<ArtifactRequest>,
     install_kind: InstallKind,
     install_type: String,
@@ -1826,6 +1827,7 @@ fn registry_source_url(registry: &str, package: &str, version: &str) -> String {
 }
 
 fn preferred_artifact(
+    repositories: &RepositorySet,
     source: &RepositorySource,
     package: &str,
     version: &str,
@@ -1833,6 +1835,7 @@ fn preferred_artifact(
     runtime: &RuntimeInfo,
 ) -> (
     ArtifactRequest,
+    Vec<ArtifactRequest>,
     Option<ArtifactRequest>,
     InstallKind,
     String,
@@ -1843,30 +1846,73 @@ fn preferred_artifact(
         cache_file_name: source_cache_file_name(package, version),
     };
 
-    if source.kind() == RepositoryKind::CranLike {
+    let mut binary_candidates =
+        binary_artifact_candidates(repositories, source, package, version, runtime);
+    let Some(binary) = binary_candidates.first().cloned() else {
         return (
             source_artifact,
-            None,
-            InstallKind::Source,
-            "source".to_string(),
-        );
-    }
-
-    let Some(binary) = binary_artifact_request(source.base_url(), package, version, runtime) else {
-        return (
-            source_artifact,
+            vec![],
             None,
             InstallKind::Source,
             "source".to_string(),
         );
     };
+    binary_candidates.remove(0);
 
     (
         binary,
+        binary_candidates,
         Some(source_artifact),
         InstallKind::Binary,
         runtime.pkg_type.clone(),
     )
+}
+
+fn binary_artifact_candidates(
+    repositories: &RepositorySet,
+    locked_source: &RepositorySource,
+    package: &str,
+    version: &str,
+    runtime: &RuntimeInfo,
+) -> Vec<ArtifactRequest> {
+    let sources = std::iter::once(locked_source)
+        .chain(
+            repositories
+                .sources()
+                .iter()
+                .filter(|source| *source != locked_source),
+        )
+        .collect::<Vec<_>>();
+    let mut seen = BTreeSet::new();
+    let mut artifacts = Vec::new();
+
+    for source in sources {
+        let Some(artifact) = binary_artifact_request_for_source(source, package, version, runtime)
+        else {
+            continue;
+        };
+        if seen.insert(artifact.url.clone()) {
+            artifacts.push(artifact);
+        }
+    }
+
+    artifacts
+}
+
+fn binary_artifact_request_for_source(
+    source: &RepositorySource,
+    package: &str,
+    version: &str,
+    runtime: &RuntimeInfo,
+) -> Option<ArtifactRequest> {
+    match source.kind() {
+        RepositoryKind::Rrepo => {
+            binary_artifact_request(source.base_url(), package, version, runtime)
+        }
+        RepositoryKind::CranLike => {
+            cran_like_binary_artifact_request(source.base_url(), package, version, runtime)
+        }
+    }
 }
 
 fn binary_artifact_request(
@@ -1892,6 +1938,36 @@ fn binary_artifact_request(
         kind: ArtifactKind::Binary,
         url: format!(
             "{}/packages/{package}/versions/{version}/binaries/macos/{target}/{}",
+            registry.trim_end_matches('/'),
+            r_minor_version(&runtime.version)?
+        ),
+        cache_file_name: macos_binary_cache_file_name(package, version),
+    })
+}
+
+fn cran_like_binary_artifact_request(
+    registry: &str,
+    package: &str,
+    version: &str,
+    runtime: &RuntimeInfo,
+) -> Option<ArtifactRequest> {
+    if runtime.pkg_type == "win.binary" {
+        return Some(ArtifactRequest {
+            kind: ArtifactKind::Binary,
+            url: format!(
+                "{}/bin/windows/contrib/{}/{package}_{version}.zip",
+                registry.trim_end_matches('/'),
+                r_minor_version(&runtime.version)?
+            ),
+            cache_file_name: windows_binary_cache_file_name(package, version),
+        });
+    }
+
+    let target = runtime.pkg_type.strip_prefix("mac.binary.")?;
+    Some(ArtifactRequest {
+        kind: ArtifactKind::Binary,
+        url: format!(
+            "{}/bin/macosx/{target}/contrib/{}/{package}_{version}.tgz",
             registry.trim_end_matches('/'),
             r_minor_version(&runtime.version)?
         ),
@@ -1940,8 +2016,20 @@ fn collect_pending_installs(
                 let source = repositories
                     .source_for_url(&source_url)
                     .unwrap_or_else(|| RepositorySource::new(lockfile.registry.clone()));
-                let (artifact, fallback_artifact, install_kind, install_type) =
-                    preferred_artifact(&source, name, &package.version, &source_url, runtime);
+                let (
+                    artifact,
+                    binary_fallback_artifacts,
+                    fallback_artifact,
+                    install_kind,
+                    install_type,
+                ) = preferred_artifact(
+                    repositories,
+                    &source,
+                    name,
+                    &package.version,
+                    &source_url,
+                    runtime,
+                );
                 let dependencies = package
                     .dependencies
                     .iter()
@@ -1957,6 +2045,7 @@ fn collect_pending_installs(
                         name: name.clone(),
                         version: package.version.clone(),
                         artifact,
+                        binary_fallback_artifacts,
                         fallback_artifact,
                         install_kind,
                         install_type,
@@ -2011,102 +2100,55 @@ fn download_artifacts_in_parallel(
                     break;
                 };
 
-                let _ = sender.send(DownloadEvent::Started {
-                    name: package.name.clone(),
-                    version: package.version.clone(),
-                    kind: package.artifact.kind,
-                });
+                let mut result = download_artifact_candidate(
+                    &repositories,
+                    &sender,
+                    &package,
+                    &package.artifact,
+                    package.install_kind,
+                    package.install_type.clone(),
+                );
 
-                let progress_sender = sender.clone();
-                let progress_name = package.name.clone();
-                let result = repositories
-                    .source_for_url(&package.artifact.url)
-                    .ok_or_else(|| {
-                        format!(
-                            "could not determine repository source for {}@{}",
-                            package.name, package.version
-                        )
-                    })
-                    .and_then(|source| {
-                        repositories.download_artifact_with_progress(
-                            &source,
-                            &package.name,
-                            &package.version,
-                            &package.artifact,
-                            move |progress| match progress {
-                                DownloadProgress::ContentLength(length) => {
-                                    let _ = progress_sender.send(DownloadEvent::ContentLength {
-                                        name: progress_name.clone(),
-                                        length,
-                                    });
-                                }
-                                DownloadProgress::Advanced(bytes) => {
-                                    let _ = progress_sender.send(DownloadEvent::Advanced {
-                                        name: progress_name.clone(),
-                                        bytes,
-                                    });
-                                }
-                            },
-                        )
-                    })
-                    .map(|artifact| DownloadedInstall {
+                for artifact in &package.binary_fallback_artifacts {
+                    if result.is_ok() {
+                        break;
+                    }
+                    let Err(error) = &result else {
+                        continue;
+                    };
+                    if !should_fallback_to_source(error) {
+                        break;
+                    }
+                    result = download_artifact_candidate(
+                        &repositories,
+                        &sender,
+                        &package,
                         artifact,
-                        install_kind: package.install_kind,
-                        install_type: package.install_type.clone(),
-                    })
-                    .or_else(|error| {
-                        let Some(fallback) = &package.fallback_artifact else {
-                            return Err(error);
-                        };
-                        if !should_fallback_to_source(&error) {
-                            return Err(error);
-                        }
-                        let _ = sender.send(DownloadEvent::FallbackToSource {
-                            name: package.name.clone(),
-                            version: package.version.clone(),
-                        });
-                        let _ = sender.send(DownloadEvent::Started {
-                            name: package.name.clone(),
-                            version: package.version.clone(),
-                            kind: fallback.kind,
-                        });
-                        let source =
-                            repositories.source_for_url(&fallback.url).ok_or_else(|| {
-                                format!(
-                                    "could not determine repository source for {}@{}",
-                                    package.name, package.version
-                                )
-                            })?;
-                        let progress_sender = sender.clone();
-                        let progress_name = package.name.clone();
-                        repositories
-                            .download_artifact_with_progress(
-                                &source,
-                                &package.name,
-                                &package.version,
-                                fallback,
-                                move |progress| match progress {
-                                    DownloadProgress::ContentLength(length) => {
-                                        let _ =
-                                            progress_sender.send(DownloadEvent::ContentLength {
-                                                name: progress_name.clone(),
-                                                length,
-                                            });
-                                    }
-                                    DownloadProgress::Advanced(bytes) => {
-                                        let _ = progress_sender.send(DownloadEvent::Advanced {
-                                            name: progress_name.clone(),
-                                            bytes,
-                                        });
-                                    }
-                                },
-                            )
-                            .map(|artifact| DownloadedInstall {
-                                artifact,
-                                install_kind: InstallKind::Source,
-                                install_type: "source".to_string(),
-                            })
+                        InstallKind::Binary,
+                        package.install_type.clone(),
+                    );
+                }
+
+                let result = result.or_else(|error| {
+                    let Some(fallback) = &package.fallback_artifact else {
+                        return Err(error);
+                    };
+                    if !should_fallback_to_source(&error) {
+                        return Err(error);
+                    }
+                    let _ = sender.send(DownloadEvent::FallbackToSource {
+                        name: package.name.clone(),
+                        version: package.version.clone(),
                     });
+                    download_artifact_candidate(
+                        &repositories,
+                        &sender,
+                        &package,
+                        fallback,
+                        InstallKind::Source,
+                        "source".to_string(),
+                    )
+                });
                 let _ = sender.send(DownloadEvent::Finished {
                     package: Box::new(package),
                     result,
@@ -2144,6 +2186,59 @@ fn download_artifacts_in_parallel(
     }
 
     Ok(downloaded)
+}
+
+fn download_artifact_candidate(
+    repositories: &RepositorySet,
+    sender: &mpsc::Sender<DownloadEvent>,
+    package: &PendingInstall,
+    artifact: &ArtifactRequest,
+    install_kind: InstallKind,
+    install_type: String,
+) -> Result<DownloadedInstall, String> {
+    let _ = sender.send(DownloadEvent::Started {
+        name: package.name.clone(),
+        version: package.version.clone(),
+        kind: artifact.kind,
+    });
+
+    let progress_sender = sender.clone();
+    let progress_name = package.name.clone();
+    repositories
+        .source_for_url(&artifact.url)
+        .ok_or_else(|| {
+            format!(
+                "could not determine repository source for {}@{}",
+                package.name, package.version
+            )
+        })
+        .and_then(|source| {
+            repositories.download_artifact_with_progress(
+                &source,
+                &package.name,
+                &package.version,
+                artifact,
+                move |progress| match progress {
+                    DownloadProgress::ContentLength(length) => {
+                        let _ = progress_sender.send(DownloadEvent::ContentLength {
+                            name: progress_name.clone(),
+                            length,
+                        });
+                    }
+                    DownloadProgress::Advanced(bytes) => {
+                        let _ = progress_sender.send(DownloadEvent::Advanced {
+                            name: progress_name.clone(),
+                            bytes,
+                        });
+                    }
+                },
+            )
+        })
+        .map(|artifact| DownloadedInstall {
+            artifact,
+            install_kind,
+            install_type,
+        })
 }
 
 fn ready_install_names(
@@ -2467,10 +2562,11 @@ fn read_log_tail(path: &Path, max_lines: usize) -> String {
 mod tests {
     use super::{
         LockfileCompatibilityError, add_resolution_roots, binary_artifact_request,
-        compiled_cache_key, constraints_from_resolved_roots, default_registry_base_url,
-        locked_install_order, lockfile_from_resolution, persisted_constraints, preferred_artifact,
-        r_minor_version, repository_sources_from_project, resolve_use_default_repository,
-        semver_add_constraint, should_fallback_to_source, validate_lockfile_compatibility,
+        compiled_cache_key, constraints_from_resolved_roots, cran_like_binary_artifact_request,
+        default_registry_base_url, locked_install_order, lockfile_from_resolution,
+        persisted_constraints, preferred_artifact, r_minor_version,
+        repository_sources_from_project, resolve_use_default_repository, semver_add_constraint,
+        should_fallback_to_source, validate_lockfile_compatibility,
     };
     use crate::description::{ProjectDescription, RDescription};
     use crate::{
@@ -2481,7 +2577,7 @@ mod tests {
         },
         r::RuntimeInfo,
         registry::ResolutionRoot,
-        repository::RepositorySource,
+        repository::{RepositorySet, RepositorySource},
         resolver::{ResolvedDependency, ResolvedPackage},
         sysreqs::SysreqDbSnapshot,
     };
@@ -2995,14 +3091,58 @@ mod tests {
     }
 
     #[test]
-    fn uses_source_artifacts_for_cran_like_repositories() {
+    fn derives_windows_cran_like_binary_artifact_url_from_runtime() {
+        let runtime = RuntimeInfo {
+            version: "4.5.2".to_string(),
+            platform: "x86_64-w64-mingw32".to_string(),
+            pkg_type: "win.binary".to_string(),
+        };
+
+        let artifact =
+            cran_like_binary_artifact_request("https://cran.example", "digest", "0.6.38", &runtime)
+                .expect("windows CRAN-like binary should be supported");
+
+        assert_eq!(
+            artifact.url,
+            "https://cran.example/bin/windows/contrib/4.5/digest_0.6.38.zip"
+        );
+        assert_eq!(artifact.cache_file_name, "digest_0.6.38.zip");
+    }
+
+    #[test]
+    fn derives_macos_cran_like_binary_artifact_url_from_runtime() {
+        let runtime = RuntimeInfo {
+            version: "4.5.2".to_string(),
+            platform: "aarch64-apple-darwin20".to_string(),
+            pkg_type: "mac.binary.big-sur-arm64".to_string(),
+        };
+
+        let artifact = cran_like_binary_artifact_request(
+            "https://cran.example",
+            "jsonlite",
+            "2.0.0",
+            &runtime,
+        )
+        .expect("macOS CRAN-like binary should be supported");
+
+        assert_eq!(
+            artifact.url,
+            "https://cran.example/bin/macosx/big-sur-arm64/contrib/4.5/jsonlite_2.0.0.tgz"
+        );
+        assert_eq!(artifact.cache_file_name, "jsonlite_2.0.0.tgz");
+    }
+
+    #[test]
+    fn prefers_cran_like_binary_artifacts_with_locked_source_fallback() {
         let runtime = RuntimeInfo {
             version: "4.5.2".to_string(),
             platform: "x86_64-w64-mingw32".to_string(),
             pkg_type: "win.binary".to_string(),
         };
         let source = RepositorySource::cran_like("https://cran.example");
-        let (artifact, fallback, install_kind, install_type) = preferred_artifact(
+        let repositories = RepositorySet::new(vec![source.clone()]);
+        let (artifact, binary_fallbacks, fallback, install_kind, install_type) = preferred_artifact(
+            &repositories,
             &source,
             "digest",
             "0.6.38",
@@ -3012,11 +3152,56 @@ mod tests {
 
         assert_eq!(
             artifact.url,
+            "https://cran.example/bin/windows/contrib/4.5/digest_0.6.38.zip"
+        );
+        assert!(binary_fallbacks.is_empty());
+        assert_eq!(
+            fallback.expect("source fallback should exist").url,
             "https://cran.example/src/contrib/digest_0.6.38.tar.gz"
         );
-        assert!(fallback.is_none());
-        assert_eq!(install_kind, crate::ui::InstallKind::Source);
-        assert_eq!(install_type, "source");
+        assert_eq!(install_kind, crate::ui::InstallKind::Binary);
+        assert_eq!(install_type, "win.binary");
+    }
+
+    #[test]
+    fn tries_locked_repository_binary_before_other_repository_binaries() {
+        let runtime = RuntimeInfo {
+            version: "4.5.2".to_string(),
+            platform: "x86_64-w64-mingw32".to_string(),
+            pkg_type: "win.binary".to_string(),
+        };
+        let default = RepositorySource::new("https://default.example/cran");
+        let locked = RepositorySource::cran_like("https://cran.example");
+        let other = RepositorySource::cran_like("https://mirror.example");
+        let repositories = RepositorySet::new(vec![default.clone(), locked.clone(), other]);
+        let (artifact, binary_fallbacks, fallback, install_kind, _) = preferred_artifact(
+            &repositories,
+            &locked,
+            "digest",
+            "0.6.38",
+            "https://cran.example/src/contrib/digest_0.6.38.tar.gz",
+            &runtime,
+        );
+
+        assert_eq!(
+            artifact.url,
+            "https://cran.example/bin/windows/contrib/4.5/digest_0.6.38.zip"
+        );
+        assert_eq!(
+            binary_fallbacks
+                .iter()
+                .map(|artifact| artifact.url.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "https://default.example/cran/packages/digest/versions/0.6.38/binaries/windows/4.5",
+                "https://mirror.example/bin/windows/contrib/4.5/digest_0.6.38.zip",
+            ]
+        );
+        assert_eq!(
+            fallback.expect("source fallback should exist").url,
+            "https://cran.example/src/contrib/digest_0.6.38.tar.gz"
+        );
+        assert_eq!(install_kind, crate::ui::InstallKind::Binary);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ use registry::{
 };
 use repository::{
     RepositoryKind, RepositorySet, RepositorySource, cran_like_source_from_package_url,
-    normalize_repository_url, repository_source_from_package_url,
+    detect_cran_like_archive_support, normalize_repository_url, repository_source_from_package_url,
 };
 use resolver::{ResolvedPackage, is_base_package, resolve_from_registry};
 use sysreqs::{
@@ -546,7 +546,13 @@ fn classify_repository_source(url: &str) -> Result<RepositorySource, String> {
             let cran_like = RepositorySource::cran_like(url);
             let cran_like_set = RepositorySet::new(vec![cran_like.clone()]);
             match cran_like_set.fetch_repository_packages(&cran_like) {
-                Ok(_) => Ok(cran_like),
+                Ok(_) => {
+                    let archive_support = detect_cran_like_archive_support(&cran_like)?;
+                    Ok(RepositorySource::cran_like_with_archive_support(
+                        url,
+                        archive_support,
+                    ))
+                }
                 Err(cran_error) => Err(format!(
                     "not an rrepo API ({rrepo_error}) or CRAN-like repository ({cran_error})"
                 )),
@@ -2580,7 +2586,7 @@ mod tests {
         },
         r::RuntimeInfo,
         registry::ResolutionRoot,
-        repository::{RepositoryKind, RepositorySet, RepositorySource},
+        repository::{CranArchiveSupport, RepositoryKind, RepositorySet, RepositorySource},
         resolver::{ResolvedDependency, ResolvedPackage},
         sysreqs::SysreqDbSnapshot,
     };
@@ -2808,13 +2814,23 @@ mod tests {
             .with_body("Package: digest\nVersion: 0.6.38\n")
             .expect(1)
             .create();
+        let archive_mock = server
+            .mock("GET", "/src/contrib/Archive/")
+            .with_status(404)
+            .expect(1)
+            .create();
 
         let source = classify_repository_source(&server.url()).expect("CRAN-like should classify");
 
         assert_eq!(source.kind(), RepositoryKind::CranLike);
+        assert_eq!(
+            source.cran_archive_support(),
+            Some(CranArchiveSupport::Unavailable)
+        );
         rrepo_mock.assert();
         gz_mock.assert();
         packages_mock.assert();
+        archive_mock.assert();
     }
 
     #[test]
@@ -2837,6 +2853,11 @@ mod tests {
             .with_body("Package: digest\nVersion: 0.6.38\n")
             .expect(1)
             .create();
+        server
+            .mock("GET", "/src/contrib/Archive/")
+            .with_status(200)
+            .expect(1)
+            .create();
         let project = ProjectDescription {
             description: RDescription::from_str("Package: test\nVersion: 0.1.0\n")
                 .expect("description should parse"),
@@ -2848,6 +2869,10 @@ mod tests {
 
         assert_eq!(sources.len(), 1);
         assert_eq!(sources[0].kind(), RepositoryKind::CranLike);
+        assert_eq!(
+            sources[0].cran_archive_support(),
+            Some(CranArchiveSupport::Available)
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,8 @@ use registry::{
     ResolutionRoot,
 };
 use repository::{
-    RepositorySet, RepositorySource, normalize_repository_url, repository_source_from_package_url,
+    RepositoryKind, RepositorySet, RepositorySource, cran_like_source_from_package_url,
+    normalize_repository_url, repository_source_from_package_url,
 };
 use resolver::{ResolvedPackage, is_base_package, resolve_from_registry};
 use sysreqs::{
@@ -354,6 +355,16 @@ enum RpxWarning {
         help("Run `rpx sync --install-system` to install missing system dependencies first.")
     )]
     ContinuingWithoutSystemDependencies,
+
+    #[error("archive listing unavailable for CRAN-like repository {url}")]
+    #[diagnostic(
+        severity(Warning),
+        code(rpx::repository::cran_archive_unavailable),
+        help(
+            "rpx can restore locked archived package URLs, but new resolution for this repository is limited to versions listed in PACKAGES."
+        )
+    )]
+    CranArchiveUnavailable { url: String },
 }
 
 fn read_project_description() -> Result<description::ProjectDescription, ProjectError> {
@@ -388,10 +399,21 @@ fn run_inner() -> RpxResult<()> {
 
     match cli.command {
         Commands::Init => cmd_init(),
-        Commands::Add { packages } => cmd_add(&packages),
-        Commands::Remove { packages } => cmd_remove(&packages),
+        Commands::Add {
+            default_repo,
+            no_default_repo,
+            packages,
+        } => cmd_add(&packages, default_repo, no_default_repo),
+        Commands::Remove {
+            default_repo,
+            no_default_repo,
+            packages,
+        } => cmd_remove(&packages, default_repo, no_default_repo),
         Commands::Run { command } => cmd_run(&command),
-        Commands::Lock => cmd_lock(),
+        Commands::Lock {
+            default_repo,
+            no_default_repo,
+        } => cmd_lock(default_repo, no_default_repo),
         Commands::Status => cmd_status(),
         Commands::Sync {
             install_system,
@@ -415,10 +437,12 @@ fn cmd_init() -> RpxResult<()> {
     Ok(())
 }
 
-fn cmd_add(packages: &[String]) -> RpxResult<()> {
+fn cmd_add(packages: &[String], default_repo: bool, no_default_repo: bool) -> RpxResult<()> {
     let mut project = read_project_description()?;
     let mut lockfile = read_project_lockfile_optional()?;
-    let repositories = configured_repositories(&project);
+    let use_default_repository =
+        resolve_use_default_repository(lockfile.as_ref(), default_repo, no_default_repo);
+    let repositories = configured_repositories(&project, use_default_repository);
     let mut new_packages = Vec::new();
 
     for package in packages {
@@ -453,6 +477,7 @@ fn cmd_add(packages: &[String]) -> RpxResult<()> {
         lockfile = Some(lockfile_from_resolution(
             project.description.resolution_roots(),
             &default_registry_base_url(),
+            use_default_repository,
             &resolved_addition.resolved,
             &sysreq_db,
         ));
@@ -462,7 +487,7 @@ fn cmd_add(packages: &[String]) -> RpxResult<()> {
     if let Some(lockfile) = lockfile {
         write_project_lockfile(lockfile)?;
     } else {
-        let _ = lock_from_description()?;
+        let _ = lock_from_description(default_repo, no_default_repo)?;
     }
     let _ = sync_from_lockfile(false, false)?;
     status(format_args!("Added {}", packages.join(", ")));
@@ -482,7 +507,10 @@ fn cmd_repo(command: RepoCommands) -> RpxResult<()> {
 
 fn cmd_repo_add(url: &str) -> RpxResult<()> {
     let mut project = read_project_description()?;
-    let source = RepositorySource::new(url);
+    let source = detect_repository_source(url).map_err(|details| RepoError::Add {
+        url: normalize_repository_url(url),
+        details,
+    })?;
 
     if project
         .additional_repositories
@@ -496,20 +524,30 @@ fn cmd_repo_add(url: &str) -> RpxResult<()> {
         return Ok(());
     }
 
-    let repositories = RepositorySet::new(vec![source.clone()]);
-    repositories
-        .fetch_repository_packages(&source)
-        .map_err(|details| RepoError::Add {
-            url: source.base_url().to_string(),
-            details,
-        })?;
-
     project
         .additional_repositories
         .push(source.base_url().to_string());
     write_project_description(&project)?;
     status(format_args!("Added repository {}", source.base_url()));
     Ok(())
+}
+
+fn detect_repository_source(url: &str) -> Result<RepositorySource, String> {
+    let rrepo = RepositorySource::new(url);
+    let rrepo_set = RepositorySet::new(vec![rrepo.clone()]);
+    match rrepo_set.fetch_repository_packages(&rrepo) {
+        Ok(_) => return Ok(rrepo),
+        Err(rrepo_error) => {
+            let cran_like = RepositorySource::cran_like(url);
+            let cran_like_set = RepositorySet::new(vec![cran_like.clone()]);
+            match cran_like_set.fetch_repository_packages(&cran_like) {
+                Ok(_) => Ok(cran_like),
+                Err(cran_error) => Err(format!(
+                    "not an rrepo API ({rrepo_error}) or CRAN-like directory listing ({cran_error})"
+                )),
+            }
+        }
+    }
 }
 
 fn cmd_repo_remove(url: &str, remove_credential: bool) -> RpxResult<()> {
@@ -574,7 +612,7 @@ fn cmd_repo_list() -> RpxResult<()> {
     Ok(())
 }
 
-fn cmd_remove(packages: &[String]) -> RpxResult<()> {
+fn cmd_remove(packages: &[String], default_repo: bool, no_default_repo: bool) -> RpxResult<()> {
     let mut project = read_project_description()?;
     for package in packages {
         project.description.remove_from_field("Imports", package);
@@ -598,7 +636,7 @@ fn cmd_remove(packages: &[String]) -> RpxResult<()> {
         remove_installed_packages(&removed);
     }
 
-    let _ = lock_from_description()?;
+    let _ = lock_from_description(default_repo, no_default_repo)?;
     let _ = sync_from_lockfile(false, false)?;
 
     if !removed.is_empty() {
@@ -631,8 +669,8 @@ fn cmd_run(command: &[String]) -> RpxResult<()> {
     Ok(())
 }
 
-fn cmd_lock() -> RpxResult<()> {
-    let outcome = lock_from_description()?;
+fn cmd_lock(default_repo: bool, no_default_repo: bool) -> RpxResult<()> {
+    let outcome = lock_from_description(default_repo, no_default_repo)?;
     if outcome.changed {
         status("Updated rpx.lock");
     } else {
@@ -946,6 +984,7 @@ fn resolve_additions_from_latest(
                 packages.join(", ")
             )
         })?;
+    warn_cran_archive_unavailable(repositories);
 
     Ok(AddResolution {
         constraints: constraints_from_resolved_roots(packages, &resolved)?,
@@ -1068,12 +1107,14 @@ fn constraints_from_resolved_roots(
         .collect()
 }
 
-fn lock_from_description() -> RpxResult<LockOutcome> {
+fn lock_from_description(default_repo: bool, no_default_repo: bool) -> RpxResult<LockOutcome> {
     let project = read_project_description()?;
     let roots = project.description.resolution_roots();
     let registry = default_registry_base_url();
-    let repositories = configured_repositories(&project);
     let existing_lockfile = read_project_lockfile_optional()?;
+    let use_default_repository =
+        resolve_use_default_repository(existing_lockfile.as_ref(), default_repo, no_default_repo);
+    let repositories = configured_repositories(&project, use_default_repository);
     if let Some(lockfile) = &existing_lockfile
         && lockfile.version > LOCKFILE_VERSION
     {
@@ -1082,7 +1123,8 @@ fn lock_from_description() -> RpxResult<LockOutcome> {
     let sysreq_db = load_sysreq_snapshot_for_lock(existing_lockfile.as_ref());
 
     if roots.is_empty() {
-        let lockfile = lockfile_from_resolution(vec![], &registry, &[], &sysreq_db);
+        let lockfile =
+            lockfile_from_resolution(vec![], &registry, use_default_repository, &[], &sysreq_db);
         let changed = existing_lockfile.as_ref() != Some(&lockfile);
         write_project_lockfile(lockfile)?;
         return Ok(LockOutcome { changed });
@@ -1094,8 +1136,15 @@ fn lock_from_description() -> RpxResult<LockOutcome> {
                 details: details.to_string(),
             }
         })?;
+    warn_cran_archive_unavailable(&repositories);
 
-    let lockfile = lockfile_from_resolution(roots, &registry, &resolved, &sysreq_db);
+    let lockfile = lockfile_from_resolution(
+        roots,
+        &registry,
+        use_default_repository,
+        &resolved,
+        &sysreq_db,
+    );
     let changed = existing_lockfile.as_ref() != Some(&lockfile);
     write_project_lockfile(lockfile)?;
     Ok(LockOutcome { changed })
@@ -1126,6 +1175,12 @@ fn load_sysreq_snapshot_for_lock(
 
     warning(RpxWarning::SysreqUnavailable);
     empty_sysreq_snapshot()
+}
+
+fn warn_cran_archive_unavailable(repositories: &RepositorySet) {
+    for url in repositories.cran_archive_unavailable_repositories() {
+        warning(RpxWarning::CranArchiveUnavailable { url });
+    }
 }
 
 fn sync_from_lockfile(install_system: bool, install_only_system: bool) -> RpxResult<SyncOutcome> {
@@ -1305,20 +1360,29 @@ fn default_registry_base_url() -> String {
         .to_string()
 }
 
-fn configured_repositories(project: &description::ProjectDescription) -> RepositorySet {
-    RepositorySet::new(repository_sources_from_project(project))
+fn configured_repositories(
+    project: &description::ProjectDescription,
+    use_default_repository: bool,
+) -> RepositorySet {
+    RepositorySet::new(repository_sources_from_project(
+        project,
+        use_default_repository,
+    ))
 }
 
 fn repository_sources_from_project(
     project: &description::ProjectDescription,
+    use_default_repository: bool,
 ) -> Vec<RepositorySource> {
-    let mut sources = vec![RepositorySource::new(default_registry_base_url())];
+    let mut sources = Vec::new();
+    if use_default_repository {
+        sources.push(RepositorySource::new(default_registry_base_url()));
+    }
     sources.extend(
         project
             .additional_repositories
             .iter()
-            .cloned()
-            .map(RepositorySource::new),
+            .flat_map(|url| [RepositorySource::new(url), RepositorySource::cran_like(url)]),
     );
     sources
 }
@@ -1327,20 +1391,38 @@ fn repositories_for_sync(
     project: &description::ProjectDescription,
     lockfile: &Lockfile,
 ) -> RepositorySet {
-    let mut sources = repository_sources_from_project(project);
+    let mut sources = repository_sources_from_project(project, lockfile.use_default_repository);
     sources.extend(lockfile.packages.values().filter_map(|package| {
-        package
-            .source_url
-            .as_deref()
-            .and_then(repository_source_from_package_url)
+        let source_url = package.source_url.as_deref()?;
+        repository_source_from_package_url(source_url)
             .map(RepositorySource::new)
+            .or_else(|| {
+                cran_like_source_from_package_url(source_url).map(RepositorySource::cran_like)
+            })
     }));
     RepositorySet::new(sources)
+}
+
+fn resolve_use_default_repository(
+    lockfile: Option<&Lockfile>,
+    default_repo: bool,
+    no_default_repo: bool,
+) -> bool {
+    if default_repo {
+        return true;
+    }
+    if no_default_repo {
+        return false;
+    }
+    lockfile
+        .map(|lockfile| lockfile.use_default_repository)
+        .unwrap_or(true)
 }
 
 fn lockfile_from_resolution(
     roots: Vec<ResolutionRoot>,
     registry: &str,
+    use_default_repository: bool,
     resolved: &[ResolvedPackage],
     sysreq_db: &sysreqs::SysreqDbSnapshot,
 ) -> Lockfile {
@@ -1350,6 +1432,7 @@ fn lockfile_from_resolution(
         version: LOCKFILE_VERSION,
         revision: LOCKFILE_REVISION,
         registry: registry.to_string(),
+        use_default_repository,
         r: LockedR {
             version: runtime_info().version,
             base_packages: required_base_packages,
@@ -1759,6 +1842,15 @@ fn preferred_artifact(
         url: source_url.to_string(),
         cache_file_name: source_cache_file_name(package, version),
     };
+
+    if source.kind() == RepositoryKind::CranLike {
+        return (
+            source_artifact,
+            None,
+            InstallKind::Source,
+            "source".to_string(),
+        );
+    }
 
     let Some(binary) = binary_artifact_request(source.base_url(), package, version, runtime) else {
         return (
@@ -2376,10 +2468,11 @@ mod tests {
     use super::{
         LockfileCompatibilityError, add_resolution_roots, binary_artifact_request,
         compiled_cache_key, constraints_from_resolved_roots, default_registry_base_url,
-        locked_install_order, lockfile_from_resolution, persisted_constraints, r_minor_version,
+        locked_install_order, lockfile_from_resolution, persisted_constraints, preferred_artifact,
+        r_minor_version, repository_sources_from_project, resolve_use_default_repository,
         semver_add_constraint, should_fallback_to_source, validate_lockfile_compatibility,
     };
-    use crate::description::RDescription;
+    use crate::description::{ProjectDescription, RDescription};
     use crate::{
         description::DescriptionExt,
         lockfile::{
@@ -2388,6 +2481,7 @@ mod tests {
         },
         r::RuntimeInfo,
         registry::ResolutionRoot,
+        repository::RepositorySource,
         resolver::{ResolvedDependency, ResolvedPackage},
         sysreqs::SysreqDbSnapshot,
     };
@@ -2438,6 +2532,7 @@ mod tests {
                 },
             ],
             "https://api.rrepo.org",
+            true,
             &[
                 ResolvedPackage {
                     name: "cli".to_string(),
@@ -2536,6 +2631,51 @@ mod tests {
     }
 
     #[test]
+    fn resolves_default_repository_preference_from_flags_then_lockfile() {
+        let lockfile = Lockfile {
+            version: LOCKFILE_VERSION,
+            revision: LOCKFILE_REVISION,
+            registry: "https://api.rrepo.org".to_string(),
+            use_default_repository: false,
+            r: LockedR::default(),
+            sysreqs: LockedSystemRequirements::default(),
+            roots: vec![],
+            packages: BTreeMap::new(),
+        };
+
+        assert!(resolve_use_default_repository(None, false, false));
+        assert!(!resolve_use_default_repository(
+            Some(&lockfile),
+            false,
+            false
+        ));
+        assert!(resolve_use_default_repository(Some(&lockfile), true, false));
+        assert!(!resolve_use_default_repository(
+            Some(&lockfile),
+            false,
+            true
+        ));
+    }
+
+    #[test]
+    fn omits_default_repository_from_project_sources_when_disabled() {
+        let project = ProjectDescription {
+            description: RDescription::from_str("Package: test\nVersion: 0.1.0\n")
+                .expect("description should parse"),
+            additional_repositories: vec!["https://cran.example".to_string()],
+        };
+
+        let sources = repository_sources_from_project(&project, false);
+
+        assert_eq!(sources.len(), 2);
+        assert!(
+            sources
+                .iter()
+                .all(|source| source.base_url() == "https://cran.example")
+        );
+    }
+
+    #[test]
     fn builds_semver_constraint_from_resolved_version() {
         assert_eq!(
             semver_add_constraint("1.1.4").unwrap(),
@@ -2600,6 +2740,7 @@ mod tests {
                 constraint: "*".to_string(),
             }],
             "https://api.rrepo.org",
+            true,
             &[],
             &empty_sysreq_db(),
         );
@@ -2641,6 +2782,7 @@ mod tests {
             version: LOCKFILE_VERSION,
             revision: LOCKFILE_REVISION + 1,
             registry: "https://api.rrepo.org".to_string(),
+            use_default_repository: true,
             r: LockedR::default(),
             sysreqs: LockedSystemRequirements::default(),
             roots: vec![],
@@ -2663,6 +2805,7 @@ mod tests {
             version: LOCKFILE_VERSION,
             revision: LOCKFILE_REVISION,
             registry: "https://api.rrepo.org".to_string(),
+            use_default_repository: true,
             r: LockedR::default(),
             sysreqs: LockedSystemRequirements::default(),
             roots: vec![],
@@ -2735,6 +2878,7 @@ mod tests {
             version: LOCKFILE_VERSION,
             revision: LOCKFILE_REVISION,
             registry: "https://api.rrepo.org".to_string(),
+            use_default_repository: true,
             r: LockedR::default(),
             sysreqs: LockedSystemRequirements::default(),
             roots: vec![],
@@ -2848,6 +2992,31 @@ mod tests {
             binary_artifact_request("https://api.rrepo.org", "digest", "0.6.37", &runtime)
                 .is_none()
         );
+    }
+
+    #[test]
+    fn uses_source_artifacts_for_cran_like_repositories() {
+        let runtime = RuntimeInfo {
+            version: "4.5.2".to_string(),
+            platform: "x86_64-w64-mingw32".to_string(),
+            pkg_type: "win.binary".to_string(),
+        };
+        let source = RepositorySource::cran_like("https://cran.example");
+        let (artifact, fallback, install_kind, install_type) = preferred_artifact(
+            &source,
+            "digest",
+            "0.6.38",
+            "https://cran.example/src/contrib/digest_0.6.38.tar.gz",
+            &runtime,
+        );
+
+        assert_eq!(
+            artifact.url,
+            "https://cran.example/src/contrib/digest_0.6.38.tar.gz"
+        );
+        assert!(fallback.is_none());
+        assert_eq!(install_kind, crate::ui::InstallKind::Source);
+        assert_eq!(install_type, "source");
     }
 
     #[test]

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -13,12 +13,36 @@ pub struct Lockfile {
     pub registry: String,
     #[serde(default = "default_true", skip_serializing_if = "is_true")]
     pub use_default_repository: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub repositories: Vec<LockedRepository>,
     #[serde(default)]
     pub r: LockedR,
     #[serde(default)]
     pub sysreqs: LockedSystemRequirements,
     pub roots: Vec<LockedRoot>,
     pub packages: BTreeMap<String, LockedPackage>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone)]
+pub struct LockedRepository {
+    pub url: String,
+    pub kind: LockedRepositoryKind,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cran_archive_support: Option<LockedCranArchiveSupport>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
+#[serde(rename_all = "kebab-case")]
+pub enum LockedRepositoryKind {
+    Rrepo,
+    CranLike,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
+#[serde(rename_all = "kebab-case")]
+pub enum LockedCranArchiveSupport {
+    Available,
+    Unavailable,
 }
 
 fn default_true() -> bool {
@@ -101,7 +125,8 @@ mod tests {
     use std::collections::BTreeMap;
 
     use super::{
-        LOCKFILE_REVISION, LOCKFILE_VERSION, LockedDependency, LockedPackage, LockedR, LockedRoot,
+        LOCKFILE_REVISION, LOCKFILE_VERSION, LockedCranArchiveSupport, LockedDependency,
+        LockedPackage, LockedR, LockedRepository, LockedRepositoryKind, LockedRoot,
         LockedSystemRequirements, Lockfile,
     };
 
@@ -112,6 +137,7 @@ mod tests {
             revision: LOCKFILE_REVISION,
             registry: "https://api.rrepo.org".to_string(),
             use_default_repository: true,
+            repositories: vec![],
             r: LockedR {
                 version: "4.4.1".to_string(),
                 base_packages: vec!["utils".to_string()],
@@ -168,6 +194,7 @@ mod tests {
             revision: LOCKFILE_REVISION,
             registry: "https://api.rrepo.org".to_string(),
             use_default_repository: false,
+            repositories: vec![],
             r: LockedR::default(),
             sysreqs: LockedSystemRequirements::default(),
             roots: vec![],
@@ -177,6 +204,30 @@ mod tests {
         let json = serde_json::to_string_pretty(&lockfile).expect("lockfile should serialize");
 
         assert!(json.contains("\"use_default_repository\": false"));
+    }
+
+    #[test]
+    fn round_trips_repository_metadata() {
+        let lockfile = Lockfile {
+            version: LOCKFILE_VERSION,
+            revision: LOCKFILE_REVISION,
+            registry: "https://api.rrepo.org".to_string(),
+            use_default_repository: true,
+            repositories: vec![LockedRepository {
+                url: "https://cran.example".to_string(),
+                kind: LockedRepositoryKind::CranLike,
+                cran_archive_support: Some(LockedCranArchiveSupport::Unavailable),
+            }],
+            r: LockedR::default(),
+            sysreqs: LockedSystemRequirements::default(),
+            roots: vec![],
+            packages: BTreeMap::new(),
+        };
+
+        let json = serde_json::to_string(&lockfile).expect("lockfile should serialize");
+        let parsed: Lockfile = serde_json::from_str(&json).expect("lockfile should parse");
+
+        assert_eq!(parsed.repositories, lockfile.repositories);
     }
 
     #[test]

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, fs};
 
 pub const LOCKFILE_VERSION: u32 = 3;
-pub const LOCKFILE_REVISION: u32 = 0;
+pub const LOCKFILE_REVISION: u32 = 1;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Lockfile {
@@ -11,12 +11,22 @@ pub struct Lockfile {
     #[serde(default)]
     pub revision: u32,
     pub registry: String,
+    #[serde(default = "default_true", skip_serializing_if = "is_true")]
+    pub use_default_repository: bool,
     #[serde(default)]
     pub r: LockedR,
     #[serde(default)]
     pub sysreqs: LockedSystemRequirements,
     pub roots: Vec<LockedRoot>,
     pub packages: BTreeMap<String, LockedPackage>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+fn is_true(value: &bool) -> bool {
+    *value
 }
 
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -101,6 +111,7 @@ mod tests {
             version: LOCKFILE_VERSION,
             revision: LOCKFILE_REVISION,
             registry: "https://api.rrepo.org".to_string(),
+            use_default_repository: true,
             r: LockedR {
                 version: "4.4.1".to_string(),
                 base_packages: vec!["utils".to_string()],
@@ -136,7 +147,7 @@ mod tests {
         let json = serde_json::to_string_pretty(&lockfile).expect("lockfile should serialize");
 
         assert!(json.contains("\"version\": 3"));
-        assert!(json.contains("\"revision\": 0"));
+        assert!(json.contains("\"revision\": 1"));
         assert!(json.contains("\"registry\": \"https://api.rrepo.org\""));
         assert!(json.contains("\"r\""));
         assert!(json.contains("\"sysreqs\""));
@@ -145,8 +156,27 @@ mod tests {
         assert!(json.contains("\"roots\""));
         assert!(json.contains("\"source_url\""));
         assert!(json.contains("\"dependencies\""));
+        assert!(!json.contains("\"use_default_repository\""));
         assert!(!json.contains("\"repositories\""));
         assert!(!json.contains("\"repository\""));
+    }
+
+    #[test]
+    fn serializes_disabled_default_repository_setting() {
+        let lockfile = Lockfile {
+            version: LOCKFILE_VERSION,
+            revision: LOCKFILE_REVISION,
+            registry: "https://api.rrepo.org".to_string(),
+            use_default_repository: false,
+            r: LockedR::default(),
+            sysreqs: LockedSystemRequirements::default(),
+            roots: vec![],
+            packages: BTreeMap::new(),
+        };
+
+        let json = serde_json::to_string_pretty(&lockfile).expect("lockfile should serialize");
+
+        assert!(json.contains("\"use_default_repository\": false"));
     }
 
     #[test]
@@ -178,6 +208,7 @@ mod tests {
 
         assert_eq!(lockfile.r, LockedR::default());
         assert_eq!(lockfile.sysreqs, LockedSystemRequirements::default());
+        assert!(lockfile.use_default_repository);
     }
 
     #[test]

--- a/src/r_version.rs
+++ b/src/r_version.rs
@@ -1,0 +1,45 @@
+use std::cmp::Ordering;
+
+pub(crate) fn r_version_components(version: &str) -> Result<Vec<u32>, String> {
+    version
+        .split(['.', '-'])
+        .map(|part| {
+            if part.is_empty() {
+                return Err(format!("invalid version {version}"));
+            }
+
+            part.parse::<u32>()
+                .map_err(|_| format!("invalid version {version}"))
+        })
+        .collect()
+}
+
+pub(crate) fn compare_r_versions(left: &str, right: &str) -> Ordering {
+    match (r_version_components(left), r_version_components(right)) {
+        (Ok(left), Ok(right)) => compare_version_components(&left, &right),
+        _ => left.cmp(right),
+    }
+}
+
+pub(crate) fn compare_version_components(left: &[u32], right: &[u32]) -> Ordering {
+    for (left, right) in left.iter().zip(right) {
+        match left.cmp(right) {
+            Ordering::Equal => continue,
+            ordering => return ordering,
+        }
+    }
+
+    left.len().cmp(&right.len())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::compare_r_versions;
+
+    #[test]
+    fn compares_r_versions_numerically() {
+        assert!(compare_r_versions("1.10", "1.2").is_gt());
+        assert!(compare_r_versions("1.2-1", "1.2").is_gt());
+        assert!(compare_r_versions("2.0.0", "1.99.99").is_gt());
+    }
+}

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -11,11 +11,13 @@ use std::{
     hash::{Hash, Hasher},
     io::{self, IsTerminal, Read},
     path::{Path, PathBuf},
-    sync::{Arc, mpsc},
+    sync::Arc,
 };
 use tar::Archive;
+use tokio::task::JoinSet;
 
 use crate::project::cache_dir_path;
+use crate::r_version::compare_r_versions;
 
 const KEYRING_SERVICE: &str = "rpx";
 
@@ -323,7 +325,11 @@ impl RepositorySet {
         let packages = index
             .into_iter()
             .filter_map(|(name, versions)| {
-                let latest_version = versions.last()?.version.clone();
+                let latest_version = versions
+                    .iter()
+                    .max_by(|left, right| compare_r_versions(&left.version, &right.version))?
+                    .version
+                    .clone();
                 Some(RepositoryPackageSummary {
                     name,
                     latest_version,
@@ -637,7 +643,7 @@ fn fetch_cran_like_current_index(
     }
 
     for versions in index.values_mut() {
-        versions.sort_by(|left, right| left.version.cmp(&right.version));
+        sort_version_summaries(versions);
     }
 
     Ok(index)
@@ -761,8 +767,12 @@ fn fetch_cran_like_archive_versions(
             })
         })
         .collect::<Vec<_>>();
-    versions.sort_by(|left, right| left.version.cmp(&right.version));
+    sort_version_summaries(&mut versions);
     Ok(CranLikePackageArchive::Available(versions))
+}
+
+fn sort_version_summaries(versions: &mut [VersionSummary]) {
+    versions.sort_by(|left, right| compare_r_versions(&left.version, &right.version));
 }
 
 fn versions_for_package(
@@ -794,9 +804,12 @@ fn package_versions_response(
         return Err(missing_package_error(package));
     }
 
+    let mut versions = by_version.into_values().collect::<Vec<_>>();
+    sort_version_summaries(&mut versions);
+
     Ok(PackageVersionsResponse {
         package: package.to_string(),
-        versions: by_version.into_values().collect(),
+        versions,
     })
 }
 
@@ -839,27 +852,33 @@ fn fetch_description_from_cran_like_tarballs(
         DescriptionCandidate::tarball(current_url, package, version),
         DescriptionCandidate::tarball(archive_url, package, version),
     ];
-    let candidate_count = candidates.len();
-    let (tx, rx) = mpsc::channel();
+    tokio::runtime::Runtime::new()
+        .map_err(|error| format!("failed to start DESCRIPTION fetch runtime: {error}"))?
+        .block_on(fetch_first_description_candidate(candidates))
+}
 
+async fn fetch_first_description_candidate(
+    candidates: [DescriptionCandidate; 3],
+) -> Result<String, String> {
+    let mut tasks = JoinSet::new();
     for candidate in candidates {
-        let tx = tx.clone();
-        std::thread::spawn(move || {
+        tasks.spawn(async move {
             let url = candidate.url.clone();
-            let result = candidate.fetch();
-            let _ = tx.send((url, result));
+            (url, candidate.fetch_async().await)
         });
     }
-    drop(tx);
 
     let mut errors = Vec::new();
-    for _ in 0..candidate_count {
-        match rx.recv() {
-            Ok((_, Ok(description))) => return Ok(description),
+    while let Some(result) = tasks.join_next().await {
+        match result {
+            Ok((_, Ok(description))) => {
+                tasks.abort_all();
+                return Ok(description);
+            }
             Ok((url, Err(error))) => errors.push((url, error)),
             Err(error) => errors.push((
                 "DESCRIPTION worker".to_string(),
-                format!("failed to receive DESCRIPTION result: {error}"),
+                format!("failed to join DESCRIPTION result: {error}"),
             )),
         }
     }
@@ -898,13 +917,14 @@ impl DescriptionCandidate {
         }
     }
 
-    fn fetch(self) -> Result<String, String> {
+    async fn fetch_async(self) -> Result<String, String> {
         match self.kind {
             DescriptionCandidateKind::Direct => {
-                fetch_description_from_direct_url(&self.url, &self.package, &self.version)
+                fetch_description_from_direct_url_async(&self.url, &self.package, &self.version)
+                    .await
             }
             DescriptionCandidateKind::Tarball => {
-                fetch_description_from_tarball(&self.url, &self.package, &self.version)
+                fetch_description_from_tarball_async(&self.url, &self.package, &self.version).await
             }
         }
     }
@@ -994,25 +1014,28 @@ fn html_unescape_minimal(value: &str) -> String {
         .replace("&quot;", "\"")
 }
 
-fn fetch_description_from_direct_url(
+async fn fetch_description_from_direct_url_async(
     url: &str,
     package: &str,
     version: &str,
 ) -> Result<String, String> {
-    let response = reqwest::blocking::get(url)
+    let response = reqwest::get(url)
+        .await
         .map_err(|error| format!("failed to download DESCRIPTION: {error}"))?;
     let status = response.status();
     if !status.is_success() {
-        return Err(unexpected_cran_like_response(response));
+        return Err(unexpected_cran_like_response_async(response).await);
     }
 
     let description = response
         .text()
+        .await
         .map_err(|error| format!("failed to read DESCRIPTION: {error}"))?;
     validate_description(&description, package, version, url)?;
     Ok(description)
 }
 
+#[cfg(test)]
 fn fetch_description_from_tarball(
     url: &str,
     package: &str,
@@ -1028,7 +1051,36 @@ fn fetch_description_from_tarball(
     let bytes = response
         .bytes()
         .map_err(|error| format!("failed to read source package for DESCRIPTION: {error}"))?;
-    let decoder = GzDecoder::new(bytes.as_ref());
+    description_from_tarball_bytes(bytes.as_ref(), url, package, version)
+}
+
+async fn fetch_description_from_tarball_async(
+    url: &str,
+    package: &str,
+    version: &str,
+) -> Result<String, String> {
+    let response = reqwest::get(url)
+        .await
+        .map_err(|error| format!("failed to download source package for DESCRIPTION: {error}"))?;
+    let status = response.status();
+    if !status.is_success() {
+        return Err(unexpected_cran_like_response_async(response).await);
+    }
+
+    let bytes = response
+        .bytes()
+        .await
+        .map_err(|error| format!("failed to read source package for DESCRIPTION: {error}"))?;
+    description_from_tarball_bytes(bytes.as_ref(), url, package, version)
+}
+
+fn description_from_tarball_bytes(
+    bytes: &[u8],
+    url: &str,
+    package: &str,
+    version: &str,
+) -> Result<String, String> {
+    let decoder = GzDecoder::new(bytes);
     let mut archive = Archive::new(decoder);
     let entries = archive
         .entries()
@@ -1120,6 +1172,18 @@ fn write_text_cache(path: &Path, value: &str) {
 fn unexpected_cran_like_response(response: reqwest::blocking::Response) -> String {
     let status = response.status();
     let body = response.text().unwrap_or_default();
+    let body = body.trim();
+
+    if body.is_empty() {
+        return format!("unexpected registry response ({status})");
+    }
+
+    format!("unexpected registry response ({status}): {body}")
+}
+
+async fn unexpected_cran_like_response_async(response: reqwest::Response) -> String {
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
     let body = body.trim();
 
     if body.is_empty() {

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -1,21 +1,34 @@
 use crate::output::try_prompt;
 use crate::registry::{
-    PackageVersionsResponse, RegistryClient, RepositoryPackagesResponse, is_not_found_error,
-    is_unauthorized_error,
+    PackageVersionsResponse, RegistryClient, RepositoryPackageSummary, RepositoryPackagesResponse,
+    VersionSummary, is_not_found_error, is_unauthorized_error,
 };
+use flate2::read::GzDecoder;
 use keyring::Entry;
 use std::{
-    collections::{BTreeSet, hash_map::DefaultHasher},
+    collections::{BTreeMap, BTreeSet, hash_map::DefaultHasher},
+    fs,
     hash::{Hash, Hasher},
-    io::{self, IsTerminal},
+    io::{self, IsTerminal, Read},
+    path::{Path, PathBuf},
     sync::Arc,
 };
+use tar::Archive;
+
+use crate::project::cache_dir_path;
 
 const KEYRING_SERVICE: &str = "rpx";
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RepositorySource {
     base_url: String,
+    kind: RepositoryKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum RepositoryKind {
+    Rrepo,
+    CranLike,
 }
 
 #[derive(Debug, Clone)]
@@ -45,6 +58,9 @@ pub struct RepositorySet {
     sources: Vec<RepositorySource>,
     credentials: Arc<dyn CredentialStore>,
     prompter: Arc<dyn ApiKeyPrompter>,
+    cran_current_indexes:
+        Arc<std::sync::Mutex<BTreeMap<String, BTreeMap<String, Vec<VersionSummary>>>>>,
+    cran_archive_unavailable: Arc<std::sync::Mutex<BTreeSet<String>>>,
 }
 
 impl std::fmt::Debug for RepositorySet {
@@ -57,8 +73,17 @@ impl std::fmt::Debug for RepositorySet {
 
 impl RepositorySource {
     pub fn new(base_url: impl AsRef<str>) -> Self {
+        Self::with_kind(base_url, RepositoryKind::Rrepo)
+    }
+
+    pub fn cran_like(base_url: impl AsRef<str>) -> Self {
+        Self::with_kind(base_url, RepositoryKind::CranLike)
+    }
+
+    pub fn with_kind(base_url: impl AsRef<str>, kind: RepositoryKind) -> Self {
         Self {
             base_url: normalize_repository_url(base_url.as_ref()),
+            kind,
         }
     }
 
@@ -66,8 +91,19 @@ impl RepositorySource {
         &self.base_url
     }
 
+    pub fn kind(&self) -> RepositoryKind {
+        self.kind
+    }
+
     pub fn matches_source_url(&self, url: &str) -> bool {
-        url.starts_with(self.base_url())
+        if !url.starts_with(self.base_url()) {
+            return false;
+        }
+
+        match self.kind {
+            RepositoryKind::Rrepo => !url.contains("/src/contrib/"),
+            RepositoryKind::CranLike => url.contains("/src/contrib/"),
+        }
     }
 }
 
@@ -89,7 +125,7 @@ impl RepositorySet {
         let mut seen = BTreeSet::new();
 
         for source in sources {
-            if seen.insert(source.base_url.clone()) {
+            if seen.insert((source.base_url.clone(), source.kind)) {
                 deduped.push(source);
             }
         }
@@ -98,6 +134,8 @@ impl RepositorySet {
             sources: deduped,
             credentials,
             prompter,
+            cran_current_indexes: Arc::new(std::sync::Mutex::new(BTreeMap::new())),
+            cran_archive_unavailable: Arc::new(std::sync::Mutex::new(BTreeSet::new())),
         }
     }
 
@@ -109,7 +147,12 @@ impl RepositorySet {
         &self,
         source: &RepositorySource,
     ) -> Result<RepositoryPackagesResponse, String> {
-        self.with_authorized_client(source, |client| client.fetch_repository_packages())
+        match source.kind() {
+            RepositoryKind::Rrepo => {
+                self.with_authorized_client(source, |client| client.fetch_repository_packages())
+            }
+            RepositoryKind::CranLike => self.fetch_cran_like_repository_packages(source),
+        }
     }
 
     pub fn fetch_package_versions_with_retry(
@@ -117,9 +160,14 @@ impl RepositorySet {
         package: &str,
     ) -> Result<SourcedPackageVersions, String> {
         for source in &self.sources {
-            match self.with_authorized_client(source, |client| {
-                client.fetch_package_versions_with_retry(package)
-            }) {
+            let result = match source.kind() {
+                RepositoryKind::Rrepo => self.with_authorized_client(source, |client| {
+                    client.fetch_package_versions_with_retry(package)
+                }),
+                RepositoryKind::CranLike => self.fetch_cran_like_package_versions(source, package),
+            };
+
+            match result {
                 Ok(response) => {
                     return Ok(SourcedPackageVersions {
                         source: source.clone(),
@@ -142,9 +190,12 @@ impl RepositorySet {
         package: &str,
         version: &str,
     ) -> Result<String, String> {
-        self.with_authorized_client(source, |client| {
-            client.fetch_description_with_retry(package, version)
-        })
+        match source.kind() {
+            RepositoryKind::Rrepo => self.with_authorized_client(source, |client| {
+                client.fetch_description_with_retry(package, version)
+            }),
+            RepositoryKind::CranLike => self.fetch_cran_like_description(source, package, version),
+        }
     }
 
     pub fn download_artifact_with_progress(
@@ -175,6 +226,127 @@ impl RepositorySet {
             .max_by_key(|source| source.base_url().len())
             .cloned()
             .or_else(|| repository_source_from_package_url(url).map(RepositorySource::new))
+            .or_else(|| cran_like_source_from_package_url(url).map(RepositorySource::cran_like))
+    }
+
+    pub fn cran_archive_unavailable_repositories(&self) -> Vec<String> {
+        self.cran_archive_unavailable
+            .lock()
+            .expect("CRAN-like archive availability should lock")
+            .iter()
+            .cloned()
+            .collect()
+    }
+
+    fn fetch_cran_like_repository_packages(
+        &self,
+        source: &RepositorySource,
+    ) -> Result<RepositoryPackagesResponse, String> {
+        let index = self.cran_like_current_index(source)?;
+        let packages = index
+            .into_iter()
+            .filter_map(|(name, versions)| {
+                let latest_version = versions.last()?.version.clone();
+                Some(RepositoryPackageSummary {
+                    name,
+                    latest_version,
+                    latest_uploaded_at: String::new(),
+                    versions: versions
+                        .into_iter()
+                        .map(|version| version.version)
+                        .collect(),
+                })
+            })
+            .collect();
+
+        Ok(RepositoryPackagesResponse {
+            repository_slug: source.base_url().to_string(),
+            packages,
+        })
+    }
+
+    fn fetch_cran_like_package_versions(
+        &self,
+        source: &RepositorySource,
+        package: &str,
+    ) -> Result<PackageVersionsResponse, String> {
+        let mut by_version = BTreeMap::new();
+
+        for version in self
+            .cran_like_current_index(source)?
+            .remove(package)
+            .unwrap_or_default()
+        {
+            by_version.insert(version.version.clone(), version);
+        }
+
+        match fetch_cran_like_archive_versions(source, package) {
+            Ok(versions) => {
+                for version in versions {
+                    by_version.entry(version.version.clone()).or_insert(version);
+                }
+            }
+            Err(CranLikeArchiveError::Unavailable) => {
+                self.cran_archive_unavailable
+                    .lock()
+                    .expect("CRAN-like archive availability should lock")
+                    .insert(source.base_url().to_string());
+            }
+            Err(CranLikeArchiveError::Failed(error)) => return Err(error),
+        }
+
+        if by_version.is_empty() {
+            return Err(missing_package_error(package));
+        }
+
+        Ok(PackageVersionsResponse {
+            package: package.to_string(),
+            versions: by_version.into_values().collect(),
+        })
+    }
+
+    fn cran_like_current_index(
+        &self,
+        source: &RepositorySource,
+    ) -> Result<BTreeMap<String, Vec<VersionSummary>>, String> {
+        let mut indexes = self
+            .cran_current_indexes
+            .lock()
+            .expect("CRAN-like current index cache should lock");
+
+        if let Some(index) = indexes.get(source.base_url()) {
+            return Ok(index.clone());
+        }
+
+        let index = fetch_cran_like_current_index(source)?;
+        indexes.insert(source.base_url().to_string(), index.clone());
+        Ok(index)
+    }
+
+    fn fetch_cran_like_description(
+        &self,
+        source: &RepositorySource,
+        package: &str,
+        version: &str,
+    ) -> Result<String, String> {
+        let path = cran_like_description_cache_path(source, package, version);
+        if let Ok(description) = fs::read_to_string(&path) {
+            if description_declares_package(&description, package) {
+                return Ok(description);
+            }
+            let _ = fs::remove_file(&path);
+        }
+
+        let versions = self.fetch_cran_like_package_versions(source, package)?;
+        let tarball_url = versions
+            .versions
+            .into_iter()
+            .find(|candidate| candidate.version == version)
+            .map(|candidate| candidate.source_url)
+            .ok_or_else(|| missing_package_error(package))?;
+        let description = fetch_description_from_tarball(&tarball_url, package)?;
+        write_text_cache(&path, &description);
+        Ok(description)
     }
 
     fn with_authorized_client<T>(
@@ -278,6 +450,288 @@ pub fn repository_source_from_package_url(url: &str) -> Option<String> {
     Some(normalize_repository_url(&url[..index]))
 }
 
+pub fn cran_like_source_from_package_url(url: &str) -> Option<String> {
+    let marker = "/src/contrib/";
+    let index = url.find(marker)?;
+    Some(normalize_repository_url(&url[..index]))
+}
+
+fn fetch_cran_like_current_index(
+    source: &RepositorySource,
+) -> Result<BTreeMap<String, Vec<VersionSummary>>, String> {
+    let url = format!("{}/src/contrib/PACKAGES", source.base_url());
+    let body = reqwest::blocking::get(&url)
+        .map_err(|error| format!("failed to contact CRAN-like repository: {error}"))?;
+    let status = body.status();
+    if !status.is_success() {
+        return Err(unexpected_cran_like_response(body));
+    }
+
+    let body = body
+        .text()
+        .map_err(|error| format!("failed to read CRAN-like PACKAGES index: {error}"))?;
+    let mut index: BTreeMap<String, Vec<VersionSummary>> = BTreeMap::new();
+
+    for record in parse_dcf_records(&body) {
+        let Some(package) = record.get("Package").filter(|value| !value.is_empty()) else {
+            continue;
+        };
+        let Some(version) = record.get("Version").filter(|value| !value.is_empty()) else {
+            continue;
+        };
+
+        index
+            .entry(package.to_string())
+            .or_default()
+            .push(VersionSummary {
+                version: version.to_string(),
+                source_url: cran_like_current_tarball_url(source, package, version),
+            });
+    }
+
+    for versions in index.values_mut() {
+        versions.sort_by(|left, right| left.version.cmp(&right.version));
+    }
+
+    Ok(index)
+}
+
+#[derive(Debug)]
+enum CranLikeArchiveError {
+    Unavailable,
+    Failed(String),
+}
+
+fn fetch_cran_like_archive_versions(
+    source: &RepositorySource,
+    package: &str,
+) -> Result<Vec<VersionSummary>, CranLikeArchiveError> {
+    let url = format!("{}/src/contrib/Archive/{package}/", source.base_url());
+    let response = reqwest::blocking::get(&url).map_err(|_| CranLikeArchiveError::Unavailable)?;
+    let status = response.status();
+    if status == reqwest::StatusCode::NOT_FOUND || status == reqwest::StatusCode::FORBIDDEN {
+        return Err(CranLikeArchiveError::Unavailable);
+    }
+    if !status.is_success() {
+        return Err(CranLikeArchiveError::Failed(unexpected_cran_like_response(
+            response,
+        )));
+    }
+
+    let body = response.text().map_err(|error| {
+        CranLikeArchiveError::Failed(format!("failed to read CRAN-like archive listing: {error}"))
+    })?;
+    let mut versions = tarball_file_names_from_listing(&body)
+        .into_iter()
+        .filter_map(|file_name| {
+            parse_cran_tarball_file_name(&file_name).and_then(|(name, version)| {
+                (name == package).then(|| VersionSummary {
+                    version: version.to_string(),
+                    source_url: cran_like_archive_tarball_url(source, package, version),
+                })
+            })
+        })
+        .collect::<Vec<_>>();
+    versions.sort_by(|left, right| left.version.cmp(&right.version));
+    Ok(versions)
+}
+
+fn cran_like_current_tarball_url(
+    source: &RepositorySource,
+    package: &str,
+    version: &str,
+) -> String {
+    format!(
+        "{}/src/contrib/{package}_{version}.tar.gz",
+        source.base_url()
+    )
+}
+
+fn cran_like_archive_tarball_url(
+    source: &RepositorySource,
+    package: &str,
+    version: &str,
+) -> String {
+    format!(
+        "{}/src/contrib/Archive/{package}/{package}_{version}.tar.gz",
+        source.base_url()
+    )
+}
+
+fn parse_dcf_records(input: &str) -> Vec<BTreeMap<String, String>> {
+    let mut records = Vec::new();
+    let mut record: BTreeMap<String, String> = BTreeMap::new();
+    let mut current_key: Option<String> = None;
+
+    for line in input.lines() {
+        if line.trim().is_empty() {
+            if !record.is_empty() {
+                records.push(record);
+                record = BTreeMap::new();
+                current_key = None;
+            }
+            continue;
+        }
+
+        if line.starts_with(' ') || line.starts_with('\t') {
+            if let Some(key) = &current_key
+                && let Some(value) = record.get_mut(key)
+            {
+                value.push(' ');
+                value.push_str(line.trim());
+            }
+            continue;
+        }
+
+        let Some((key, value)) = line.split_once(':') else {
+            current_key = None;
+            continue;
+        };
+        let key = key.trim().to_string();
+        record.insert(key.clone(), value.trim().to_string());
+        current_key = Some(key);
+    }
+
+    if !record.is_empty() {
+        records.push(record);
+    }
+
+    records
+}
+
+fn tarball_file_names_from_listing(listing: &str) -> Vec<String> {
+    listing
+        .split(['"', '\'', '<', '>', ' ', '\n', '\r', '\t'])
+        .filter_map(|part| part.rsplit('/').next())
+        .filter(|part| part.ends_with(".tar.gz") && part.contains('_'))
+        .map(html_unescape_minimal)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
+fn parse_cran_tarball_file_name(file_name: &str) -> Option<(&str, &str)> {
+    let stem = file_name.strip_suffix(".tar.gz")?;
+    let (package, version) = stem.rsplit_once('_')?;
+    if package.is_empty() || version.is_empty() {
+        return None;
+    }
+    Some((package, version))
+}
+
+fn html_unescape_minimal(value: &str) -> String {
+    value
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+}
+
+fn fetch_description_from_tarball(url: &str, package: &str) -> Result<String, String> {
+    let response = reqwest::blocking::get(url)
+        .map_err(|error| format!("failed to download source package for DESCRIPTION: {error}"))?;
+    let status = response.status();
+    if !status.is_success() {
+        return Err(unexpected_cran_like_response(response));
+    }
+
+    let bytes = response
+        .bytes()
+        .map_err(|error| format!("failed to read source package for DESCRIPTION: {error}"))?;
+    let decoder = GzDecoder::new(bytes.as_ref());
+    let mut archive = Archive::new(decoder);
+    let entries = archive
+        .entries()
+        .map_err(|error| format!("failed to read source package archive: {error}"))?;
+
+    for entry in entries {
+        let mut entry = entry.map_err(|error| format!("failed to read archive entry: {error}"))?;
+        let is_description = {
+            let path = entry
+                .path()
+                .map_err(|error| format!("failed to read archive entry path: {error}"))?;
+            path_is_top_level_description(&path, package)
+        };
+        if !is_description {
+            continue;
+        }
+
+        let mut description = String::new();
+        entry
+            .read_to_string(&mut description)
+            .map_err(|error| format!("failed to read DESCRIPTION from source package: {error}"))?;
+        if description.trim().is_empty() {
+            return Err(format!(
+                "source package {url} contains an empty DESCRIPTION"
+            ));
+        }
+        if !description_declares_package(&description, package) {
+            return Err(format!(
+                "source package {url} DESCRIPTION does not describe package {package}"
+            ));
+        }
+        return Ok(description);
+    }
+
+    Err(format!(
+        "source package {url} does not contain {package}/DESCRIPTION"
+    ))
+}
+
+fn path_is_top_level_description(path: &Path, package: &str) -> bool {
+    let mut components = path.components().filter_map(|component| {
+        let component = component.as_os_str().to_str()?;
+        (component != ".").then_some(component)
+    });
+
+    components.next() == Some(package)
+        && components.next() == Some("DESCRIPTION")
+        && components.next().is_none()
+}
+
+fn description_declares_package(description: &str, package: &str) -> bool {
+    parse_dcf_records(description)
+        .first()
+        .and_then(|record| record.get("Package"))
+        .is_some_and(|name| name == package)
+}
+
+fn cran_like_description_cache_path(
+    source: &RepositorySource,
+    package: &str,
+    version: &str,
+) -> PathBuf {
+    cache_dir_path()
+        .join("cran-like")
+        .join(hash_string(source.base_url()))
+        .join("descriptions")
+        .join(package)
+        .join(format!("{version}.dcf"))
+}
+
+fn write_text_cache(path: &Path, value: &str) {
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+    let _ = fs::write(path, value);
+}
+
+fn unexpected_cran_like_response(response: reqwest::blocking::Response) -> String {
+    let status = response.status();
+    let body = response.text().unwrap_or_default();
+    let body = body.trim();
+
+    if body.is_empty() {
+        return format!("unexpected registry response ({status})");
+    }
+
+    format!("unexpected registry response ({status}): {body}")
+}
+
+fn missing_package_error(package: &str) -> String {
+    format!("unexpected registry response (404 Not Found): package {package} not found")
+}
+
 fn keyring_entry(source: &RepositorySource) -> Result<Entry, String> {
     Entry::new(KEYRING_SERVICE, &keyring_account_name(source))
         .map_err(|error| format!("failed to access local keyring: {error}"))
@@ -296,8 +750,9 @@ fn hash_string(value: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use flate2::{Compression, write::GzEncoder};
     use mockito::Server;
-    use std::{collections::BTreeMap, sync::Mutex};
+    use std::{collections::BTreeMap, io::Write as _, sync::Mutex};
 
     #[derive(Default)]
     struct MemoryCredentialStore {
@@ -353,6 +808,17 @@ mod tests {
             )
             .as_deref(),
             Some("https://scalerail.rrepo.dev/test")
+        );
+    }
+
+    #[test]
+    fn derives_cran_like_repository_source_from_package_url() {
+        assert_eq!(
+            cran_like_source_from_package_url(
+                "https://cran.example/src/contrib/Archive/digest/digest_0.6.37.tar.gz"
+            )
+            .as_deref(),
+            Some("https://cran.example")
         );
     }
 
@@ -445,5 +911,206 @@ mod tests {
         additional_mock.assert();
         assert_eq!(result.source.base_url(), default_server.url());
         assert_eq!(result.response.versions[0].version, "0.6.37");
+    }
+
+    #[test]
+    fn fetches_cran_like_versions_from_current_and_archive_listings() {
+        let mut server = Server::new();
+        let current_mock = server
+            .mock("GET", "/src/contrib/PACKAGES")
+            .with_status(200)
+            .with_header("content-type", "text/plain")
+            .with_body(
+                r#"Package: digest
+Version: 0.6.38
+
+Package: rlang
+Version: 1.1.6
+"#,
+            )
+            .expect(1)
+            .create();
+        let archive_mock = server
+            .mock("GET", "/src/contrib/Archive/digest/")
+            .with_status(200)
+            .with_header("content-type", "text/html")
+            .with_body(
+                r#"<a href="digest_0.6.37.tar.gz">digest_0.6.37.tar.gz</a>
+<a href="digest_0.6.38.tar.gz">digest_0.6.38.tar.gz</a>"#,
+            )
+            .expect(1)
+            .create();
+        let source = RepositorySource::cran_like(server.url());
+        let repositories = RepositorySet::with_support(
+            vec![source.clone()],
+            Arc::new(MemoryCredentialStore::default()),
+            Arc::new(StaticPrompter {
+                token: "secret".to_string(),
+            }),
+        );
+
+        let result = repositories
+            .fetch_package_versions_with_retry("digest")
+            .expect("CRAN-like versions should resolve");
+
+        current_mock.assert();
+        archive_mock.assert();
+        assert_eq!(result.source.kind(), RepositoryKind::CranLike);
+        assert_eq!(
+            result
+                .response
+                .versions
+                .iter()
+                .map(|version| version.version.as_str())
+                .collect::<Vec<_>>(),
+            vec!["0.6.37", "0.6.38"]
+        );
+        assert_eq!(
+            result.response.versions[1].source_url,
+            format!("{}/src/contrib/digest_0.6.38.tar.gz", server.url())
+        );
+    }
+
+    #[test]
+    fn resolves_cran_like_current_versions_when_archive_listing_is_unavailable() {
+        let mut server = Server::new();
+        let current_mock = server
+            .mock("GET", "/src/contrib/PACKAGES")
+            .with_status(200)
+            .with_header("content-type", "text/plain")
+            .with_body("Package: digest\nVersion: 0.6.38\n")
+            .expect(1)
+            .create();
+        let archive_mock = server
+            .mock("GET", "/src/contrib/Archive/digest/")
+            .with_status(404)
+            .expect(1)
+            .create();
+        let source = RepositorySource::cran_like(server.url());
+        let repositories = RepositorySet::with_support(
+            vec![source.clone()],
+            Arc::new(MemoryCredentialStore::default()),
+            Arc::new(StaticPrompter {
+                token: "secret".to_string(),
+            }),
+        );
+
+        let result = repositories
+            .fetch_package_versions_with_retry("digest")
+            .expect("CRAN-like versions should resolve");
+
+        current_mock.assert();
+        archive_mock.assert();
+        assert_eq!(result.response.versions[0].version, "0.6.38");
+        assert_eq!(
+            repositories.cran_archive_unavailable_repositories(),
+            vec![server.url()]
+        );
+    }
+
+    #[test]
+    fn fetches_cran_like_description_from_source_tarball() {
+        let mut server = Server::new();
+        let current_mock = server
+            .mock("GET", "/src/contrib/PACKAGES")
+            .with_status(200)
+            .with_header("content-type", "text/plain")
+            .with_body("Package: digest\nVersion: 0.6.38\n")
+            .expect(1)
+            .create();
+        let archive_mock = server
+            .mock("GET", "/src/contrib/Archive/digest/")
+            .with_status(404)
+            .expect(1)
+            .create();
+        let tarball_mock = server
+            .mock("GET", "/src/contrib/digest_0.6.38.tar.gz")
+            .with_status(200)
+            .with_header("content-type", "application/gzip")
+            .with_body(source_tarball(
+                "digest",
+                "Package: digest\nVersion: 0.6.38\nImports: utils\n",
+            ))
+            .expect(1)
+            .create();
+        let source = RepositorySource::cran_like(server.url());
+        write_text_cache(
+            &cran_like_description_cache_path(&source, "digest", "0.6.38"),
+            "",
+        );
+        let repositories = RepositorySet::with_support(
+            vec![source.clone()],
+            Arc::new(MemoryCredentialStore::default()),
+            Arc::new(StaticPrompter {
+                token: "secret".to_string(),
+            }),
+        );
+
+        let description = repositories
+            .fetch_description_with_retry(&source, "digest", "0.6.38")
+            .expect("DESCRIPTION should be extracted");
+
+        current_mock.assert();
+        archive_mock.assert();
+        tarball_mock.assert();
+        assert!(description.contains("Package: digest"));
+        assert!(description.contains("Imports: utils"));
+    }
+
+    #[test]
+    fn fetches_cran_like_description_from_top_level_source_tarball_entry() {
+        let mut server = Server::new();
+        let current_mock = server
+            .mock("GET", "/src/contrib/rprojroot_2.1.1.tar.gz")
+            .with_status(200)
+            .with_header("content-type", "application/gzip")
+            .with_body(source_tarball_entries(&[
+                ("rprojroot/tests/testthat/package/DESCRIPTION", ""),
+                (
+                    "rprojroot/tests/testthat/hierarchy/DESCRIPTION",
+                    "Package: hierarchy\nVersion: 0.0-0\n",
+                ),
+                (
+                    "rprojroot/DESCRIPTION",
+                    "Package: rprojroot\nVersion: 2.1.1\nDepends: R (>= 3.0.0)\n",
+                ),
+            ]))
+            .expect(1)
+            .create();
+
+        let description = fetch_description_from_tarball(
+            &format!("{}/src/contrib/rprojroot_2.1.1.tar.gz", server.url()),
+            "rprojroot",
+        )
+        .expect("top-level DESCRIPTION should be extracted");
+
+        current_mock.assert();
+        assert!(description.contains("Package: rprojroot"));
+        assert!(!description.contains("Package: hierarchy"));
+    }
+
+    fn source_tarball(package: &str, description: &str) -> Vec<u8> {
+        source_tarball_entries(&[(&format!("{package}/DESCRIPTION"), description)])
+    }
+
+    fn source_tarball_entries(entries: &[(&str, &str)]) -> Vec<u8> {
+        let mut tar = Vec::new();
+        {
+            let mut builder = tar::Builder::new(&mut tar);
+            for (path, description) in entries {
+                let mut header = tar::Header::new_gnu();
+                header.set_size(description.len() as u64);
+                header.set_mode(0o644);
+                header.set_cksum();
+                builder
+                    .append_data(&mut header, path, description.as_bytes())
+                    .expect("DESCRIPTION should be written to tarball");
+            }
+            builder.finish().expect("tarball should finish");
+        }
+
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&tar).expect("tarball should gzip");
+        encoder.finish().expect("gzip should finish")
     }
 }

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -23,6 +23,7 @@ const KEYRING_SERVICE: &str = "rpx";
 pub struct RepositorySource {
     base_url: String,
     kind: RepositoryKind,
+    cran_archive_support: Option<CranArchiveSupport>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -85,6 +86,18 @@ impl RepositorySource {
         Self {
             base_url: normalize_repository_url(base_url.as_ref()),
             kind,
+            cran_archive_support: None,
+        }
+    }
+
+    pub(crate) fn cran_like_with_archive_support(
+        base_url: impl AsRef<str>,
+        support: CranArchiveSupport,
+    ) -> Self {
+        Self {
+            base_url: normalize_repository_url(base_url.as_ref()),
+            kind: RepositoryKind::CranLike,
+            cran_archive_support: Some(support),
         }
     }
 
@@ -94,6 +107,10 @@ impl RepositorySource {
 
     pub fn kind(&self) -> RepositoryKind {
         self.kind
+    }
+
+    pub(crate) fn cran_archive_support(&self) -> Option<CranArchiveSupport> {
+        self.cran_archive_support
     }
 
     pub fn matches_source_url(&self, url: &str) -> bool {
@@ -138,14 +155,30 @@ impl RepositorySet {
                 deduped.push(source);
             }
         }
+        let cran_archive_listing_support = deduped
+            .iter()
+            .filter_map(|source| {
+                source
+                    .cran_archive_support()
+                    .map(|support| (source.base_url().to_string(), support))
+            })
+            .collect::<BTreeMap<_, _>>();
+        let cran_archive_unavailable = cran_archive_listing_support
+            .iter()
+            .filter_map(|(url, support)| {
+                (*support == CranArchiveSupport::Unavailable).then_some(url.clone())
+            })
+            .collect::<BTreeSet<_>>();
 
         Self {
             sources: deduped,
             credentials,
             prompter,
             cran_current_indexes: Arc::new(std::sync::Mutex::new(BTreeMap::new())),
-            cran_archive_unavailable: Arc::new(std::sync::Mutex::new(BTreeSet::new())),
-            cran_archive_listing_support: Arc::new(std::sync::Mutex::new(BTreeMap::new())),
+            cran_archive_unavailable: Arc::new(std::sync::Mutex::new(cran_archive_unavailable)),
+            cran_archive_listing_support: Arc::new(std::sync::Mutex::new(
+                cran_archive_listing_support,
+            )),
         }
     }
 
@@ -654,8 +687,8 @@ enum CranLikeArchiveError {
     Failed(String),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum CranArchiveSupport {
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum CranArchiveSupport {
     Available,
     Unavailable,
 }
@@ -683,6 +716,16 @@ fn fetch_cran_like_archive_listing_available(
     }
 
     Ok(true)
+}
+
+pub(crate) fn detect_cran_like_archive_support(
+    source: &RepositorySource,
+) -> Result<CranArchiveSupport, String> {
+    match fetch_cran_like_archive_listing_available(source) {
+        Ok(true) => Ok(CranArchiveSupport::Available),
+        Ok(false) | Err(CranLikeArchiveError::Unavailable) => Ok(CranArchiveSupport::Unavailable),
+        Err(CranLikeArchiveError::Failed(error)) => Err(error),
+    }
 }
 
 fn fetch_cran_like_archive_versions(
@@ -1333,6 +1376,49 @@ Version: 1.1.6
             result.response.versions[1].source_url,
             format!("{}/src/contrib/digest_0.6.38.tar.gz", server.url())
         );
+    }
+
+    #[test]
+    fn uses_preclassified_cran_archive_support_for_package_versions() {
+        let mut server = Server::new();
+        let current_mock = server
+            .mock("GET", "/src/contrib/PACKAGES")
+            .with_status(200)
+            .with_header("content-type", "text/plain")
+            .with_body("Package: digest\nVersion: 0.6.38\n")
+            .expect(1)
+            .create();
+        let root_archive_mock = server
+            .mock("GET", "/src/contrib/Archive/")
+            .with_status(200)
+            .expect(0)
+            .create();
+        let package_archive_mock = server
+            .mock("GET", "/src/contrib/Archive/digest/")
+            .with_status(200)
+            .with_body(r#"<a href="digest_0.6.37.tar.gz">digest_0.6.37.tar.gz</a>"#)
+            .expect(1)
+            .create();
+        let source = RepositorySource::cran_like_with_archive_support(
+            server.url(),
+            CranArchiveSupport::Available,
+        );
+        let repositories = RepositorySet::with_support(
+            vec![source],
+            Arc::new(MemoryCredentialStore::default()),
+            Arc::new(StaticPrompter {
+                token: "secret".to_string(),
+            }),
+        );
+
+        let result = repositories
+            .fetch_package_versions_with_retry("digest")
+            .expect("digest should resolve");
+
+        assert_eq!(result.response.versions.len(), 2);
+        current_mock.assert();
+        root_archive_mock.assert();
+        package_archive_mock.assert();
     }
 
     #[test]

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -103,8 +103,16 @@ impl RepositorySource {
         }
 
         match self.kind {
-            RepositoryKind::Rrepo => !url.contains("/src/contrib/"),
-            RepositoryKind::CranLike => url.contains("/src/contrib/"),
+            RepositoryKind::Rrepo => {
+                !url.contains("/src/contrib/")
+                    && !url.contains("/bin/windows/")
+                    && !url.contains("/bin/macosx/")
+            }
+            RepositoryKind::CranLike => {
+                url.contains("/src/contrib/")
+                    || url.contains("/bin/windows/")
+                    || url.contains("/bin/macosx/")
+            }
         }
     }
 }

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -165,6 +165,7 @@ impl RepositorySet {
         }
     }
 
+    #[cfg(test)]
     pub fn fetch_package_versions_with_retry(
         &self,
         package: &str,
@@ -192,6 +193,39 @@ impl RepositorySet {
         Err(format!(
             "unexpected registry response (404 Not Found): package {package} not found"
         ))
+    }
+
+    pub fn fetch_all_package_versions_with_retry(
+        &self,
+        package: &str,
+    ) -> Result<Vec<SourcedPackageVersions>, String> {
+        let mut responses = Vec::new();
+
+        for source in &self.sources {
+            let result = match source.kind() {
+                RepositoryKind::Rrepo => self.with_authorized_client(source, |client| {
+                    client.fetch_package_versions_with_retry(package)
+                }),
+                RepositoryKind::CranLike => self.fetch_cran_like_package_versions(source, package),
+            };
+
+            match result {
+                Ok(response) => responses.push(SourcedPackageVersions {
+                    source: source.clone(),
+                    response,
+                }),
+                Err(error) if is_not_found_error(&error) => continue,
+                Err(error) => return Err(error),
+            }
+        }
+
+        if responses.is_empty() {
+            return Err(format!(
+                "unexpected registry response (404 Not Found): package {package} not found"
+            ));
+        }
+
+        Ok(responses)
     }
 
     pub fn fetch_description_with_retry(

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -961,9 +961,7 @@ fn combine_description_errors(errors: Vec<(String, String)>) -> String {
         .map(|(url, error)| format!("{url}: {error}"))
         .collect::<Vec<_>>()
         .join("; ");
-    format!(
-        "failed to fetch DESCRIPTION from direct, current, or archive source package ({details})"
-    )
+    format!("failed to fetch DESCRIPTION from any candidate location ({details})")
 }
 
 fn parse_dcf_records(input: &str) -> Vec<BTreeMap<String, String>> {
@@ -1139,13 +1137,11 @@ fn validate_description(
     url: &str,
 ) -> Result<(), String> {
     if description.trim().is_empty() {
-        return Err(format!(
-            "source package {url} contains an empty DESCRIPTION"
-        ));
+        return Err(format!("DESCRIPTION at {url} is empty"));
     }
     if !description_declares_package_version(description, package, version) {
         return Err(format!(
-            "source package {url} DESCRIPTION does not describe package {package} {version}"
+            "DESCRIPTION at {url} does not describe package {package} {version}"
         ));
     }
     Ok(())

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -62,7 +62,6 @@ pub struct RepositorySet {
         Arc<std::sync::Mutex<BTreeMap<String, BTreeMap<String, Vec<VersionSummary>>>>>,
     cran_archive_unavailable: Arc<std::sync::Mutex<BTreeSet<String>>>,
     cran_archive_listing_support: Arc<std::sync::Mutex<BTreeMap<String, CranArchiveSupport>>>,
-    unavailable_rrepo_sources: Arc<std::sync::Mutex<BTreeSet<String>>>,
 }
 
 impl std::fmt::Debug for RepositorySet {
@@ -147,7 +146,6 @@ impl RepositorySet {
             cran_current_indexes: Arc::new(std::sync::Mutex::new(BTreeMap::new())),
             cran_archive_unavailable: Arc::new(std::sync::Mutex::new(BTreeSet::new())),
             cran_archive_listing_support: Arc::new(std::sync::Mutex::new(BTreeMap::new())),
-            unavailable_rrepo_sources: Arc::new(std::sync::Mutex::new(BTreeSet::new())),
         }
     }
 
@@ -172,16 +170,6 @@ impl RepositorySet {
         package: &str,
     ) -> Result<SourcedPackageVersions, String> {
         for source in &self.sources {
-            if source.kind() == RepositoryKind::Rrepo
-                && self
-                    .unavailable_rrepo_sources
-                    .lock()
-                    .expect("unavailable rrepo cache should lock")
-                    .contains(source.base_url())
-            {
-                continue;
-            }
-
             let result = match source.kind() {
                 RepositoryKind::Rrepo => self.with_authorized_client(source, |client| {
                     client.fetch_package_versions_with_retry(package)
@@ -195,15 +183,6 @@ impl RepositorySet {
                         source: source.clone(),
                         response,
                     });
-                }
-                Err(error)
-                    if source.kind() == RepositoryKind::Rrepo && is_not_found_error(&error) =>
-                {
-                    self.unavailable_rrepo_sources
-                        .lock()
-                        .expect("unavailable rrepo cache should lock")
-                        .insert(source.base_url().to_string());
-                    continue;
                 }
                 Err(error) if is_not_found_error(&error) => continue,
                 Err(error) => return Err(error),
@@ -1323,7 +1302,7 @@ Version: 1.1.6
     }
 
     #[test]
-    fn skips_rrepo_candidate_after_not_found_for_same_repository_base() {
+    fn keeps_querying_rrepo_after_package_not_found() {
         let mut server = Server::new();
         let digest_rrepo_mock = server
             .mock("GET", "/packages/digest/versions")
@@ -1332,43 +1311,40 @@ Version: 1.1.6
             .create();
         let rlang_rrepo_mock = server
             .mock("GET", "/packages/rlang/versions")
-            .with_status(404)
-            .expect(0)
-            .create();
-        let current_mock = server
-            .mock("GET", "/src/contrib/PACKAGES")
             .with_status(200)
-            .with_header("content-type", "text/plain")
-            .with_body("Package: digest\nVersion: 0.6.38\n\nPackage: rlang\nVersion: 1.1.6\n")
-            .expect(1)
-            .create();
-        let archive_mock = server
-            .mock("GET", "/src/contrib/Archive/")
-            .with_status(404)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{
+  "package": "rlang",
+  "versions": [
+    {
+      "version": "1.1.6",
+      "sourceUrl": "https://example.test/packages/rlang/versions/1.1.6/source"
+    }
+  ]
+}"#,
+            )
             .expect(1)
             .create();
         let repositories = RepositorySet::with_support(
-            vec![
-                RepositorySource::new(server.url()),
-                RepositorySource::cran_like(server.url()),
-            ],
+            vec![RepositorySource::new(server.url())],
             Arc::new(MemoryCredentialStore::default()),
             Arc::new(StaticPrompter {
                 token: "secret".to_string(),
             }),
         );
 
-        repositories
+        let result = repositories
             .fetch_package_versions_with_retry("digest")
-            .expect("digest should resolve from CRAN-like source");
-        repositories
+            .expect_err("digest should remain missing");
+        assert!(is_not_found_error(&result));
+        let result = repositories
             .fetch_package_versions_with_retry("rlang")
-            .expect("rlang should resolve from CRAN-like source");
+            .expect("rlang should resolve from rrepo source");
+        assert_eq!(result.response.versions[0].version, "1.1.6");
 
         digest_rrepo_mock.assert();
         rlang_rrepo_mock.assert();
-        current_mock.assert();
-        archive_mock.assert();
     }
 
     #[test]

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -11,7 +11,7 @@ use std::{
     hash::{Hash, Hasher},
     io::{self, IsTerminal, Read},
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, mpsc},
 };
 use tar::Archive;
 
@@ -61,6 +61,8 @@ pub struct RepositorySet {
     cran_current_indexes:
         Arc<std::sync::Mutex<BTreeMap<String, BTreeMap<String, Vec<VersionSummary>>>>>,
     cran_archive_unavailable: Arc<std::sync::Mutex<BTreeSet<String>>>,
+    cran_archive_listing_support: Arc<std::sync::Mutex<BTreeMap<String, CranArchiveSupport>>>,
+    unavailable_rrepo_sources: Arc<std::sync::Mutex<BTreeSet<String>>>,
 }
 
 impl std::fmt::Debug for RepositorySet {
@@ -136,6 +138,8 @@ impl RepositorySet {
             prompter,
             cran_current_indexes: Arc::new(std::sync::Mutex::new(BTreeMap::new())),
             cran_archive_unavailable: Arc::new(std::sync::Mutex::new(BTreeSet::new())),
+            cran_archive_listing_support: Arc::new(std::sync::Mutex::new(BTreeMap::new())),
+            unavailable_rrepo_sources: Arc::new(std::sync::Mutex::new(BTreeSet::new())),
         }
     }
 
@@ -160,6 +164,16 @@ impl RepositorySet {
         package: &str,
     ) -> Result<SourcedPackageVersions, String> {
         for source in &self.sources {
+            if source.kind() == RepositoryKind::Rrepo
+                && self
+                    .unavailable_rrepo_sources
+                    .lock()
+                    .expect("unavailable rrepo cache should lock")
+                    .contains(source.base_url())
+            {
+                continue;
+            }
+
             let result = match source.kind() {
                 RepositoryKind::Rrepo => self.with_authorized_client(source, |client| {
                     client.fetch_package_versions_with_retry(package)
@@ -173,6 +187,15 @@ impl RepositorySet {
                         source: source.clone(),
                         response,
                     });
+                }
+                Err(error)
+                    if source.kind() == RepositoryKind::Rrepo && is_not_found_error(&error) =>
+                {
+                    self.unavailable_rrepo_sources
+                        .lock()
+                        .expect("unavailable rrepo cache should lock")
+                        .insert(source.base_url().to_string());
+                    continue;
                 }
                 Err(error) if is_not_found_error(&error) => continue,
                 Err(error) => return Err(error),
@@ -270,6 +293,22 @@ impl RepositorySet {
         source: &RepositorySource,
         package: &str,
     ) -> Result<PackageVersionsResponse, String> {
+        match self.cran_archive_support(source) {
+            Some(CranArchiveSupport::Unavailable) => {
+                self.cran_versions_without_archive(source, package)
+            }
+            Some(CranArchiveSupport::Available) => {
+                self.cran_versions_with_known_archive(source, package)
+            }
+            None => self.cran_versions_with_unknown_archive(source, package),
+        }
+    }
+
+    fn cran_versions_without_archive(
+        &self,
+        source: &RepositorySource,
+        package: &str,
+    ) -> Result<PackageVersionsResponse, String> {
         let mut by_version = BTreeMap::new();
 
         for version in self
@@ -280,29 +319,100 @@ impl RepositorySet {
             by_version.insert(version.version.clone(), version);
         }
 
-        match fetch_cran_like_archive_versions(source, package) {
-            Ok(versions) => {
-                for version in versions {
-                    by_version.entry(version.version.clone()).or_insert(version);
-                }
+        package_versions_response(package, by_version)
+    }
+
+    fn cran_versions_with_known_archive(
+        &self,
+        source: &RepositorySource,
+        package: &str,
+    ) -> Result<PackageVersionsResponse, String> {
+        let (index, archive) = std::thread::scope(|scope| {
+            let current = scope.spawn(|| self.cran_like_current_index(source));
+            let archive = scope.spawn(|| fetch_cran_like_archive_versions(source, package));
+            (
+                current
+                    .join()
+                    .expect("current index worker should not panic"),
+                archive.join().expect("archive worker should not panic"),
+            )
+        });
+        let mut by_version = versions_for_package(index?, package);
+
+        match archive {
+            Ok(CranLikePackageArchive::Available(versions)) => {
+                merge_versions(&mut by_version, versions)
             }
-            Err(CranLikeArchiveError::Unavailable) => {
-                self.cran_archive_unavailable
-                    .lock()
-                    .expect("CRAN-like archive availability should lock")
-                    .insert(source.base_url().to_string());
-            }
+            Ok(CranLikePackageArchive::Missing) | Err(CranLikeArchiveError::Unavailable) => {}
             Err(CranLikeArchiveError::Failed(error)) => return Err(error),
         }
 
-        if by_version.is_empty() {
-            return Err(missing_package_error(package));
+        package_versions_response(package, by_version)
+    }
+
+    fn cran_versions_with_unknown_archive(
+        &self,
+        source: &RepositorySource,
+        package: &str,
+    ) -> Result<PackageVersionsResponse, String> {
+        let (index, root_archive, package_archive) = std::thread::scope(|scope| {
+            let current = scope.spawn(|| self.cran_like_current_index(source));
+            let root_archive = scope.spawn(|| fetch_cran_like_archive_listing_available(source));
+            let package_archive = scope.spawn(|| fetch_cran_like_archive_versions(source, package));
+            (
+                current
+                    .join()
+                    .expect("current index worker should not panic"),
+                root_archive
+                    .join()
+                    .expect("archive support worker should not panic"),
+                package_archive
+                    .join()
+                    .expect("archive package worker should not panic"),
+            )
+        });
+        let mut by_version = versions_for_package(index?, package);
+
+        match (&root_archive, &package_archive) {
+            (_, Ok(CranLikePackageArchive::Available(_))) => {
+                self.record_cran_archive_support(source, CranArchiveSupport::Available);
+            }
+            (Ok(false), _) | (Err(CranLikeArchiveError::Unavailable), _) => {
+                self.record_cran_archive_support(source, CranArchiveSupport::Unavailable);
+            }
+            (Err(CranLikeArchiveError::Failed(error)), _) => return Err(error.clone()),
+            (Ok(true), Err(CranLikeArchiveError::Failed(error))) => return Err(error.clone()),
+            (Ok(true), _) => {
+                self.record_cran_archive_support(source, CranArchiveSupport::Available);
+            }
         }
 
-        Ok(PackageVersionsResponse {
-            package: package.to_string(),
-            versions: by_version.into_values().collect(),
-        })
+        if let Ok(CranLikePackageArchive::Available(versions)) = package_archive {
+            merge_versions(&mut by_version, versions);
+        }
+
+        package_versions_response(package, by_version)
+    }
+
+    fn cran_archive_support(&self, source: &RepositorySource) -> Option<CranArchiveSupport> {
+        self.cran_archive_listing_support
+            .lock()
+            .expect("CRAN-like archive listing support should lock")
+            .get(source.base_url())
+            .copied()
+    }
+
+    fn record_cran_archive_support(&self, source: &RepositorySource, support: CranArchiveSupport) {
+        self.cran_archive_listing_support
+            .lock()
+            .expect("CRAN-like archive listing support should lock")
+            .insert(source.base_url().to_string(), support);
+        if support == CranArchiveSupport::Unavailable {
+            self.cran_archive_unavailable
+                .lock()
+                .expect("CRAN-like archive availability should lock")
+                .insert(source.base_url().to_string());
+        }
     }
 
     fn cran_like_current_index(
@@ -331,20 +441,13 @@ impl RepositorySet {
     ) -> Result<String, String> {
         let path = cran_like_description_cache_path(source, package, version);
         if let Ok(description) = fs::read_to_string(&path) {
-            if description_declares_package(&description, package) {
+            if description_declares_package_version(&description, package, version) {
                 return Ok(description);
             }
             let _ = fs::remove_file(&path);
         }
 
-        let versions = self.fetch_cran_like_package_versions(source, package)?;
-        let tarball_url = versions
-            .versions
-            .into_iter()
-            .find(|candidate| candidate.version == version)
-            .map(|candidate| candidate.source_url)
-            .ok_or_else(|| missing_package_error(package))?;
-        let description = fetch_description_from_tarball(&tarball_url, package)?;
+        let description = fetch_description_from_cran_like_tarballs(source, package, version)?;
         write_text_cache(&path, &description);
         Ok(description)
     }
@@ -459,17 +562,7 @@ pub fn cran_like_source_from_package_url(url: &str) -> Option<String> {
 fn fetch_cran_like_current_index(
     source: &RepositorySource,
 ) -> Result<BTreeMap<String, Vec<VersionSummary>>, String> {
-    let url = format!("{}/src/contrib/PACKAGES", source.base_url());
-    let body = reqwest::blocking::get(&url)
-        .map_err(|error| format!("failed to contact CRAN-like repository: {error}"))?;
-    let status = body.status();
-    if !status.is_success() {
-        return Err(unexpected_cran_like_response(body));
-    }
-
-    let body = body
-        .text()
-        .map_err(|error| format!("failed to read CRAN-like PACKAGES index: {error}"))?;
+    let body = fetch_cran_like_packages_index(source)?;
     let mut index: BTreeMap<String, Vec<VersionSummary>> = BTreeMap::new();
 
     for record in parse_dcf_records(&body) {
@@ -496,20 +589,92 @@ fn fetch_cran_like_current_index(
     Ok(index)
 }
 
+fn fetch_cran_like_packages_index(source: &RepositorySource) -> Result<String, String> {
+    fetch_cran_like_packages_gz_index(source)
+        .or_else(|_| fetch_cran_like_packages_plain_index(source))
+}
+
+fn fetch_cran_like_packages_gz_index(source: &RepositorySource) -> Result<String, String> {
+    let url = format!("{}/src/contrib/PACKAGES.gz", source.base_url());
+    let response = reqwest::blocking::get(&url)
+        .map_err(|error| format!("failed to contact CRAN-like repository: {error}"))?;
+    let status = response.status();
+    if !status.is_success() {
+        return Err(unexpected_cran_like_response(response));
+    }
+
+    let bytes = response
+        .bytes()
+        .map_err(|error| format!("failed to read CRAN-like PACKAGES.gz index: {error}"))?;
+    let mut decoder = GzDecoder::new(bytes.as_ref());
+    let mut body = String::new();
+    decoder
+        .read_to_string(&mut body)
+        .map_err(|error| format!("failed to decompress CRAN-like PACKAGES.gz index: {error}"))?;
+    Ok(body)
+}
+
+fn fetch_cran_like_packages_plain_index(source: &RepositorySource) -> Result<String, String> {
+    let url = format!("{}/src/contrib/PACKAGES", source.base_url());
+    let body = reqwest::blocking::get(&url)
+        .map_err(|error| format!("failed to contact CRAN-like repository: {error}"))?;
+    let status = body.status();
+    if !status.is_success() {
+        return Err(unexpected_cran_like_response(body));
+    }
+
+    body.text()
+        .map_err(|error| format!("failed to read CRAN-like PACKAGES index: {error}"))
+}
+
 #[derive(Debug)]
 enum CranLikeArchiveError {
     Unavailable,
     Failed(String),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CranArchiveSupport {
+    Available,
+    Unavailable,
+}
+
+#[derive(Debug)]
+enum CranLikePackageArchive {
+    Available(Vec<VersionSummary>),
+    Missing,
+}
+
+fn fetch_cran_like_archive_listing_available(
+    source: &RepositorySource,
+) -> Result<bool, CranLikeArchiveError> {
+    let url = format!("{}/src/contrib/Archive/", source.base_url());
+    let response = reqwest::blocking::get(&url).map_err(|_| CranLikeArchiveError::Unavailable)?;
+    let status = response.status();
+
+    if status == reqwest::StatusCode::NOT_FOUND || status == reqwest::StatusCode::FORBIDDEN {
+        return Ok(false);
+    }
+    if !status.is_success() {
+        return Err(CranLikeArchiveError::Failed(unexpected_cran_like_response(
+            response,
+        )));
+    }
+
+    Ok(true)
+}
+
 fn fetch_cran_like_archive_versions(
     source: &RepositorySource,
     package: &str,
-) -> Result<Vec<VersionSummary>, CranLikeArchiveError> {
+) -> Result<CranLikePackageArchive, CranLikeArchiveError> {
     let url = format!("{}/src/contrib/Archive/{package}/", source.base_url());
     let response = reqwest::blocking::get(&url).map_err(|_| CranLikeArchiveError::Unavailable)?;
     let status = response.status();
-    if status == reqwest::StatusCode::NOT_FOUND || status == reqwest::StatusCode::FORBIDDEN {
+    if status == reqwest::StatusCode::NOT_FOUND {
+        return Ok(CranLikePackageArchive::Missing);
+    }
+    if status == reqwest::StatusCode::FORBIDDEN {
         return Err(CranLikeArchiveError::Unavailable);
     }
     if !status.is_success() {
@@ -533,7 +698,42 @@ fn fetch_cran_like_archive_versions(
         })
         .collect::<Vec<_>>();
     versions.sort_by(|left, right| left.version.cmp(&right.version));
-    Ok(versions)
+    Ok(CranLikePackageArchive::Available(versions))
+}
+
+fn versions_for_package(
+    mut index: BTreeMap<String, Vec<VersionSummary>>,
+    package: &str,
+) -> BTreeMap<String, VersionSummary> {
+    index
+        .remove(package)
+        .unwrap_or_default()
+        .into_iter()
+        .map(|version| (version.version.clone(), version))
+        .collect()
+}
+
+fn merge_versions(
+    by_version: &mut BTreeMap<String, VersionSummary>,
+    versions: Vec<VersionSummary>,
+) {
+    for version in versions {
+        by_version.entry(version.version.clone()).or_insert(version);
+    }
+}
+
+fn package_versions_response(
+    package: &str,
+    by_version: BTreeMap<String, VersionSummary>,
+) -> Result<PackageVersionsResponse, String> {
+    if by_version.is_empty() {
+        return Err(missing_package_error(package));
+    }
+
+    Ok(PackageVersionsResponse {
+        package: package.to_string(),
+        versions: by_version.into_values().collect(),
+    })
 }
 
 fn cran_like_current_tarball_url(
@@ -555,6 +755,109 @@ fn cran_like_archive_tarball_url(
     format!(
         "{}/src/contrib/Archive/{package}/{package}_{version}.tar.gz",
         source.base_url()
+    )
+}
+
+fn cran_like_current_description_url(source: &RepositorySource, package: &str) -> String {
+    format!("{}/web/packages/{package}/DESCRIPTION", source.base_url())
+}
+
+fn fetch_description_from_cran_like_tarballs(
+    source: &RepositorySource,
+    package: &str,
+    version: &str,
+) -> Result<String, String> {
+    let current_url = cran_like_current_tarball_url(source, package, version);
+    let archive_url = cran_like_archive_tarball_url(source, package, version);
+    let direct_url = cran_like_current_description_url(source, package);
+    let candidates = [
+        DescriptionCandidate::direct(direct_url, package, version),
+        DescriptionCandidate::tarball(current_url, package, version),
+        DescriptionCandidate::tarball(archive_url, package, version),
+    ];
+    let candidate_count = candidates.len();
+    let (tx, rx) = mpsc::channel();
+
+    for candidate in candidates {
+        let tx = tx.clone();
+        std::thread::spawn(move || {
+            let url = candidate.url.clone();
+            let result = candidate.fetch();
+            let _ = tx.send((url, result));
+        });
+    }
+    drop(tx);
+
+    let mut errors = Vec::new();
+    for _ in 0..candidate_count {
+        match rx.recv() {
+            Ok((_, Ok(description))) => return Ok(description),
+            Ok((url, Err(error))) => errors.push((url, error)),
+            Err(error) => errors.push((
+                "DESCRIPTION worker".to_string(),
+                format!("failed to receive DESCRIPTION result: {error}"),
+            )),
+        }
+    }
+
+    Err(combine_description_errors(errors))
+}
+
+struct DescriptionCandidate {
+    url: String,
+    package: String,
+    version: String,
+    kind: DescriptionCandidateKind,
+}
+
+enum DescriptionCandidateKind {
+    Direct,
+    Tarball,
+}
+
+impl DescriptionCandidate {
+    fn direct(url: String, package: &str, version: &str) -> Self {
+        Self {
+            url,
+            package: package.to_string(),
+            version: version.to_string(),
+            kind: DescriptionCandidateKind::Direct,
+        }
+    }
+
+    fn tarball(url: String, package: &str, version: &str) -> Self {
+        Self {
+            url,
+            package: package.to_string(),
+            version: version.to_string(),
+            kind: DescriptionCandidateKind::Tarball,
+        }
+    }
+
+    fn fetch(self) -> Result<String, String> {
+        match self.kind {
+            DescriptionCandidateKind::Direct => {
+                fetch_description_from_direct_url(&self.url, &self.package, &self.version)
+            }
+            DescriptionCandidateKind::Tarball => {
+                fetch_description_from_tarball(&self.url, &self.package, &self.version)
+            }
+        }
+    }
+}
+
+fn combine_description_errors(errors: Vec<(String, String)>) -> String {
+    if let Some((_, error)) = errors.iter().find(|(_, error)| !is_not_found_error(error)) {
+        return error.clone();
+    }
+
+    let details = errors
+        .into_iter()
+        .map(|(url, error)| format!("{url}: {error}"))
+        .collect::<Vec<_>>()
+        .join("; ");
+    format!(
+        "failed to fetch DESCRIPTION from direct, current, or archive source package ({details})"
     )
 }
 
@@ -627,7 +930,30 @@ fn html_unescape_minimal(value: &str) -> String {
         .replace("&quot;", "\"")
 }
 
-fn fetch_description_from_tarball(url: &str, package: &str) -> Result<String, String> {
+fn fetch_description_from_direct_url(
+    url: &str,
+    package: &str,
+    version: &str,
+) -> Result<String, String> {
+    let response = reqwest::blocking::get(url)
+        .map_err(|error| format!("failed to download DESCRIPTION: {error}"))?;
+    let status = response.status();
+    if !status.is_success() {
+        return Err(unexpected_cran_like_response(response));
+    }
+
+    let description = response
+        .text()
+        .map_err(|error| format!("failed to read DESCRIPTION: {error}"))?;
+    validate_description(&description, package, version, url)?;
+    Ok(description)
+}
+
+fn fetch_description_from_tarball(
+    url: &str,
+    package: &str,
+    version: &str,
+) -> Result<String, String> {
     let response = reqwest::blocking::get(url)
         .map_err(|error| format!("failed to download source package for DESCRIPTION: {error}"))?;
     let status = response.status();
@@ -660,22 +986,32 @@ fn fetch_description_from_tarball(url: &str, package: &str) -> Result<String, St
         entry
             .read_to_string(&mut description)
             .map_err(|error| format!("failed to read DESCRIPTION from source package: {error}"))?;
-        if description.trim().is_empty() {
-            return Err(format!(
-                "source package {url} contains an empty DESCRIPTION"
-            ));
-        }
-        if !description_declares_package(&description, package) {
-            return Err(format!(
-                "source package {url} DESCRIPTION does not describe package {package}"
-            ));
-        }
+        validate_description(&description, package, version, url)?;
         return Ok(description);
     }
 
     Err(format!(
         "source package {url} does not contain {package}/DESCRIPTION"
     ))
+}
+
+fn validate_description(
+    description: &str,
+    package: &str,
+    version: &str,
+    url: &str,
+) -> Result<(), String> {
+    if description.trim().is_empty() {
+        return Err(format!(
+            "source package {url} contains an empty DESCRIPTION"
+        ));
+    }
+    if !description_declares_package_version(description, package, version) {
+        return Err(format!(
+            "source package {url} DESCRIPTION does not describe package {package} {version}"
+        ));
+    }
+    Ok(())
 }
 
 fn path_is_top_level_description(path: &Path, package: &str) -> bool {
@@ -689,11 +1025,12 @@ fn path_is_top_level_description(path: &Path, package: &str) -> bool {
         && components.next().is_none()
 }
 
-fn description_declares_package(description: &str, package: &str) -> bool {
-    parse_dcf_records(description)
-        .first()
-        .and_then(|record| record.get("Package"))
-        .is_some_and(|name| name == package)
+fn description_declares_package_version(description: &str, package: &str, version: &str) -> bool {
+    let Some(record) = parse_dcf_records(description).into_iter().next() else {
+        return false;
+    };
+    record.get("Package").is_some_and(|name| name == package)
+        && record.get("Version").is_some_and(|value| value == version)
 }
 
 fn cran_like_description_cache_path(
@@ -931,6 +1268,11 @@ Version: 1.1.6
             .expect(1)
             .create();
         let archive_mock = server
+            .mock("GET", "/src/contrib/Archive/")
+            .with_status(200)
+            .expect(1)
+            .create();
+        let package_archive_mock = server
             .mock("GET", "/src/contrib/Archive/digest/")
             .with_status(200)
             .with_header("content-type", "text/html")
@@ -955,6 +1297,7 @@ Version: 1.1.6
 
         current_mock.assert();
         archive_mock.assert();
+        package_archive_mock.assert();
         assert_eq!(result.source.kind(), RepositoryKind::CranLike);
         assert_eq!(
             result
@@ -972,6 +1315,55 @@ Version: 1.1.6
     }
 
     #[test]
+    fn skips_rrepo_candidate_after_not_found_for_same_repository_base() {
+        let mut server = Server::new();
+        let digest_rrepo_mock = server
+            .mock("GET", "/packages/digest/versions")
+            .with_status(404)
+            .expect(1)
+            .create();
+        let rlang_rrepo_mock = server
+            .mock("GET", "/packages/rlang/versions")
+            .with_status(404)
+            .expect(0)
+            .create();
+        let current_mock = server
+            .mock("GET", "/src/contrib/PACKAGES")
+            .with_status(200)
+            .with_header("content-type", "text/plain")
+            .with_body("Package: digest\nVersion: 0.6.38\n\nPackage: rlang\nVersion: 1.1.6\n")
+            .expect(1)
+            .create();
+        let archive_mock = server
+            .mock("GET", "/src/contrib/Archive/")
+            .with_status(404)
+            .expect(1)
+            .create();
+        let repositories = RepositorySet::with_support(
+            vec![
+                RepositorySource::new(server.url()),
+                RepositorySource::cran_like(server.url()),
+            ],
+            Arc::new(MemoryCredentialStore::default()),
+            Arc::new(StaticPrompter {
+                token: "secret".to_string(),
+            }),
+        );
+
+        repositories
+            .fetch_package_versions_with_retry("digest")
+            .expect("digest should resolve from CRAN-like source");
+        repositories
+            .fetch_package_versions_with_retry("rlang")
+            .expect("rlang should resolve from CRAN-like source");
+
+        digest_rrepo_mock.assert();
+        rlang_rrepo_mock.assert();
+        current_mock.assert();
+        archive_mock.assert();
+    }
+
+    #[test]
     fn resolves_cran_like_current_versions_when_archive_listing_is_unavailable() {
         let mut server = Server::new();
         let current_mock = server
@@ -982,7 +1374,7 @@ Version: 1.1.6
             .expect(1)
             .create();
         let archive_mock = server
-            .mock("GET", "/src/contrib/Archive/digest/")
+            .mock("GET", "/src/contrib/Archive/")
             .with_status(404)
             .expect(1)
             .create();
@@ -1012,18 +1404,6 @@ Version: 1.1.6
     fn fetches_cran_like_description_from_source_tarball() {
         let mut server = Server::new();
         let current_mock = server
-            .mock("GET", "/src/contrib/PACKAGES")
-            .with_status(200)
-            .with_header("content-type", "text/plain")
-            .with_body("Package: digest\nVersion: 0.6.38\n")
-            .expect(1)
-            .create();
-        let archive_mock = server
-            .mock("GET", "/src/contrib/Archive/digest/")
-            .with_status(404)
-            .expect(1)
-            .create();
-        let tarball_mock = server
             .mock("GET", "/src/contrib/digest_0.6.38.tar.gz")
             .with_status(200)
             .with_header("content-type", "application/gzip")
@@ -1032,6 +1412,10 @@ Version: 1.1.6
                 "Package: digest\nVersion: 0.6.38\nImports: utils\n",
             ))
             .expect(1)
+            .create();
+        let _archive_mock = server
+            .mock("GET", "/src/contrib/Archive/digest/digest_0.6.38.tar.gz")
+            .with_status(404)
             .create();
         let source = RepositorySource::cran_like(server.url());
         write_text_cache(
@@ -1051,10 +1435,71 @@ Version: 1.1.6
             .expect("DESCRIPTION should be extracted");
 
         current_mock.assert();
-        archive_mock.assert();
-        tarball_mock.assert();
         assert!(description.contains("Package: digest"));
         assert!(description.contains("Imports: utils"));
+    }
+
+    #[test]
+    fn fetches_cran_like_description_from_direct_endpoint() {
+        let mut server = Server::new();
+        let direct_mock = server
+            .mock("GET", "/web/packages/digest/DESCRIPTION")
+            .with_status(200)
+            .with_header("content-type", "text/plain")
+            .with_body("Package: digest\nVersion: 0.6.38\nImports: utils\n")
+            .expect(1)
+            .create();
+        let source = RepositorySource::cran_like(server.url());
+        let repositories = RepositorySet::with_support(
+            vec![source.clone()],
+            Arc::new(MemoryCredentialStore::default()),
+            Arc::new(StaticPrompter {
+                token: "secret".to_string(),
+            }),
+        );
+
+        let description = repositories
+            .fetch_description_with_retry(&source, "digest", "0.6.38")
+            .expect("direct DESCRIPTION should be used");
+
+        direct_mock.assert();
+        assert!(description.contains("Package: digest"));
+        assert!(description.contains("Version: 0.6.38"));
+    }
+
+    #[test]
+    fn fetches_cran_like_description_from_archive_tarball() {
+        let mut server = Server::new();
+        let _current_mock = server
+            .mock("GET", "/src/contrib/digest_0.6.37.tar.gz")
+            .with_status(404)
+            .create();
+        let archive_mock = server
+            .mock("GET", "/src/contrib/Archive/digest/digest_0.6.37.tar.gz")
+            .with_status(200)
+            .with_header("content-type", "application/gzip")
+            .with_body(source_tarball(
+                "digest",
+                "Package: digest\nVersion: 0.6.37\nImports: utils\n",
+            ))
+            .expect(1)
+            .create();
+        let source = RepositorySource::cran_like(server.url());
+        let repositories = RepositorySet::with_support(
+            vec![source.clone()],
+            Arc::new(MemoryCredentialStore::default()),
+            Arc::new(StaticPrompter {
+                token: "secret".to_string(),
+            }),
+        );
+
+        let description = repositories
+            .fetch_description_with_retry(&source, "digest", "0.6.37")
+            .expect("archive DESCRIPTION should be extracted");
+
+        archive_mock.assert();
+        assert!(description.contains("Package: digest"));
+        assert!(description.contains("Version: 0.6.37"));
     }
 
     #[test]
@@ -1081,6 +1526,7 @@ Version: 1.1.6
         let description = fetch_description_from_tarball(
             &format!("{}/src/contrib/rprojroot_2.1.1.tar.gz", server.url()),
             "rprojroot",
+            "2.1.1",
         )
         .expect("top-level DESCRIPTION should be extracted");
 

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -11,7 +11,7 @@ use std::{
     hash::{Hash, Hasher},
     io::{self, IsTerminal, Read},
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, OnceLock},
 };
 use tar::Archive;
 use tokio::task::JoinSet;
@@ -20,6 +20,7 @@ use crate::project::cache_dir_path;
 use crate::r_version::compare_r_versions;
 
 const KEYRING_SERVICE: &str = "rpx";
+static DESCRIPTION_FETCH_RUNTIME: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct RepositorySource {
@@ -437,14 +438,19 @@ impl RepositorySet {
             (_, Ok(CranLikePackageArchive::Available(_))) => {
                 self.record_cran_archive_support(source, CranArchiveSupport::Available);
             }
-            (Ok(false), _) | (Err(CranLikeArchiveError::Unavailable), _) => {
+            (Ok(CranLikeArchiveListingSupport::Unavailable), _) => {
                 self.record_cran_archive_support(source, CranArchiveSupport::Unavailable);
             }
             (Err(CranLikeArchiveError::Failed(error)), _) => return Err(error.clone()),
-            (Ok(true), Err(CranLikeArchiveError::Failed(error))) => return Err(error.clone()),
-            (Ok(true), _) => {
+            (
+                Ok(CranLikeArchiveListingSupport::Available),
+                Err(CranLikeArchiveError::Failed(error)),
+            ) => return Err(error.clone()),
+            (Ok(CranLikeArchiveListingSupport::Available), _) => {
                 self.record_cran_archive_support(source, CranArchiveSupport::Available);
             }
+            (Ok(CranLikeArchiveListingSupport::Unknown), _)
+            | (Err(CranLikeArchiveError::Unavailable), _) => {}
         }
 
         if let Ok(CranLikePackageArchive::Available(versions)) = package_archive {
@@ -693,6 +699,13 @@ enum CranLikeArchiveError {
     Failed(String),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CranLikeArchiveListingSupport {
+    Available,
+    Unavailable,
+    Unknown,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub(crate) enum CranArchiveSupport {
     Available,
@@ -707,13 +720,16 @@ enum CranLikePackageArchive {
 
 fn fetch_cran_like_archive_listing_available(
     source: &RepositorySource,
-) -> Result<bool, CranLikeArchiveError> {
+) -> Result<CranLikeArchiveListingSupport, CranLikeArchiveError> {
     let url = format!("{}/src/contrib/Archive/", source.base_url());
-    let response = reqwest::blocking::get(&url).map_err(|_| CranLikeArchiveError::Unavailable)?;
+    let response = match reqwest::blocking::get(&url) {
+        Ok(response) => response,
+        Err(_) => return Ok(CranLikeArchiveListingSupport::Unknown),
+    };
     let status = response.status();
 
     if status == reqwest::StatusCode::NOT_FOUND || status == reqwest::StatusCode::FORBIDDEN {
-        return Ok(false);
+        return Ok(CranLikeArchiveListingSupport::Unavailable);
     }
     if !status.is_success() {
         return Err(CranLikeArchiveError::Failed(unexpected_cran_like_response(
@@ -721,15 +737,18 @@ fn fetch_cran_like_archive_listing_available(
         )));
     }
 
-    Ok(true)
+    Ok(CranLikeArchiveListingSupport::Available)
 }
 
 pub(crate) fn detect_cran_like_archive_support(
     source: &RepositorySource,
-) -> Result<CranArchiveSupport, String> {
+) -> Result<Option<CranArchiveSupport>, String> {
     match fetch_cran_like_archive_listing_available(source) {
-        Ok(true) => Ok(CranArchiveSupport::Available),
-        Ok(false) | Err(CranLikeArchiveError::Unavailable) => Ok(CranArchiveSupport::Unavailable),
+        Ok(CranLikeArchiveListingSupport::Available) => Ok(Some(CranArchiveSupport::Available)),
+        Ok(CranLikeArchiveListingSupport::Unavailable) => Ok(Some(CranArchiveSupport::Unavailable)),
+        Ok(CranLikeArchiveListingSupport::Unknown) | Err(CranLikeArchiveError::Unavailable) => {
+            Ok(None)
+        }
         Err(CranLikeArchiveError::Failed(error)) => Err(error),
     }
 }
@@ -852,8 +871,10 @@ fn fetch_description_from_cran_like_tarballs(
         DescriptionCandidate::tarball(current_url, package, version),
         DescriptionCandidate::tarball(archive_url, package, version),
     ];
-    tokio::runtime::Runtime::new()
-        .map_err(|error| format!("failed to start DESCRIPTION fetch runtime: {error}"))?
+    DESCRIPTION_FETCH_RUNTIME
+        .get_or_init(|| {
+            tokio::runtime::Runtime::new().expect("DESCRIPTION fetch runtime should start")
+        })
         .block_on(fetch_first_description_candidate(candidates))
 }
 
@@ -1566,6 +1587,16 @@ Version: 1.1.6
             repositories.cran_archive_unavailable_repositories(),
             vec![server.url()]
         );
+    }
+
+    #[test]
+    fn treats_archive_listing_transport_failure_as_unknown_support() {
+        let source = RepositorySource::cran_like("http://127.0.0.1:9");
+
+        let result = fetch_cran_like_archive_listing_available(&source)
+            .expect("transport failures should not be hard archive probe errors");
+
+        assert_eq!(result, CranLikeArchiveListingSupport::Unknown);
     }
 
     #[test]

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -16,6 +16,7 @@ use r_description::VersionConstraint;
 
 use crate::{
     description::{DescriptionDependency, RDescription},
+    r_version::{compare_version_components, r_version_components},
     registry::ResolutionRoot,
     repository::{RepositorySet, RepositorySource},
     ui::ResolutionUi,
@@ -68,17 +69,7 @@ impl FromStr for RPackageVersion {
     type Err = String;
 
     fn from_str(version: &str) -> Result<Self, Self::Err> {
-        let components = version
-            .split(['.', '-'])
-            .map(|part| {
-                if part.is_empty() {
-                    return Err(format!("invalid version {version}"));
-                }
-
-                part.parse::<u32>()
-                    .map_err(|_| format!("invalid version {version}"))
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+        let components = r_version_components(version)?;
 
         Ok(Self {
             raw: version.to_string(),
@@ -89,14 +80,7 @@ impl FromStr for RPackageVersion {
 
 impl Ord for RPackageVersion {
     fn cmp(&self, other: &Self) -> Ordering {
-        for (left, right) in self.components.iter().zip(&other.components) {
-            match left.cmp(right) {
-                Ordering::Equal => continue,
-                ordering => return ordering,
-            }
-        }
-
-        self.components.len().cmp(&other.components.len())
+        compare_version_components(&self.components, &other.components)
     }
 }
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -16,7 +16,7 @@ use r_description::VersionConstraint;
 
 use crate::{
     description::{DescriptionDependency, RDescription},
-    registry::{ResolutionRoot, VersionSummary},
+    registry::ResolutionRoot,
     repository::{RepositorySet, RepositorySource},
     ui::ResolutionUi,
 };
@@ -137,6 +137,13 @@ struct PackageMetadata {
     system_requirements: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+struct VersionCandidate {
+    version: String,
+    source_url: String,
+    source: RepositorySource,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ResolverError(String);
 
@@ -160,8 +167,7 @@ struct RegistryDependencyProvider<'a> {
     progress: ResolutionUi,
     root_dependencies: Vec<PackageDependency>,
     preferred_versions_by_package: BTreeMap<String, RPackageVersion>,
-    versions_by_package: RefCell<BTreeMap<String, Vec<VersionSummary>>>,
-    source_by_package: RefCell<BTreeMap<String, RepositorySource>>,
+    versions_by_package: RefCell<BTreeMap<String, Vec<VersionCandidate>>>,
     metadata_by_package_version: RefCell<BTreeMap<(String, String), PackageMetadata>>,
 }
 
@@ -195,12 +201,11 @@ impl<'a> RegistryDependencyProvider<'a> {
             root_dependencies,
             preferred_versions_by_package,
             versions_by_package: RefCell::new(BTreeMap::new()),
-            source_by_package: RefCell::new(BTreeMap::new()),
             metadata_by_package_version: RefCell::new(BTreeMap::new()),
         })
     }
 
-    fn package_versions(&self, package: &str) -> Result<Vec<VersionSummary>, ResolverError> {
+    fn package_versions(&self, package: &str) -> Result<Vec<VersionCandidate>, ResolverError> {
         if let Some(versions) = self.versions_by_package.borrow().get(package) {
             self.progress
                 .on_cache_hit(&format!("cached versions for {package}"));
@@ -208,19 +213,30 @@ impl<'a> RegistryDependencyProvider<'a> {
         }
 
         self.progress.on_version_load(package);
-        let sourced = self
+        let sourced_versions = self
             .repositories
-            .fetch_package_versions_with_retry(package)?;
-        let mut versions = sourced.response.versions;
+            .fetch_all_package_versions_with_retry(package)?;
+        let mut versions_by_version = BTreeMap::new();
+
+        for sourced in sourced_versions {
+            for version in sourced.response.versions {
+                versions_by_version
+                    .entry(version.version.clone())
+                    .or_insert_with(|| VersionCandidate {
+                        version: version.version,
+                        source_url: version.source_url,
+                        source: sourced.source.clone(),
+                    });
+            }
+        }
+
+        let mut versions = versions_by_version.into_values().collect::<Vec<_>>();
         versions.sort_by(|left, right| {
             let left_version = parse_version(&left.version).expect("registry version should parse");
             let right_version =
                 parse_version(&right.version).expect("registry version should parse");
             left_version.cmp(&right_version)
         });
-        self.source_by_package
-            .borrow_mut()
-            .insert(package.to_string(), sourced.source);
         self.versions_by_package
             .borrow_mut()
             .insert(package.to_string(), versions.clone());
@@ -257,14 +273,8 @@ impl<'a> RegistryDependencyProvider<'a> {
                     "version {version} missing from registry for {package}"
                 ))
             })?;
-        let source = self
-            .source_by_package
-            .borrow()
-            .get(package)
-            .cloned()
-            .ok_or_else(|| ResolverError(format!("missing repository source for {package}")))?;
         let description = self.repositories.fetch_description_with_retry(
-            &source,
+            &version_entry.source,
             package,
             &version_entry.version,
         )?;
@@ -624,6 +634,7 @@ enum ParsedConstraint {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mockito::Server;
 
     #[derive(Debug, Clone)]
     struct TestPackageVersion {
@@ -895,13 +906,15 @@ mod tests {
         provider.versions_by_package.borrow_mut().insert(
             "cli".to_string(),
             vec![
-                VersionSummary {
+                VersionCandidate {
                     version: "3.6.4".to_string(),
                     source_url: "https://example.test/cli/3.6.4".to_string(),
+                    source: RepositorySource::new("https://example.test"),
                 },
-                VersionSummary {
+                VersionCandidate {
                     version: "3.6.5".to_string(),
                     source_url: "https://example.test/cli/3.6.5".to_string(),
+                    source: RepositorySource::new("https://example.test"),
                 },
             ],
         );
@@ -915,5 +928,101 @@ mod tests {
             .expect("selection should exist");
 
         assert_eq!(chosen.to_string(), "3.6.4");
+    }
+
+    #[test]
+    fn resolves_highest_compatible_version_across_repositories() {
+        let mut first = Server::new();
+        let first_versions = first
+            .mock("GET", "/packages/pkg/versions")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(format!(
+                r#"{{"package":"pkg","versions":[{{"version":"1.0.0","sourceUrl":"{}/packages/pkg/versions/1.0.0/source"}}]}}"#,
+                first.url()
+            ))
+            .expect(1)
+            .create();
+        let mut second = Server::new();
+        let second_versions = second
+            .mock("GET", "/packages/pkg/versions")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(format!(
+                r#"{{"package":"pkg","versions":[{{"version":"2.0.0","sourceUrl":"{}/packages/pkg/versions/2.0.0/source"}}]}}"#,
+                second.url()
+            ))
+            .expect(1)
+            .create();
+        let second_description = second
+            .mock("GET", "/packages/pkg/versions/2.0.0/description")
+            .with_status(200)
+            .with_body("Package: pkg\nVersion: 2.0.0\n")
+            .expect(1)
+            .create();
+        let repositories = RepositorySet::new(vec![
+            RepositorySource::new(first.url()),
+            RepositorySource::new(second.url()),
+        ]);
+
+        let resolved = resolve_from_registry(
+            &repositories,
+            &[ResolutionRoot {
+                name: "pkg".to_string(),
+                constraint: "*".to_string(),
+            }],
+            &BTreeMap::new(),
+        )
+        .expect("resolution should succeed");
+
+        assert_eq!(resolved[0].version, "2.0.0");
+        assert_eq!(
+            resolved[0].source_url,
+            format!("{}/packages/pkg/versions/2.0.0/source", second.url())
+        );
+        first_versions.assert();
+        second_versions.assert();
+        second_description.assert();
+    }
+
+    #[test]
+    fn keeps_preferred_locked_version_from_enabled_repositories() {
+        let mut server = Server::new();
+        let versions = server
+            .mock("GET", "/packages/pkg/versions")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(format!(
+                r#"{{"package":"pkg","versions":[{{"version":"1.0.0","sourceUrl":"{0}/packages/pkg/versions/1.0.0/source"}},{{"version":"2.0.0","sourceUrl":"{0}/packages/pkg/versions/2.0.0/source"}}]}}"#,
+                server.url()
+            ))
+            .expect(1)
+            .create();
+        let description = server
+            .mock("GET", "/packages/pkg/versions/1.0.0/description")
+            .with_status(200)
+            .with_body("Package: pkg\nVersion: 1.0.0\n")
+            .expect(1)
+            .create();
+        let repositories = RepositorySet::new(vec![RepositorySource::new(server.url())]);
+        let preferred = BTreeMap::from([("pkg".to_string(), "1.0.0".to_string())]);
+
+        let resolved = resolve_from_registry(
+            &repositories,
+            &[ResolutionRoot {
+                name: "pkg".to_string(),
+                constraint: "*".to_string(),
+            }],
+            &preferred,
+        )
+        .expect("resolution should succeed");
+
+        assert_eq!(resolved[0].version, "1.0.0");
+        assert_eq!(
+            resolved[0].source_url,
+            format!("{}/packages/pkg/versions/1.0.0/source", server.url())
+        );
+        versions.assert();
+        description.assert();
     }
 }


### PR DESCRIPTION
This pull request introduces improvements to how the tool handles repository selection during dependency resolution and enhances the lockfile to record whether the built-in default repository was used. The changes add new CLI flags for repository selection, update the lockfile schema, and improve the resolver logic to support selecting the highest compatible package version across multiple repositories. Several new and updated tests ensure correct behavior for these features.

**CLI and Lockfile Enhancements:**

* Added `--default-repo` and `--no-default-repo` flags to the `add`, `remove`, and `lock` commands in `src/cli.rs`, allowing users to explicitly control whether the built-in default repository is used during dependency resolution. [[1]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccR28-R41) [[2]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccR55-R68) [[3]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccL68-R110)
* Updated the lockfile format in `src/lockfile.rs` to include a new `use_default_repository` boolean field, with logic to omit the field when true (the default), and incremented the lockfile revision. [[1]](diffhunk://#diff-0b742865f84d423347a6e004c290a3882ed8ada12f9f78a24877ea90a99ed72fL6-R15) [[2]](diffhunk://#diff-0b742865f84d423347a6e004c290a3882ed8ada12f9f78a24877ea90a99ed72fR24-R31)

**Dependency Resolution Improvements:**

* Refactored the resolver in `src/resolver.rs` to aggregate and consider package versions from all repositories, enabling selection of the highest compatible version across repositories. Introduced the `VersionCandidate` struct to track version, source URL, and repository source. [[1]](diffhunk://#diff-cbb50fec325653fd70e0bcb9f84525b95fc31231915716c70457695941f3951dR140-R146) [[2]](diffhunk://#diff-cbb50fec325653fd70e0bcb9f84525b95fc31231915716c70457695941f3951dL163-R170) [[3]](diffhunk://#diff-cbb50fec325653fd70e0bcb9f84525b95fc31231915716c70457695941f3951dL198-L223) [[4]](diffhunk://#diff-cbb50fec325653fd70e0bcb9f84525b95fc31231915716c70457695941f3951dL260-R277)
* Removed the now-unnecessary `source_by_package` tracking, as the source is now associated directly with each version candidate. [[1]](diffhunk://#diff-cbb50fec325653fd70e0bcb9f84525b95fc31231915716c70457695941f3951dL163-R170) [[2]](diffhunk://#diff-cbb50fec325653fd70e0bcb9f84525b95fc31231915716c70457695941f3951dL198-L223) [[3]](diffhunk://#diff-cbb50fec325653fd70e0bcb9f84525b95fc31231915716c70457695941f3951dL260-R277)

**Testing and Validation:**

* Added and updated tests in `src/lockfile.rs` to verify correct serialization and deserialization of the new lockfile field and its default behavior. [[1]](diffhunk://#diff-0b742865f84d423347a6e004c290a3882ed8ada12f9f78a24877ea90a99ed72fR114) [[2]](diffhunk://#diff-0b742865f84d423347a6e004c290a3882ed8ada12f9f78a24877ea90a99ed72fL139-R150) [[3]](diffhunk://#diff-0b742865f84d423347a6e004c290a3882ed8ada12f9f78a24877ea90a99ed72fR159-R181) [[4]](diffhunk://#diff-0b742865f84d423347a6e004c290a3882ed8ada12f9f78a24877ea90a99ed72fR211)
* Added tests in `src/resolver.rs` to verify that the resolver correctly chooses the highest compatible version from multiple repositories and respects preferred locked versions. [[1]](diffhunk://#diff-cbb50fec325653fd70e0bcb9f84525b95fc31231915716c70457695941f3951dR637) [[2]](diffhunk://#diff-cbb50fec325653fd70e0bcb9f84525b95fc31231915716c70457695941f3951dL898-R917) [[3]](diffhunk://#diff-cbb50fec325653fd70e0bcb9f84525b95fc31231915716c70457695941f3951dR932-R1027)