### PR TITLE
feat: install the local package during sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2305,7 +2305,7 @@ dependencies = [
 
 [[package]]
 name = "rpx"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "async-trait",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rpx"
-version = "1.6.0"
+version = "1.7.0"
 edition = "2024"
 description = "Rust CLI for managing R package project dependencies"
 license = "MIT"

--- a/src/description.rs
+++ b/src/description.rs
@@ -80,6 +80,13 @@ pub fn init_description() -> Result<String, DescriptionError> {
         path: path.clone(),
         source,
     })?;
+    let namespace_path = path.with_file_name("NAMESPACE");
+    if !namespace_path.exists() {
+        fs::write(&namespace_path, "").map_err(|source| DescriptionError::WriteFailed {
+            path: namespace_path,
+            source,
+        })?;
+    }
 
     Ok(path.display().to_string())
 }
@@ -92,7 +99,7 @@ fn initial_description(package_name: &str) -> RDescription {
     description.set_description("Add a package description.");
     description.set_license("MIT");
     description.set_authors(
-        &r#"person("First", "Last", role = c("aut", "cre"))"#
+        &r#"person("First", "Last", email = "you@example.com", role = c("aut", "cre"))"#
             .parse()
             .unwrap(),
     );

--- a/src/http.rs
+++ b/src/http.rs
@@ -626,6 +626,7 @@ pub async fn rrepo_repository_packages(
     let mut url = base_url.clone();
     url.path_segments_mut()
         .expect("repository base URL should support path segments")
+        .pop_if_empty()
         .push("packages");
 
     get_response(client, url).await
@@ -639,6 +640,7 @@ pub async fn rrepo_package_versions(
     let mut url = base_url.clone();
     url.path_segments_mut()
         .expect("repository base URL should support path segments")
+        .pop_if_empty()
         .extend(["packages", package, "versions"]);
 
     get_response(client, url).await
@@ -653,6 +655,7 @@ pub async fn rrepo_package_description(
     let mut url = base_url.clone();
     url.path_segments_mut()
         .expect("repository base URL should support path segments")
+        .pop_if_empty()
         .extend(["packages", package, "versions", version, "description"]);
 
     get_response(client, url).await
@@ -667,6 +670,7 @@ pub async fn rrepo_source_artifact(
     let mut url = base_url.clone();
     url.path_segments_mut()
         .expect("repository base URL should support path segments")
+        .pop_if_empty()
         .extend(["packages", package, "versions", version, "source"]);
 
     get_response(client, url).await
@@ -682,6 +686,7 @@ pub async fn rrepo_windows_binary(
     let mut url = base_url.clone();
     url.path_segments_mut()
         .expect("repository base URL should support path segments")
+        .pop_if_empty()
         .extend([
             "packages", package, "versions", version, "binaries", "windows", r_minor,
         ]);
@@ -700,6 +705,7 @@ pub async fn rrepo_macos_binary(
     let mut url = base_url.clone();
     url.path_segments_mut()
         .expect("repository base URL should support path segments")
+        .pop_if_empty()
         .extend([
             "packages", package, "versions", version, "binaries", "macos", target, r_minor,
         ]);
@@ -714,6 +720,7 @@ pub async fn cran_packages(
     let mut url = base_url.clone();
     url.path_segments_mut()
         .expect("repository base URL should support path segments")
+        .pop_if_empty()
         .extend(["src", "contrib", "PACKAGES"]);
 
     client.get(url).send().await
@@ -726,6 +733,7 @@ pub async fn cran_archive_root(
     let mut url = base_url.clone();
     url.path_segments_mut()
         .expect("repository base URL should support path segments")
+        .pop_if_empty()
         .extend(["src", "contrib", "Archive", ""]);
 
     client.get(url).send().await
@@ -739,6 +747,7 @@ pub async fn cran_package_archive_listing(
     let mut url = base_url.clone();
     url.path_segments_mut()
         .expect("repository base URL should support path segments")
+        .pop_if_empty()
         .extend(["src", "contrib", "Archive", package, ""]);
 
     client.get(url).send().await
@@ -754,6 +763,7 @@ pub async fn cran_current_source_tarball(
     let mut url = base_url.clone();
     url.path_segments_mut()
         .expect("repository base URL should support path segments")
+        .pop_if_empty()
         .extend(["src", "contrib", &file_name]);
 
     client.get(url).send().await
@@ -769,6 +779,7 @@ pub async fn cran_archive_source_tarball(
     let mut url = base_url.clone();
     url.path_segments_mut()
         .expect("repository base URL should support path segments")
+        .pop_if_empty()
         .extend(["src", "contrib", "Archive", package, &file_name]);
 
     client.get(url).send().await
@@ -782,6 +793,7 @@ pub async fn cran_latest_package_description(
     let mut url = base_url.clone();
     url.path_segments_mut()
         .expect("repository base URL should support path segments")
+        .pop_if_empty()
         .extend(["web", "packages", package, "DESCRIPTION"]);
 
     client.get(url).send().await
@@ -798,6 +810,7 @@ pub async fn cran_windows_binary(
     let mut url = base_url.clone();
     url.path_segments_mut()
         .expect("repository base URL should support path segments")
+        .pop_if_empty()
         .extend(["bin", "windows", "contrib", r_minor, &file_name]);
 
     client.get(url).send().await
@@ -815,6 +828,7 @@ pub async fn cran_macos_binary(
     let mut url = base_url.clone();
     url.path_segments_mut()
         .expect("repository base URL should support path segments")
+        .pop_if_empty()
         .extend(["bin", "macosx", target, "contrib", r_minor, &file_name]);
 
     client.get(url).send().await
@@ -940,6 +954,7 @@ fn cran_archive_source_url_for_error(
 
     url.path_segments_mut()
         .expect("repository base URL should support path segments")
+        .pop_if_empty()
         .extend(["src", "contrib", "Archive", package, &file_name]);
 
     url

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use futures_util::StreamExt;
 use miette::Diagnostic;
+use pubgrub::{DefaultStringReporter, PubGrubError, Reporter};
 use r_description::{
     VersionConstraint,
     lossless::{RDescription, Relation, Relations, Version},
@@ -211,6 +212,13 @@ enum LockError {
     )]
     ResolveFailed { details: String },
 
+    #[error("package requirements are incompatible\n\n{explanation}")]
+    #[diagnostic(
+        code(rpx::lock::no_solution),
+        help("Adjust package constraints in DESCRIPTION and try again.")
+    )]
+    NoSolution { explanation: String },
+
     #[error("repository operation failed: {source}")]
     #[diagnostic(code(rpx::lock::repository_failed))]
     Repository {
@@ -218,7 +226,7 @@ enum LockError {
         source: RepositoryError,
     },
 
-    #[error("failed to resolve package set from registry: {source}")]
+    #[error("failed to resolve package set from registry")]
     #[diagnostic(
         code(rpx::lock::resolve_failed),
         help("Check package names and version constraints in DESCRIPTION.")
@@ -231,6 +239,18 @@ enum LockError {
     #[error("repository {repository} cannot be written to the lockfile")]
     #[diagnostic(code(rpx::lock::unsupported_repository))]
     UnsupportedRepository { repository: String },
+}
+
+fn lock_error_from_resolution(error: ResolutionError) -> LockError {
+    match error {
+        ResolutionError::PubGrub(PubGrubError::NoSolution(mut derivation_tree)) => {
+            derivation_tree.collapse_no_versions();
+            LockError::NoSolution {
+                explanation: DefaultStringReporter::report(&derivation_tree),
+            }
+        }
+        source => LockError::Resolution { source },
+    }
 }
 
 #[derive(Debug, Error, Diagnostic)]
@@ -1980,7 +2000,7 @@ async fn lockfile_from_roots(
         preferred_versions,
     )
     .await
-    .map_err(|source| LockError::Resolution { source })?;
+    .map_err(lock_error_from_resolution)?;
 
     let sysreq_db = load_sysreq_snapshot_for_lock(existing_lockfile).await;
     lockfile_from_selected_versions(
@@ -3241,9 +3261,9 @@ fn locked_install_order(lockfile: &Lockfile) -> Result<Vec<String>, String> {
 mod tests {
     use super::{
         LockError, LockfileCompatibilityError, ProjectPackage, apply_added_packages_to_description,
-        locked_dependencies_from_description, locked_install_order, locked_package_repositories,
-        lockfile_supports_project, package_not_found_help, parse_add_package,
-        pinned_package_relations, project_install_partitions,
+        lock_error_from_resolution, locked_dependencies_from_description, locked_install_order,
+        locked_package_repositories, lockfile_supports_project, package_not_found_help,
+        parse_add_package, pinned_package_relations, project_install_partitions,
         remove_packages_from_description_dependencies, roots_from_description,
         validate_lockfile_compatibility,
     };
@@ -3252,6 +3272,8 @@ mod tests {
         LockedSystemRequirements, Lockfile,
     };
     use crate::repository::{LocalRepository, PackageRepository};
+    use crate::resolver::{RDependencyProvider, ResolutionError};
+    use pubgrub::{DerivationTree, External, PubGrubError, Ranges};
     use r_description::{
         VersionConstraint,
         lossless::{RDescription, Relation, Version},
@@ -3272,6 +3294,26 @@ mod tests {
             .expect_err("local repositories should not be lockable");
 
         assert!(matches!(error, LockError::UnsupportedRepository { .. }));
+    }
+
+    #[test]
+    fn renders_pubgrub_no_solution_report() {
+        let error: PubGrubError<RDependencyProvider> =
+            PubGrubError::NoSolution(DerivationTree::External(External::NoVersions(
+                "testthat".to_string(),
+                Ranges::empty(),
+            )));
+
+        let error = lock_error_from_resolution(ResolutionError::PubGrub(error));
+        let LockError::NoSolution { explanation } = &error else {
+            panic!("no-solution error should have a dedicated diagnostic");
+        };
+
+        assert!(explanation.contains("testthat"));
+        let rendered = format!("{:?}", miette::Report::new(error));
+        assert!(rendered.contains("package requirements are incompatible"));
+        assert!(rendered.contains("testthat"));
+        assert!(!rendered.contains("There is no solution"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,8 +58,7 @@ use project::{
 };
 use r::{InstallFailure, base_packages, install_local_package, installed_packages};
 use repository::DEFAULT_REGISTRY_BASE_URL;
-use repository::normalize_repository_url;
-use resolver::{is_base_package, resolve_from_registry};
+use resolver::{ResolutionError, is_base_package, resolve_from_registry};
 use sysreqs::{
     SystemDependencyPlan, cached_latest_snapshot, current_host_platform,
     empty_snapshot as empty_sysreq_snapshot, install as install_system_dependencies,
@@ -78,7 +77,10 @@ use crate::{
         RVirtualEnv, fetch_runtime_info, installed_packages_async, r_version_async,
         remove_packages_from_venv,
     },
-    repository::{ArchiveSupport, PackageRepository, RepositoryType},
+    repository::{
+        ArchiveSupport, CranRepository, PackageRepository, RepositoryError, RrepoRepository,
+        parse_repository_url,
+    },
     resolver::PackageVersion,
 };
 
@@ -142,9 +144,13 @@ enum ProjectError {
 
 #[derive(Debug, Error, Diagnostic)]
 enum RepoError {
-    #[error("failed to add repository {url}: {details}")]
+    #[error("failed to add repository {url}: {source}")]
     #[diagnostic(code(rpx::repo::add_failed))]
-    Add { url: String, details: String },
+    Add {
+        url: String,
+        #[source]
+        source: RepositoryError,
+    },
 
     #[error("failed to remove repository credential: {details}")]
     #[diagnostic(code(rpx::repo::credential_remove_failed))]
@@ -201,6 +207,27 @@ enum LockError {
         help("Check package names and version constraints in DESCRIPTION.")
     )]
     ResolveFailed { details: String },
+
+    #[error("repository operation failed: {source}")]
+    #[diagnostic(code(rpx::lock::repository_failed))]
+    Repository {
+        #[source]
+        source: RepositoryError,
+    },
+
+    #[error("failed to resolve package set from registry: {source}")]
+    #[diagnostic(
+        code(rpx::lock::resolve_failed),
+        help("Check package names and version constraints in DESCRIPTION.")
+    )]
+    Resolution {
+        #[source]
+        source: ResolutionError,
+    },
+
+    #[error("repository {repository} cannot be written to the lockfile")]
+    #[diagnostic(code(rpx::lock::unsupported_repository))]
+    UnsupportedRepository { repository: String },
 }
 
 #[derive(Debug, Error, Diagnostic)]
@@ -479,7 +506,7 @@ async fn cmd_add(
     let repositories = repository_preference
         .package_repositories(&client, &description, current_lockfile.as_ref())
         .await
-        .map_err(|details| LockError::ResolveFailed { details })?;
+        .map_err(|source| LockError::Repository { source })?;
 
     let mut desired_roots =
         roots_from_lockfile_or_description(current_lockfile.as_ref(), &description)?;
@@ -552,35 +579,40 @@ async fn cmd_repo_add(url: &str) -> RpxResult<()> {
     let mut repositories = DefaultRepositoryPreference::FromLockfileOrDefault
         .package_repositories(&client, &description, current_lockfile.as_ref())
         .await
-        .map_err(|details| LockError::ResolveFailed { details })?;
-    let new_repo = PackageRepository::from_url(&client, url)
+        .map_err(|source| LockError::Repository { source })?;
+    let new_repo = <dyn PackageRepository>::from_url(&client, url)
         .await
-        .map_err(|details| RepoError::Add {
-            url: normalize_repository_url(url),
-            details,
+        .map_err(|source| RepoError::Add {
+            url: url.trim().to_string(),
+            source,
         })?;
+    let new_repo_url = remote_repository_url(new_repo.as_ref())
+        .expect("URL-classified repositories should be remote")
+        .clone();
 
     let mut additional_repositories = description.additional_repositories().unwrap_or_default();
-    if additional_repositories
-        .iter()
-        .any(|existing| normalize_repository_url(existing) == new_repo.base_url().as_str())
-    {
+    if additional_repositories.iter().any(|existing| {
+        parse_repository_url(existing).is_ok_and(|existing| existing == new_repo_url)
+    }) {
         status(format_args!(
             "Repository already configured: {}",
-            new_repo.base_url().as_str()
+            new_repo_url.as_str()
         ));
         return Ok(());
     }
 
-    additional_repositories.push(new_repo.base_url().to_string());
+    additional_repositories.push(new_repo_url.to_string());
     let additional_repositories = additional_repositories
         .iter()
         .map(String::as_str)
         .collect::<Vec<_>>();
     description.set_additional_repositories(&additional_repositories);
 
-    if !repositories.contains(&new_repo) {
-        repositories.push(new_repo.clone());
+    if !repositories
+        .iter()
+        .any(|repository| repository.as_ref() == new_repo.as_ref())
+    {
+        repositories.push(Arc::clone(&new_repo));
     }
 
     let roots = roots_from_lockfile_or_description(current_lockfile.as_ref(), &description)?;
@@ -601,10 +633,7 @@ async fn cmd_repo_add(url: &str) -> RpxResult<()> {
 
     write_description(&description)?;
     write_project_lockfile(&lockfile)?;
-    status(format_args!(
-        "Added repository {}",
-        new_repo.base_url().to_string()
-    ));
+    status(format_args!("Added repository {new_repo_url}"));
     Ok(())
 }
 
@@ -615,16 +644,18 @@ async fn cmd_repo_remove(url: &str, remove_credential: bool) -> RpxResult<()> {
     let mut repositories = DefaultRepositoryPreference::FromLockfileOrDefault
         .package_repositories(&client, &description, current_lockfile.as_ref())
         .await
-        .map_err(|details| LockError::ResolveFailed { details })?;
-    let normalized_url = normalize_repository_url(url);
-    let base_url = reqwest::Url::parse(&normalized_url).map_err(|error| RepoError::Add {
-        url: normalized_url.clone(),
-        details: format!("invalid repository URL {normalized_url}: {error}"),
+        .map_err(|source| LockError::Repository { source })?;
+    let base_url = parse_repository_url(url).map_err(|source| RepoError::Add {
+        url: url.trim().to_string(),
+        source,
     })?;
+    let normalized_url = base_url.to_string();
 
     let mut additional_repositories = description.additional_repositories().unwrap_or_default();
     let previous_len = additional_repositories.len();
-    additional_repositories.retain(|existing| normalize_repository_url(existing) != normalized_url);
+    additional_repositories.retain(|existing| {
+        parse_repository_url(existing).map_or(true, |existing| existing != base_url)
+    });
 
     if additional_repositories.len() == previous_len {
         status(format_args!("Repository not configured: {normalized_url}"));
@@ -637,7 +668,9 @@ async fn cmd_repo_remove(url: &str, remove_credential: bool) -> RpxResult<()> {
         .collect::<Vec<_>>();
     description.set_additional_repositories(&additional_repositories);
 
-    repositories.retain(|repository| repository.base_url().as_str() != normalized_url);
+    repositories.retain(|repository| {
+        remote_repository_url(repository.as_ref()).is_none_or(|url| url != &base_url)
+    });
 
     let roots = roots_from_lockfile_or_description(current_lockfile.as_ref(), &description)?;
     let preferred_versions = preferred_versions_from_lockfile(
@@ -678,11 +711,11 @@ async fn cmd_repo_list() -> RpxResult<()> {
     }
 
     for url in additional_repositories {
-        let normalized_url = normalize_repository_url(&url);
-        let base_url = reqwest::Url::parse(&normalized_url).map_err(|error| RepoError::Add {
-            url: normalized_url.clone(),
-            details: format!("invalid repository URL {normalized_url}: {error}"),
+        let base_url = parse_repository_url(&url).map_err(|source| RepoError::Add {
+            url: url.clone(),
+            source,
         })?;
+        let normalized_url = base_url.to_string();
         let credential = http::has_stored_credential(&base_url).map_err(|error| {
             RepoError::CredentialInspect {
                 details: error.to_string(),
@@ -713,7 +746,7 @@ async fn cmd_remove(
     let repositories = repository_preference
         .package_repositories(&client, &description, current_lockfile.as_ref())
         .await
-        .map_err(|details| LockError::ResolveFailed { details })?;
+        .map_err(|source| LockError::Repository { source })?;
 
     let mut desired_roots =
         roots_from_lockfile_or_description(current_lockfile.as_ref(), &description)?;
@@ -795,7 +828,7 @@ async fn cmd_lock(repository_preference: DefaultRepositoryPreference) -> RpxResu
     let repositories = repository_preference
         .package_repositories(&client, &description, current_lockfile.as_ref())
         .await
-        .map_err(|details| LockError::ResolveFailed { details })?;
+        .map_err(|source| LockError::Repository { source })?;
     let roots = roots_from_lockfile_or_description(current_lockfile.as_ref(), &description)?;
     let preferred_versions = preferred_versions_from_lockfile(
         current_lockfile.as_ref(),
@@ -1039,7 +1072,7 @@ impl DefaultRepositoryPreference {
         client: &http::HttpClient,
         description: &RDescription,
         lockfile: Option<&Lockfile>,
-    ) -> Result<Vec<PackageRepository>, String> {
+    ) -> Result<Vec<Arc<dyn PackageRepository>>, RepositoryError> {
         let mut repos = match lockfile {
             Some(lockfile) => package_repositories_from_lockfile(lockfile)?,
             None => package_repositories_from_description(client, description).await?,
@@ -1047,7 +1080,10 @@ impl DefaultRepositoryPreference {
 
         if self == Self::Enabled || (self == Self::FromLockfileOrDefault && lockfile.is_none()) {
             let default = default_repository(client).await?;
-            if !repos.contains(&default) {
+            if !repos
+                .iter()
+                .any(|repository| repository.as_ref() == default.as_ref())
+            {
                 repos.insert(0, default);
             }
         }
@@ -1058,22 +1094,24 @@ impl DefaultRepositoryPreference {
 
 fn package_repositories_from_lockfile(
     lockfile: &Lockfile,
-) -> Result<Vec<PackageRepository>, String> {
+) -> Result<Vec<Arc<dyn PackageRepository>>, RepositoryError> {
     lockfile
         .repositories
         .iter()
         .map(|locked_repository| {
-            let url =
-                reqwest::Url::parse(&locked_repository.url).map_err(|error| error.to_string())?;
+            let url = parse_repository_url(&locked_repository.url)?;
 
-            let repo_type = locked_repository_type(
-                locked_repository.kind,
-                locked_repository
-                    .cran_archive_support
-                    .unwrap_or(ArchiveSupport::Unavailable),
-            );
-
-            Ok(PackageRepository::new(url, repo_type))
+            Ok(match locked_repository.kind {
+                LockedRepositoryKind::Rrepo => {
+                    Arc::new(RrepoRepository::new(url)) as Arc<dyn PackageRepository>
+                }
+                LockedRepositoryKind::CranLike => Arc::new(CranRepository::new(
+                    url,
+                    locked_repository
+                        .cran_archive_support
+                        .unwrap_or(ArchiveSupport::Unavailable),
+                )),
+            })
         })
         .collect()
 }
@@ -1081,13 +1119,13 @@ fn package_repositories_from_lockfile(
 async fn package_repositories_from_description(
     client: &http::HttpClient,
     description: &RDescription,
-) -> Result<Vec<PackageRepository>, String> {
+) -> Result<Vec<Arc<dyn PackageRepository>>, RepositoryError> {
     let additional_repositories = description.additional_repositories().unwrap_or_default();
 
     futures_util::future::join_all(
         additional_repositories
             .iter()
-            .map(|url| async move { PackageRepository::from_url(client, url).await }),
+            .map(|url| async move { <dyn PackageRepository>::from_url(client, url).await }),
     )
     .await
     .into_iter()
@@ -1098,19 +1136,27 @@ fn lockfile_repositories_match_description(
     description: &RDescription,
     lockfile: &Lockfile,
 ) -> bool {
-    let description_repositories = description
+    let Some(description_repositories) = description
         .additional_repositories()
         .unwrap_or_default()
         .into_iter()
-        .map(|url| normalize_repository_url(&url))
-        .collect::<Vec<_>>();
-    let default_repository = default_repository_base_url();
-    let lockfile_repositories = lockfile
+        .map(|url| parse_repository_url(&url).ok())
+        .collect::<Option<Vec<_>>>()
+    else {
+        return false;
+    };
+    let Ok(default_repository) = default_repository_base_url() else {
+        return false;
+    };
+    let Some(lockfile_repositories) = lockfile
         .repositories
         .iter()
-        .map(|repository| normalize_repository_url(&repository.url))
-        .filter(|url| url != &default_repository)
-        .collect::<Vec<_>>();
+        .map(|repository| parse_repository_url(&repository.url).ok())
+        .filter(|url| url.as_ref() != Some(&default_repository))
+        .collect::<Option<Vec<_>>>()
+    else {
+        return false;
+    };
 
     description_repositories == lockfile_repositories
 }
@@ -1262,7 +1308,7 @@ fn invalid_add_constraint(package: &str, details: impl Into<String>) -> AddError
 
 async fn add_relations_for_packages(
     client: &http::HttpClient,
-    repositories: &[PackageRepository],
+    repositories: &[Arc<dyn PackageRepository>],
     packages: &[String],
 ) -> RpxResult<BTreeSet<Relation>> {
     let non_base_packages = packages
@@ -1294,7 +1340,7 @@ async fn add_relations_for_packages(
 
 async fn latest_package_versions_for_add(
     client: &http::HttpClient,
-    repositories: &[PackageRepository],
+    repositories: &[Arc<dyn PackageRepository>],
     packages: &[String],
 ) -> RpxResult<BTreeMap<String, PackageVersion>> {
     if packages.is_empty() {
@@ -1310,7 +1356,7 @@ async fn latest_package_versions_for_add(
             repository
                 .packages(client)
                 .await
-                .map_err(|details| (repository.base_url(), details))
+                .map_err(|details| (repository.to_string(), details))
         }
     }))
     .await;
@@ -1455,7 +1501,7 @@ fn locked_root_from_relation(relation: &Relation) -> lockfile::LockedRoot {
 
 fn preferred_versions_from_lockfile(
     lockfile: Option<&Lockfile>,
-    repositories: &[PackageRepository],
+    repositories: &[Arc<dyn PackageRepository>],
     excluded_packages: &BTreeSet<String>,
 ) -> RpxResult<BTreeMap<String, PackageVersion>> {
     let Some(lockfile) = lockfile else {
@@ -1486,18 +1532,19 @@ fn preferred_versions_from_lockfile(
 }
 
 fn repository_for_locked_package(
-    repositories: &[PackageRepository],
+    repositories: &[Arc<dyn PackageRepository>],
     package: &LockedPackage,
-) -> RpxResult<Arc<PackageRepository>> {
+) -> RpxResult<Arc<dyn PackageRepository>> {
     if let Some(source_url) = package.source_url.as_deref()
-        && let Some(repository) = repositories
-            .iter()
-            .find(|repository| source_url.starts_with(repository.base_url().as_str()))
+        && let Some(repository) = repositories.iter().find(|repository| {
+            remote_repository_url(repository.as_ref())
+                .is_some_and(|url| source_url.starts_with(url.as_str()))
+        })
     {
-        return Ok(Arc::new(repository.clone()));
+        return Ok(Arc::clone(repository));
     }
 
-    repositories.first().cloned().map(Arc::new).ok_or_else(|| {
+    repositories.first().cloned().ok_or_else(|| {
         LockError::ResolveFailed {
             details: format!(
                 "no repository available for locked package {}",
@@ -1506,6 +1553,16 @@ fn repository_for_locked_package(
         }
         .into()
     })
+}
+
+fn remote_repository_url(repository: &dyn PackageRepository) -> Option<&reqwest::Url> {
+    if let Some(repository) = repository.downcast_ref::<RrepoRepository>() {
+        Some(repository.url())
+    } else {
+        repository
+            .downcast_ref::<CranRepository>()
+            .map(CranRepository::url)
+    }
 }
 
 fn apply_added_packages_to_description(
@@ -1691,49 +1748,35 @@ pub(crate) fn exit_with_status(code: Option<i32>) {
     }
 }
 
-async fn default_repository(client: &http::HttpClient) -> Result<PackageRepository, String> {
+async fn default_repository(
+    client: &http::HttpClient,
+) -> Result<Arc<dyn PackageRepository>, RepositoryError> {
     match env::var("RPX_REGISTRY_BASE_URL") {
-        Ok(url) => {
-            let normalized_url = normalize_repository_url(&url);
-
-            PackageRepository::from_url(client, &normalized_url)
-                .await
-                .map_err(|details| {
-                    format!(
-                        "failed to classify RPX_REGISTRY_BASE_URL repository {}: {details}",
-                        normalized_url
-                    )
-                })
-        }
+        Ok(url) => <dyn PackageRepository>::from_url(client, &url).await,
 
         Err(_) => {
-            let url = reqwest::Url::parse(DEFAULT_REGISTRY_BASE_URL).map_err(|error| {
-                format!(
-                    "invalid default registry URL {}: {error}",
-                    DEFAULT_REGISTRY_BASE_URL
-                )
-            })?;
+            let url = parse_repository_url(DEFAULT_REGISTRY_BASE_URL)?;
 
-            Ok(PackageRepository::new(url, RepositoryType::Rrepo))
+            Ok(Arc::new(RrepoRepository::new(url)))
         }
     }
 }
 
-fn default_repository_base_url() -> String {
-    env::var("RPX_REGISTRY_BASE_URL")
-        .unwrap_or_else(|_| DEFAULT_REGISTRY_BASE_URL.to_string())
-        .trim_end_matches('/')
-        .to_string()
+fn default_repository_base_url() -> Result<reqwest::Url, RepositoryError> {
+    let value =
+        env::var("RPX_REGISTRY_BASE_URL").unwrap_or_else(|_| DEFAULT_REGISTRY_BASE_URL.to_string());
+    parse_repository_url(&value)
 }
 
 fn repository_kind_label(lockfile: Option<&Lockfile>, url: &str) -> &'static str {
-    let normalized_url = normalize_repository_url(url);
+    let Ok(url) = parse_repository_url(url) else {
+        return "unknown";
+    };
     lockfile
         .and_then(|lockfile| {
-            lockfile
-                .repositories
-                .iter()
-                .find(|repository| normalize_repository_url(&repository.url) == normalized_url)
+            lockfile.repositories.iter().find(|repository| {
+                parse_repository_url(&repository.url).is_ok_and(|repository| repository == url)
+            })
         })
         .map(|repository| match repository.kind {
             LockedRepositoryKind::Rrepo => "rrepo",
@@ -1744,7 +1787,7 @@ fn repository_kind_label(lockfile: Option<&Lockfile>, url: &str) -> &'static str
 
 async fn lockfile_from_roots(
     client: &http::HttpClient,
-    repositories: Vec<PackageRepository>,
+    repositories: Vec<Arc<dyn PackageRepository>>,
     roots: BTreeSet<Relation>,
     preferred_versions: BTreeMap<String, PackageVersion>,
     existing_lockfile: Option<&Lockfile>,
@@ -1757,7 +1800,7 @@ async fn lockfile_from_roots(
         preferred_versions,
     )
     .await
-    .map_err(|details| LockError::ResolveFailed { details })?;
+    .map_err(|source| LockError::Resolution { source })?;
 
     let sysreq_db = load_sysreq_snapshot_for_lock(existing_lockfile).await;
     lockfile_from_selected_versions(
@@ -1769,7 +1812,7 @@ async fn lockfile_from_roots(
         r_version,
     )
     .await
-    .map_err(|details| LockError::ResolveFailed { details }.into())
+    .map_err(Into::into)
 }
 
 async fn lockfile_from_selected_versions(
@@ -1777,9 +1820,9 @@ async fn lockfile_from_selected_versions(
     roots: BTreeSet<Relation>,
     selected: Vec<(String, PackageVersion)>,
     sysreq_db: &sysreqs::SysreqDbSnapshot,
-    repositories: &[PackageRepository],
+    repositories: &[Arc<dyn PackageRepository>],
     r_version: Option<&str>,
-) -> Result<Lockfile, String> {
+) -> Result<Lockfile, LockError> {
     let mut packages = BTreeMap::new();
     let mut sysreq_packages = BTreeMap::new();
 
@@ -1787,9 +1830,11 @@ async fn lockfile_from_selected_versions(
         let description = version
             .repository()
             .description(&client, &name, version.version())
-            .await?;
+            .await
+            .map_err(|source| LockError::Repository { source })?;
 
-        let dependencies = locked_dependencies_from_description(&description)?;
+        let dependencies = locked_dependencies_from_description(&description)
+            .map_err(|details| LockError::ResolveFailed { details })?;
 
         let rules = sysreqs::match_rules(&description, sysreq_db);
 
@@ -1803,7 +1848,7 @@ async fn lockfile_from_selected_versions(
                 package: name.clone(),
                 version: version.version().to_string(),
                 source: Some("repository".to_string()),
-                source_url: Some(version.source_url(&name)),
+                source_url: Some(package_source_url(&name, &version)?),
                 dependencies,
             },
         );
@@ -1827,7 +1872,7 @@ async fn lockfile_from_selected_versions(
     Ok(Lockfile {
         version: LOCKFILE_VERSION,
         revision: LOCKFILE_REVISION,
-        repositories: locked_package_repositories(repositories),
+        repositories: locked_package_repositories(repositories)?,
         r: LockedR {
             version: resolved_r_version,
             base_packages: required_base_packages,
@@ -1934,22 +1979,59 @@ fn relation_bounds(
     }
 }
 
-fn locked_package_repositories(repositories: &[PackageRepository]) -> Vec<LockedRepository> {
+fn package_source_url(name: &str, version: &PackageVersion) -> Result<String, LockError> {
+    let repository = version.repository().as_ref();
+    let mut url = if let Some(repository) = repository.downcast_ref::<RrepoRepository>() {
+        let mut url = repository.url().clone();
+        let version = version.version().to_string();
+        url.path_segments_mut()
+            .expect("repository base URL should support path segments")
+            .pop_if_empty()
+            .extend(["packages", name, "versions", &version, "source"]);
+        return Ok(url.to_string());
+    } else if let Some(repository) = repository.downcast_ref::<CranRepository>() {
+        repository.url().clone()
+    } else {
+        return Err(LockError::UnsupportedRepository {
+            repository: repository.to_string(),
+        });
+    };
+
+    let file_name = format!("{name}_{}.tar.gz", version.version());
+    url.path_segments_mut()
+        .expect("repository base URL should support path segments")
+        .pop_if_empty()
+        .extend(["src", "contrib", "Archive", name, &file_name]);
+    Ok(url.to_string())
+}
+
+fn locked_package_repositories(
+    repositories: &[Arc<dyn PackageRepository>],
+) -> Result<Vec<LockedRepository>, LockError> {
     repositories
         .iter()
         .map(|repository| {
-            let (kind, cran_archive_support) = match repository.repo_type() {
-                RepositoryType::Rrepo => (LockedRepositoryKind::Rrepo, None),
-                RepositoryType::Cran { archives } => {
-                    (LockedRepositoryKind::CranLike, Some(archives))
-                }
-            };
+            let repository = repository.as_ref();
+            let (url, kind, cran_archive_support) =
+                if let Some(repository) = repository.downcast_ref::<RrepoRepository>() {
+                    (repository.url(), LockedRepositoryKind::Rrepo, None)
+                } else if let Some(repository) = repository.downcast_ref::<CranRepository>() {
+                    (
+                        repository.url(),
+                        LockedRepositoryKind::CranLike,
+                        Some(repository.archive_support()),
+                    )
+                } else {
+                    return Err(LockError::UnsupportedRepository {
+                        repository: repository.to_string(),
+                    });
+                };
 
-            LockedRepository {
-                url: repository.base_url().to_string(),
+            Ok(LockedRepository {
+                url: url.to_string(),
                 kind,
                 cran_archive_support,
-            }
+            })
         })
         .collect()
 }
@@ -1974,13 +2056,6 @@ fn locked_base_packages_from_locked<'a>(
     );
 
     base_packages.into_iter().collect()
-}
-
-fn locked_repository_type(kind: LockedRepositoryKind, archives: ArchiveSupport) -> RepositoryType {
-    match kind {
-        LockedRepositoryKind::Rrepo => RepositoryType::Rrepo,
-        LockedRepositoryKind::CranLike => RepositoryType::Cran { archives: archives },
-    }
 }
 
 fn validate_lockfile_compatibility(lockfile: &Lockfile) -> Result<(), LockfileCompatibilityError> {
@@ -2985,20 +3060,38 @@ fn locked_install_order(lockfile: &Lockfile) -> Result<Vec<String>, String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        LockfileCompatibilityError, apply_added_packages_to_description,
-        locked_dependencies_from_description, locked_install_order, package_not_found_help,
-        parse_add_package, pinned_package_relations, remove_packages_from_description_dependencies,
-        roots_from_description, validate_lockfile_compatibility,
+        LockError, LockfileCompatibilityError, apply_added_packages_to_description,
+        locked_dependencies_from_description, locked_install_order, locked_package_repositories,
+        package_not_found_help, parse_add_package, pinned_package_relations,
+        remove_packages_from_description_dependencies, roots_from_description,
+        validate_lockfile_compatibility,
     };
     use crate::lockfile::{
         LOCKFILE_REVISION, LOCKFILE_VERSION, LockedDependency, LockedPackage, LockedR,
         LockedSystemRequirements, Lockfile,
     };
+    use crate::repository::{LocalRepository, PackageRepository};
     use r_description::{
         VersionConstraint,
         lossless::{RDescription, Relation},
     };
-    use std::collections::{BTreeMap, BTreeSet};
+    use std::{
+        collections::{BTreeMap, BTreeSet},
+        path::PathBuf,
+        sync::Arc,
+    };
+
+    #[test]
+    fn rejects_local_repository_locking() {
+        let repositories: Vec<Arc<dyn PackageRepository>> = vec![Arc::new(LocalRepository::new(
+            PathBuf::from("vendor/example"),
+        ))];
+
+        let error = locked_package_repositories(&repositories)
+            .expect_err("local repositories should not be lockable");
+
+        assert!(matches!(error, LockError::UnsupportedRepository { .. }));
+    }
 
     #[test]
     fn builds_root_relations_from_description_constraints() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1308,28 +1308,6 @@ fn manifest_requirement_names(description: &RDescription) -> BTreeSet<String> {
         .collect()
 }
 
-fn project_hard_requirement_names(description: &RDescription) -> BTreeSet<String> {
-    description
-        .imports()
-        .into_iter()
-        .flat_map(|relations| relations.iter())
-        .chain(
-            description
-                .depends()
-                .into_iter()
-                .flat_map(|relations| relations.iter()),
-        )
-        .chain(
-            description
-                .linking_to()
-                .into_iter()
-                .flat_map(|relations| relations.iter()),
-        )
-        .map(|relation| relation.name())
-        .filter(|package| package != "R" && !is_base_package(package))
-        .collect()
-}
-
 fn lockfile_supports_project(lockfile: &Lockfile, project: &ProjectPackage) -> bool {
     if lockfile.packages.contains_key(&project.name) {
         return false;
@@ -1363,37 +1341,6 @@ fn locked_dependency_allows_version(
         });
 
     minimum_matches && maximum_matches
-}
-
-fn project_install_partitions(
-    description: &RDescription,
-    lockfile: &Lockfile,
-) -> (Vec<LockedPackage>, Vec<LockedPackage>) {
-    let mut pending = project_hard_requirement_names(description);
-    let mut before_project = BTreeSet::new();
-
-    while let Some(package) = pending.pop_first() {
-        let Some(locked) = lockfile.packages.get(&package) else {
-            continue;
-        };
-        if !before_project.insert(package) {
-            continue;
-        }
-
-        pending.extend(
-            locked
-                .dependencies
-                .iter()
-                .filter(|dependency| lockfile.packages.contains_key(&dependency.package))
-                .map(|dependency| dependency.package.clone()),
-        );
-    }
-
-    lockfile
-        .packages
-        .values()
-        .cloned()
-        .partition(|package| before_project.contains(&package.package))
 }
 
 fn lockfile_requirement_names(lockfile: &Lockfile) -> BTreeSet<String> {
@@ -1911,22 +1858,25 @@ async fn sync_from_lockfile(
         let _ = remove_packages_from_venv(std::slice::from_ref(&project.name));
     }
 
-    let client = http::client();
-    let repositories = lockfile.repositories.clone();
-    let (before_project, after_project) = project_install_partitions(&description, &lockfile);
-    install_locked_packages(client.clone(), before_project, repositories.clone())
-        .await
-        .map_err(|details| SyncError::DownloadArtifactsFailed { details })?;
+    let root_dependencies = locked_dependencies_from_description(&description)
+        .map_err(|details| SyncError::ProjectInstallFailed { details })?;
+    let root_package = LockedPackage {
+        package: project.name.clone(),
+        version: project.version.to_string(),
+        source: None,
+        source_url: None,
+        dependencies: root_dependencies,
+    };
+    let mut packages = lockfile.packages.values().cloned().collect::<Vec<_>>();
+    packages.push(root_package);
 
-    install_project_package(&project_root(), &project_library_path())
-        .await
-        .map_err(|failure| SyncError::ProjectInstallFailed {
-            details: install_failure_message(&project.name, &project.version.to_string(), &failure),
-        })?;
-
-    install_locked_packages(client, after_project, repositories)
-        .await
-        .map_err(|details| SyncError::DownloadArtifactsFailed { details })?;
+    install_locked_packages(
+        http::client(),
+        packages,
+        lockfile.repositories.clone(),
+        &project.name,
+    )
+    .await?;
 
     return Ok(outcome);
 }
@@ -2549,7 +2499,8 @@ async fn install_locked_packages(
     client: http::HttpClient,
     packages: Vec<LockedPackage>,
     repositories: Vec<LockedRepository>,
-) -> Result<(), String> {
+    project_package: &str,
+) -> Result<(), SyncError> {
     let total_packages = packages.len() as u64;
     let sync_span = tracing::info_span!(
         "sync_packages",
@@ -2565,7 +2516,8 @@ async fn install_locked_packages(
     sync_span.pb_set_length(total_packages);
     sync_span.pb_start();
 
-    locked_package_install_order(&packages)?;
+    locked_package_install_order(&packages)
+        .map_err(|details| SyncError::DownloadArtifactsFailed { details })?;
 
     let locked_names = packages
         .iter()
@@ -2579,7 +2531,7 @@ async fn install_locked_packages(
 
     let pending_packages = packages
         .into_iter()
-        .filter(|p| !installed_packages.contains(&p.package))
+        .filter(|p| p.package == project_package || !installed_packages.contains(&p.package))
         .collect::<Vec<_>>();
     let mut completed = total_packages.saturating_sub(pending_packages.len() as u64);
     sync_span.record("completed", completed);
@@ -2593,11 +2545,16 @@ async fn install_locked_packages(
         return Ok(());
     }
 
-    let r_version = Arc::new(r_version_async().await?);
-    let r_minor = Arc::new(
-        r_minor_version(r_version.as_str())
-            .ok_or_else(|| format!("failed to parse R minor version from {r_version}"))?,
+    let r_version = Arc::new(
+        r_version_async()
+            .await
+            .map_err(|details| SyncError::DownloadArtifactsFailed { details })?,
     );
+    let r_minor = Arc::new(r_minor_version(r_version.as_str()).ok_or_else(|| {
+        SyncError::DownloadArtifactsFailed {
+            details: format!("failed to parse R minor version from {r_version}"),
+        }
+    })?);
     let repositories = Arc::new(repositories);
     let client = Arc::new(client);
     let locked_names = Arc::new(locked_names);
@@ -2610,6 +2567,59 @@ async fn install_locked_packages(
 
     for package in pending_packages {
         let package_name = package.package.clone();
+        if package_name == project_package {
+            let install_locked_names = Arc::clone(&locked_names);
+            let install_installed_packages = Arc::clone(&installed_packages);
+            let install_installed_rx = installed_rx.clone();
+            let install_installed_tx = installed_tx.clone();
+            let install_shared_pool = Arc::clone(&shared_pool);
+            let install_pool = Arc::clone(&install_pool);
+            install_tasks.spawn(
+                async move {
+                    wait_for_locked_package_dependencies(
+                        &package,
+                        install_locked_names,
+                        Arc::clone(&install_installed_packages),
+                        install_installed_rx,
+                    )
+                    .await
+                    .map_err(|details| SyncError::DownloadArtifactsFailed { details })?;
+
+                    let _install_permit = install_pool.acquire_owned().await.map_err(|_| {
+                        SyncError::DownloadArtifactsFailed {
+                            details: "install pool closed before project installation".to_string(),
+                        }
+                    })?;
+                    let _shared_permit =
+                        install_shared_pool.acquire_owned().await.map_err(|_| {
+                            SyncError::DownloadArtifactsFailed {
+                                details: "sync work pool closed before project installation"
+                                    .to_string(),
+                            }
+                        })?;
+
+                    install_project_package(&project_root(), &project_library_path())
+                        .await
+                        .map_err(|failure| SyncError::ProjectInstallFailed {
+                            details: install_failure_message(
+                                &package.package,
+                                &package.version,
+                                &failure,
+                            ),
+                        })?;
+                    {
+                        let mut installed_packages = install_installed_packages.lock().await;
+                        installed_packages.insert(package_name.clone());
+                    }
+                    let _ = install_installed_tx.send(());
+
+                    Ok::<_, SyncError>(package_name)
+                }
+                .instrument(sync_span.clone()),
+            );
+            continue;
+        }
+
         let cache_key =
             CompiledPackageCacheKey::new(&package.package, &package.version, r_version.as_str());
         let (prepared_tx, prepared_rx) = oneshot::channel();
@@ -2649,9 +2659,14 @@ async fn install_locked_packages(
         let install_pool = Arc::clone(&install_pool);
         install_tasks.spawn(
             async move {
-                let prepared_artifact = prepared_rx.await.map_err(|_| {
-                    format!("{package_name} artifact preparation task ended without a result")
-                })??;
+                let prepared_artifact = prepared_rx
+                    .await
+                    .map_err(|_| SyncError::DownloadArtifactsFailed {
+                        details: format!(
+                            "{package_name} artifact preparation task ended without a result"
+                        ),
+                    })?
+                    .map_err(|details| SyncError::DownloadArtifactsFailed { details })?;
 
                 // Keep package spans out of the progress UI while blocked on dependency installs.
                 wait_for_locked_package_dependencies(
@@ -2660,26 +2675,31 @@ async fn install_locked_packages(
                     Arc::clone(&install_installed_packages),
                     install_installed_rx,
                 )
-                .await?;
+                .await
+                .map_err(|details| SyncError::DownloadArtifactsFailed { details })?;
 
-                let _install_permit = install_pool
-                    .acquire_owned()
-                    .await
-                    .map_err(|_| "install pool closed before package installation".to_string())?;
-                let _shared_permit = install_shared_pool
-                    .acquire_owned()
-                    .await
-                    .map_err(|_| "sync work pool closed before package installation".to_string())?;
+                let _install_permit = install_pool.acquire_owned().await.map_err(|_| {
+                    SyncError::DownloadArtifactsFailed {
+                        details: "install pool closed before package installation".to_string(),
+                    }
+                })?;
+                let _shared_permit = install_shared_pool.acquire_owned().await.map_err(|_| {
+                    SyncError::DownloadArtifactsFailed {
+                        details: "sync work pool closed before package installation".to_string(),
+                    }
+                })?;
 
                 let installed =
-                    install_prepared_locked_package(package, cache_key, prepared_artifact).await?;
+                    install_prepared_locked_package(package, cache_key, prepared_artifact)
+                        .await
+                        .map_err(|details| SyncError::DownloadArtifactsFailed { details })?;
                 {
                     let mut installed_packages = install_installed_packages.lock().await;
                     installed_packages.insert(installed.clone());
                 }
                 let _ = install_installed_tx.send(());
 
-                Ok::<_, String>(installed)
+                Ok::<_, SyncError>(installed)
             }
             .instrument(sync_span.clone()),
         );
@@ -2688,7 +2708,9 @@ async fn install_locked_packages(
     sync_span.record("running", install_tasks.len() as u64);
 
     while let Some(result) = install_tasks.join_next().await {
-        result.map_err(|error| format!("install task failed to join: {error}"))??;
+        result.map_err(|error| SyncError::DownloadArtifactsFailed {
+            details: format!("install task failed to join: {error}"),
+        })??;
         completed += 1;
         sync_span.record("completed", completed);
         sync_span.record("running", install_tasks.len() as u64);
@@ -3253,8 +3275,8 @@ mod tests {
     use super::{
         LockError, LockfileCompatibilityError, ProjectPackage, apply_added_packages_to_description,
         lock_error_from_resolution, locked_dependencies_from_description, locked_install_order,
-        locked_package_repositories, lockfile_supports_project, package_not_found_help,
-        parse_add_package, pinned_package_relations, project_install_partitions,
+        locked_package_install_order, locked_package_repositories, lockfile_supports_project,
+        package_not_found_help, parse_add_package, pinned_package_relations,
         remove_packages_from_description_dependencies, roots_from_description,
         validate_lockfile_compatibility,
     };
@@ -3308,7 +3330,7 @@ mod tests {
     }
 
     #[test]
-    fn stages_project_hard_dependency_closure_before_project() {
+    fn install_graph_includes_project_dependencies_and_dependents() {
         let description: RDescription = "Package: project\nVersion: 1.0.1\nTitle: Project\nDescription: Test project.\nLicense: MIT\nImports: hard\nSuggests: testthat\n"
             .parse()
             .expect("description should parse");
@@ -3325,42 +3347,28 @@ mod tests {
             min_version: None,
             max_version_exclusive: None,
         };
-        let lockfile = Lockfile {
-            version: LOCKFILE_VERSION,
-            revision: LOCKFILE_REVISION,
-            repositories: vec![],
-            r: LockedR::default(),
-            sysreqs: LockedSystemRequirements::default(),
-            roots: vec![],
-            packages: BTreeMap::from([
-                (
-                    "hard".to_string(),
-                    package("hard", vec![dependency("leaf")]),
-                ),
-                ("leaf".to_string(), package("leaf", vec![])),
-                (
-                    "testthat".to_string(),
-                    package("testthat", vec![dependency("project")]),
-                ),
-            ]),
+        let project = LockedPackage {
+            package: "project".to_string(),
+            version: "1.0.1".to_string(),
+            source: None,
+            source_url: None,
+            dependencies: locked_dependencies_from_description(&description).unwrap(),
         };
+        let packages = vec![
+            package("hard", vec![dependency("leaf")]),
+            package("leaf", vec![]),
+            project,
+            package("reverse", vec![dependency("project")]),
+            package("unrelated", vec![]),
+        ];
 
-        let (before, after) = project_install_partitions(&description, &lockfile);
+        let order = locked_package_install_order(&packages).unwrap();
+        let position = |name: &str| order.iter().position(|package| package == name).unwrap();
 
-        assert_eq!(
-            before
-                .into_iter()
-                .map(|package| package.package)
-                .collect::<Vec<_>>(),
-            vec!["hard", "leaf"]
-        );
-        assert_eq!(
-            after
-                .into_iter()
-                .map(|package| package.package)
-                .collect::<Vec<_>>(),
-            vec!["testthat"]
-        );
+        assert!(position("leaf") < position("hard"));
+        assert!(position("hard") < position("project"));
+        assert!(position("project") < position("reverse"));
+        assert!(order.contains(&"unrelated".to_string()));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -564,7 +564,7 @@ async fn cmd_add(
     )?;
     let lockfile = lockfile_from_roots(
         &client,
-        &description,
+        project_repository(&description),
         repositories,
         desired_roots,
         preferred_versions,
@@ -651,7 +651,7 @@ async fn cmd_repo_add(url: &str) -> RpxResult<()> {
     )?;
     let lockfile = lockfile_from_roots(
         &client,
-        &description,
+        project_repository(&description),
         repositories,
         roots,
         preferred_versions,
@@ -709,7 +709,7 @@ async fn cmd_repo_remove(url: &str, remove_credential: bool) -> RpxResult<()> {
     )?;
     let lockfile = lockfile_from_roots(
         &client,
-        &description,
+        project_repository(&description),
         repositories,
         roots,
         preferred_versions,
@@ -809,7 +809,7 @@ async fn cmd_remove(
         .collect::<Vec<_>>();
     let lockfile = lockfile_from_roots(
         &client,
-        &description,
+        project_repository(&description),
         repositories,
         desired_roots,
         preferred_versions,
@@ -869,7 +869,7 @@ async fn cmd_lock(repository_preference: DefaultRepositoryPreference) -> RpxResu
 
     let lockfile = lockfile_from_roots(
         &client,
-        &description,
+        project_repository(&description),
         repositories,
         roots,
         preferred_versions,
@@ -1296,14 +1296,8 @@ fn project_package(description: &RDescription) -> Result<ProjectPackage, Reposit
     Ok(ProjectPackage { name, version })
 }
 
-fn project_package_version(
-    description: &RDescription,
-) -> Result<(ProjectPackage, PackageVersion), RepositoryError> {
-    let package = project_package(description)?;
-    let repository: Arc<dyn PackageRepository> =
-        Arc::new(LocalRepository::new(project_root()).with_description(description.clone()));
-    let version = PackageVersion::new(package.version.clone(), repository);
-    Ok((package, version))
+fn project_repository(description: &RDescription) -> Arc<LocalRepository> {
+    Arc::new(LocalRepository::new(project_root()).with_description(description.clone()))
 }
 
 fn manifest_requirement_names(description: &RDescription) -> BTreeSet<String> {
@@ -1982,20 +1976,17 @@ fn repository_kind_label(lockfile: Option<&Lockfile>, url: &str) -> &'static str
 
 async fn lockfile_from_roots(
     client: &http::HttpClient,
-    description: &RDescription,
+    root: Arc<LocalRepository>,
     repositories: Vec<Arc<dyn PackageRepository>>,
     roots: BTreeSet<Relation>,
     preferred_versions: BTreeMap<String, PackageVersion>,
     existing_lockfile: Option<&Lockfile>,
     r_version: Option<&str>,
 ) -> RpxResult<Lockfile> {
-    let (root_package, root_version) =
-        project_package_version(description).map_err(|source| LockError::Repository { source })?;
     let selected = resolve_from_registry(
         client.clone(),
         repositories.clone(),
-        root_package.name,
-        root_version,
+        root,
         roots.clone(),
         preferred_versions,
     )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,9 +54,12 @@ use lockfile::{
 use output::{blank_note_line, blank_status_line, note, prompt, status, warning};
 use project::{
     artifact_cache_path, build_temp_library_path, cache_dir_path, project_library_path,
-    project_library_root_path,
+    project_library_root_path, project_root,
 };
-use r::{InstallFailure, base_packages, install_local_package, installed_packages};
+use r::{
+    InstallFailure, base_packages, install_local_package, install_project_package,
+    installed_packages,
+};
 use repository::DEFAULT_REGISTRY_BASE_URL;
 use resolver::{ResolutionError, is_base_package, resolve_from_registry};
 use sysreqs::{
@@ -78,8 +81,8 @@ use crate::{
         remove_packages_from_venv,
     },
     repository::{
-        ArchiveSupport, CranRepository, PackageRepository, RepositoryError, RrepoRepository,
-        parse_repository_url,
+        ArchiveSupport, CranRepository, LocalRepository, PackageRepository, RepositoryError,
+        RrepoRepository, parse_repository_url,
     },
     resolver::PackageVersion,
 };
@@ -283,6 +286,10 @@ enum SyncError {
     #[error("failed to prepare source artifacts: {details}")]
     #[diagnostic(code(rpx::sync::download_failed))]
     DownloadArtifactsFailed { details: String },
+
+    #[error("failed to install project package: {details}")]
+    #[diagnostic(code(rpx::sync::project_install_failed))]
+    ProjectInstallFailed { details: String },
 }
 
 #[derive(Debug, Error, Diagnostic)]
@@ -537,6 +544,7 @@ async fn cmd_add(
     )?;
     let lockfile = lockfile_from_roots(
         &client,
+        &description,
         repositories,
         desired_roots,
         preferred_versions,
@@ -623,6 +631,7 @@ async fn cmd_repo_add(url: &str) -> RpxResult<()> {
     )?;
     let lockfile = lockfile_from_roots(
         &client,
+        &description,
         repositories,
         roots,
         preferred_versions,
@@ -680,6 +689,7 @@ async fn cmd_repo_remove(url: &str, remove_credential: bool) -> RpxResult<()> {
     )?;
     let lockfile = lockfile_from_roots(
         &client,
+        &description,
         repositories,
         roots,
         preferred_versions,
@@ -779,6 +789,7 @@ async fn cmd_remove(
         .collect::<Vec<_>>();
     let lockfile = lockfile_from_roots(
         &client,
+        &description,
         repositories,
         desired_roots,
         preferred_versions,
@@ -838,6 +849,7 @@ async fn cmd_lock(repository_preference: DefaultRepositoryPreference) -> RpxResu
 
     let lockfile = lockfile_from_roots(
         &client,
+        &description,
         repositories,
         roots,
         preferred_versions,
@@ -875,6 +887,8 @@ async fn cmd_sync(install_system: bool, install_only_system: bool) -> RpxResult<
 
 async fn cmd_status() -> RpxResult<()> {
     let description = read_description()?;
+    let project =
+        project_package(&description).map_err(|source| LockError::Repository { source })?;
     let lockfile = read_project_lockfile()?;
 
     match validate_lockfile_compatibility(&lockfile) {
@@ -882,19 +896,23 @@ async fn cmd_status() -> RpxResult<()> {
         Err(LockfileCompatibilityError::Older) => return Err(StatusError::LockfileOlder.into()),
         Err(LockfileCompatibilityError::Newer) => return Err(StatusError::LockfileNewer.into()),
     }
+    if !lockfile_supports_project(&lockfile, &project) {
+        return Err(StatusError::LockfileOlder.into());
+    }
 
     let manifest_requirements = manifest_requirement_names(&description);
     let lock_requirements = lockfile_requirement_names(&lockfile);
     let installed = installed_packages().await;
     let installed_names = installed
         .iter()
-        .map(|package| &package.package)
-        .collect::<BTreeSet<&String>>();
+        .map(|package| package.package.clone())
+        .collect::<BTreeSet<_>>();
     let installed_versions = installed
         .iter()
         .map(|package| (package.package.clone(), package.version.clone()))
         .collect::<std::collections::BTreeMap<_, _>>();
-    let locked_names = lockfile.packages.keys().collect::<BTreeSet<&String>>();
+    let mut desired_names = lockfile.packages.keys().cloned().collect::<BTreeSet<_>>();
+    desired_names.insert(project.name.clone());
     let runtime_status = runtime_status(&lockfile).await;
     let system_plan = if host_supports_system_sync() {
         system_plan_from_lockfile(&lockfile).ok()
@@ -910,15 +928,15 @@ async fn cmd_status() -> RpxResult<()> {
         .difference(&manifest_requirements)
         .cloned()
         .collect::<Vec<_>>();
-    let missing_from_library = locked_names
+    let missing_from_library = desired_names
         .difference(&installed_names)
-        .map(|package| (*package).clone())
+        .cloned()
         .collect::<Vec<_>>();
     let extra_in_library = installed_names
-        .difference(&locked_names)
-        .map(|package| (*package).clone())
+        .difference(&desired_names)
+        .cloned()
         .collect::<Vec<_>>();
-    let version_mismatches = lockfile
+    let mut version_mismatches = lockfile
         .packages
         .iter()
         .filter(|(name, _)| !is_base_package(name))
@@ -934,6 +952,16 @@ async fn cmd_status() -> RpxResult<()> {
                 })
         })
         .collect::<Vec<_>>();
+    let project_version = project.version.to_string();
+    if let Some(installed_version) = installed_versions
+        .get(&project.name)
+        .filter(|installed_version| *installed_version != &project_version)
+    {
+        version_mismatches.push(format!(
+            "{} ({installed_version} installed, {project_version} expected)",
+            project.name
+        ));
+    }
 
     if missing_from_lockfile.is_empty()
         && extra_in_lockfile.is_empty()
@@ -985,10 +1013,10 @@ async fn cmd_status() -> RpxResult<()> {
         "Packages locked but no longer in DESCRIPTION:",
         &extra_in_lockfile,
     );
-    print_status_group("Packages locked but not installed:", &missing_from_library);
-    print_status_group("Packages installed but not locked:", &extra_in_library);
+    print_status_group("Required packages not installed:", &missing_from_library);
+    print_status_group("Unexpected packages installed:", &extra_in_library);
     print_status_group(
-        "Installed versions that differ from rpx.lock:",
+        "Installed versions that differ from expected versions:",
         &version_mismatches,
     );
     print_runtime_version_warning(&runtime_status);
@@ -1219,12 +1247,139 @@ fn roots_from_description(description: &RDescription) -> BTreeSet<Relation> {
         .collect()
 }
 
+#[derive(Debug, Clone)]
+struct ProjectPackage {
+    name: String,
+    version: Version,
+}
+
+fn project_package(description: &RDescription) -> Result<ProjectPackage, RepositoryError> {
+    let path = project_root().join("DESCRIPTION");
+    let name = description
+        .package()
+        .ok_or_else(|| RepositoryError::MissingField {
+            path: path.clone(),
+            field: "Package",
+        })?;
+    let version = description
+        .version()
+        .ok_or_else(|| RepositoryError::MissingField {
+            path,
+            field: "Version",
+        })?
+        .parse::<Version>()
+        .map_err(|details| RepositoryError::InvalidData {
+            resource: "project package version".to_string(),
+            details,
+        })?;
+
+    Ok(ProjectPackage { name, version })
+}
+
+fn project_package_version(
+    description: &RDescription,
+) -> Result<(ProjectPackage, PackageVersion), RepositoryError> {
+    let package = project_package(description)?;
+    let repository: Arc<dyn PackageRepository> =
+        Arc::new(LocalRepository::new(project_root()).with_description(description.clone()));
+    let version = PackageVersion::new(package.version.clone(), repository);
+    Ok((package, version))
+}
+
 fn manifest_requirement_names(description: &RDescription) -> BTreeSet<String> {
     roots_from_description(description)
         .into_iter()
         .map(|relation| relation.name())
         .filter(|package| !is_base_package(package))
         .collect()
+}
+
+fn project_hard_requirement_names(description: &RDescription) -> BTreeSet<String> {
+    description
+        .imports()
+        .into_iter()
+        .flat_map(|relations| relations.iter())
+        .chain(
+            description
+                .depends()
+                .into_iter()
+                .flat_map(|relations| relations.iter()),
+        )
+        .chain(
+            description
+                .linking_to()
+                .into_iter()
+                .flat_map(|relations| relations.iter()),
+        )
+        .map(|relation| relation.name())
+        .filter(|package| package != "R" && !is_base_package(package))
+        .collect()
+}
+
+fn lockfile_supports_project(lockfile: &Lockfile, project: &ProjectPackage) -> bool {
+    if lockfile.packages.contains_key(&project.name) {
+        return false;
+    }
+
+    lockfile.packages.values().all(|package| {
+        package
+            .dependencies
+            .iter()
+            .filter(|dependency| dependency.package == project.name)
+            .all(|dependency| locked_dependency_allows_version(dependency, &project.version))
+    })
+}
+
+fn locked_dependency_allows_version(
+    dependency: &lockfile::LockedDependency,
+    version: &Version,
+) -> bool {
+    let minimum_matches = dependency.min_version.as_deref().is_none_or(|minimum| {
+        minimum
+            .parse::<Version>()
+            .is_ok_and(|minimum| version >= &minimum)
+    });
+    let maximum_matches = dependency
+        .max_version_exclusive
+        .as_deref()
+        .is_none_or(|maximum| {
+            maximum
+                .parse::<Version>()
+                .is_ok_and(|maximum| version < &maximum)
+        });
+
+    minimum_matches && maximum_matches
+}
+
+fn project_install_partitions(
+    description: &RDescription,
+    lockfile: &Lockfile,
+) -> (Vec<LockedPackage>, Vec<LockedPackage>) {
+    let mut pending = project_hard_requirement_names(description);
+    let mut before_project = BTreeSet::new();
+
+    while let Some(package) = pending.pop_first() {
+        let Some(locked) = lockfile.packages.get(&package) else {
+            continue;
+        };
+        if !before_project.insert(package) {
+            continue;
+        }
+
+        pending.extend(
+            locked
+                .dependencies
+                .iter()
+                .filter(|dependency| lockfile.packages.contains_key(&dependency.package))
+                .map(|dependency| dependency.package.clone()),
+        );
+    }
+
+    lockfile
+        .packages
+        .values()
+        .cloned()
+        .partition(|package| before_project.contains(&package.package))
 }
 
 fn lockfile_requirement_names(lockfile: &Lockfile) -> BTreeSet<String> {
@@ -1695,9 +1850,14 @@ async fn sync_from_lockfile(
     install_only_system: bool,
 ) -> RpxResult<SyncOutcome> {
     let description = read_description()?;
+    let project =
+        project_package(&description).map_err(|source| LockError::Repository { source })?;
     let manifest_requirements = manifest_requirement_names(&description);
     let lockfile = read_project_lockfile()?;
     validate_lockfile_compatibility_for_sync(&lockfile)?;
+    if !lockfile_supports_project(&lockfile, &project) {
+        return Err(SyncError::LockfileOlder.into());
+    }
     validate_runtime_for_sync(&lockfile).await?;
     if host_supports_system_sync() {
         let system_plan = system_plan_from_lockfile(&lockfile).unwrap_or_else(|error| {
@@ -1718,9 +1878,13 @@ async fn sync_from_lockfile(
 
     let mut outcome = SyncOutcome::default();
 
-    let extra_packages = installed_packages()
-        .await
+    let installed = installed_packages().await;
+    let project_is_installed = installed
+        .iter()
+        .any(|package| package.package == project.name);
+    let extra_packages = installed
         .into_iter()
+        .filter(|package| package.package != project.name)
         .filter_map(|p| match lockfile.packages.get(&p.package) {
             Some(locked) if locked.version == p.version => None,
             _ => Some(p.package),
@@ -1729,15 +1893,26 @@ async fn sync_from_lockfile(
 
     outcome.removed = extra_packages.len();
     let _ = remove_packages_from_venv(&extra_packages);
+    if project_is_installed {
+        let _ = remove_packages_from_venv(std::slice::from_ref(&project.name));
+    }
 
     let client = http::client();
-    install_locked_packages(
-        client,
-        lockfile.packages.values().cloned().collect::<Vec<_>>(),
-        lockfile.repositories.iter().cloned().collect::<Vec<_>>(),
-    )
-    .await
-    .map_err(|details| SyncError::DownloadArtifactsFailed { details })?;
+    let repositories = lockfile.repositories.clone();
+    let (before_project, after_project) = project_install_partitions(&description, &lockfile);
+    install_locked_packages(client.clone(), before_project, repositories.clone())
+        .await
+        .map_err(|details| SyncError::DownloadArtifactsFailed { details })?;
+
+    install_project_package(&project_root(), &project_library_path())
+        .await
+        .map_err(|failure| SyncError::ProjectInstallFailed {
+            details: install_failure_message(&project.name, &project.version.to_string(), &failure),
+        })?;
+
+    install_locked_packages(client, after_project, repositories)
+        .await
+        .map_err(|details| SyncError::DownloadArtifactsFailed { details })?;
 
     return Ok(outcome);
 }
@@ -1787,15 +1962,20 @@ fn repository_kind_label(lockfile: Option<&Lockfile>, url: &str) -> &'static str
 
 async fn lockfile_from_roots(
     client: &http::HttpClient,
+    description: &RDescription,
     repositories: Vec<Arc<dyn PackageRepository>>,
     roots: BTreeSet<Relation>,
     preferred_versions: BTreeMap<String, PackageVersion>,
     existing_lockfile: Option<&Lockfile>,
     r_version: Option<&str>,
 ) -> RpxResult<Lockfile> {
+    let (root_package, root_version) =
+        project_package_version(description).map_err(|source| LockError::Repository { source })?;
     let selected = resolve_from_registry(
         client.clone(),
         repositories.clone(),
+        root_package.name,
+        root_version,
         roots.clone(),
         preferred_versions,
     )
@@ -3060,9 +3240,10 @@ fn locked_install_order(lockfile: &Lockfile) -> Result<Vec<String>, String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        LockError, LockfileCompatibilityError, apply_added_packages_to_description,
+        LockError, LockfileCompatibilityError, ProjectPackage, apply_added_packages_to_description,
         locked_dependencies_from_description, locked_install_order, locked_package_repositories,
-        package_not_found_help, parse_add_package, pinned_package_relations,
+        lockfile_supports_project, package_not_found_help, parse_add_package,
+        pinned_package_relations, project_install_partitions,
         remove_packages_from_description_dependencies, roots_from_description,
         validate_lockfile_compatibility,
     };
@@ -3073,7 +3254,7 @@ mod tests {
     use crate::repository::{LocalRepository, PackageRepository};
     use r_description::{
         VersionConstraint,
-        lossless::{RDescription, Relation},
+        lossless::{RDescription, Relation, Version},
     };
     use std::{
         collections::{BTreeMap, BTreeSet},
@@ -3091,6 +3272,98 @@ mod tests {
             .expect_err("local repositories should not be lockable");
 
         assert!(matches!(error, LockError::UnsupportedRepository { .. }));
+    }
+
+    #[test]
+    fn stages_project_hard_dependency_closure_before_project() {
+        let description: RDescription = "Package: project\nVersion: 1.0.1\nTitle: Project\nDescription: Test project.\nLicense: MIT\nImports: hard\nSuggests: testthat\n"
+            .parse()
+            .expect("description should parse");
+        let package = |name: &str, dependencies: Vec<LockedDependency>| LockedPackage {
+            package: name.to_string(),
+            version: "1.0.0".to_string(),
+            source: None,
+            source_url: None,
+            dependencies,
+        };
+        let dependency = |name: &str| LockedDependency {
+            package: name.to_string(),
+            kind: "Imports".to_string(),
+            min_version: None,
+            max_version_exclusive: None,
+        };
+        let lockfile = Lockfile {
+            version: LOCKFILE_VERSION,
+            revision: LOCKFILE_REVISION,
+            repositories: vec![],
+            r: LockedR::default(),
+            sysreqs: LockedSystemRequirements::default(),
+            roots: vec![],
+            packages: BTreeMap::from([
+                (
+                    "hard".to_string(),
+                    package("hard", vec![dependency("leaf")]),
+                ),
+                ("leaf".to_string(), package("leaf", vec![])),
+                (
+                    "testthat".to_string(),
+                    package("testthat", vec![dependency("project")]),
+                ),
+            ]),
+        };
+
+        let (before, after) = project_install_partitions(&description, &lockfile);
+
+        assert_eq!(
+            before
+                .into_iter()
+                .map(|package| package.package)
+                .collect::<Vec<_>>(),
+            vec!["hard", "leaf"]
+        );
+        assert_eq!(
+            after
+                .into_iter()
+                .map(|package| package.package)
+                .collect::<Vec<_>>(),
+            vec!["testthat"]
+        );
+    }
+
+    #[test]
+    fn validates_locked_reverse_dependencies_against_project_version() {
+        let project = ProjectPackage {
+            name: "project".to_string(),
+            version: "1.0.1".parse::<Version>().unwrap(),
+        };
+        let mut lockfile = Lockfile {
+            version: LOCKFILE_VERSION,
+            revision: LOCKFILE_REVISION,
+            repositories: vec![],
+            r: LockedR::default(),
+            sysreqs: LockedSystemRequirements::default(),
+            roots: vec![],
+            packages: BTreeMap::from([(
+                "testthat".to_string(),
+                LockedPackage {
+                    package: "testthat".to_string(),
+                    version: "3.0.0".to_string(),
+                    source: None,
+                    source_url: None,
+                    dependencies: vec![LockedDependency {
+                        package: "project".to_string(),
+                        kind: "Imports".to_string(),
+                        min_version: Some("1.0.0".to_string()),
+                        max_version_exclusive: Some("1.1.0".to_string()),
+                    }],
+                },
+            )]),
+        };
+
+        assert!(lockfile_supports_project(&lockfile, &project));
+        lockfile.packages.get_mut("testthat").unwrap().dependencies[0].min_version =
+            Some("1.1.0".to_string());
+        assert!(!lockfile_supports_project(&lockfile, &project));
     }
 
     #[test]

--- a/src/r.rs
+++ b/src/r.rs
@@ -76,6 +76,26 @@ pub async fn install_local_package(
         .await
         .expect("failed to run Rscript");
 
+    install_command_result(output)
+}
+
+pub async fn install_project_package(
+    project_root: &Path,
+    target_library: &Path,
+) -> Result<(), InstallFailure> {
+    let output = Command::with_venv("R")
+        .arg("CMD")
+        .arg("INSTALL")
+        .arg(format!("--library={}", target_library.display()))
+        .arg(project_root)
+        .output()
+        .await
+        .expect("failed to run R CMD INSTALL");
+
+    install_command_result(output)
+}
+
+fn install_command_result(output: std::process::Output) -> Result<(), InstallFailure> {
     if output.status.success() {
         return Ok(());
     }

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -3,6 +3,7 @@ mod local;
 mod rrepo;
 
 use crate::http;
+use crate::resolver::PackageVersion;
 use async_trait::async_trait;
 use r_description::lossless::{RDescription, Version};
 use reqwest::Url;
@@ -11,8 +12,10 @@ use std::{
     any::Any,
     collections::{BTreeMap, BTreeSet},
     fmt::Debug,
+    path::PathBuf,
     sync::Arc,
 };
+use thiserror::Error;
 
 pub use cran::CranRepository;
 pub use local::LocalRepository;
@@ -27,21 +30,90 @@ pub enum ArchiveSupport {
     Unavailable,
 }
 
+#[derive(Debug, Clone, Error)]
+pub enum RepositoryError {
+    #[error("request failed: {source}")]
+    Request {
+        #[source]
+        source: Arc<reqwest_middleware::Error>,
+    },
+
+    #[error("response failed: {source}")]
+    Response {
+        #[source]
+        source: Arc<reqwest::Error>,
+    },
+
+    #[error("failed to read source archive: {source}")]
+    Archive {
+        #[source]
+        source: Arc<std::io::Error>,
+    },
+
+    #[error("failed to read {path}: {source}")]
+    FileRead {
+        path: PathBuf,
+        #[source]
+        source: Arc<std::io::Error>,
+    },
+
+    #[error("failed to parse DESCRIPTION {location}: {source}")]
+    Description {
+        location: String,
+        #[source]
+        source: Arc<r_description::lossless::Error>,
+    },
+
+    #[error("invalid {resource}: {details}")]
+    InvalidData { resource: String, details: String },
+
+    #[error("DESCRIPTION at {path} is missing {field}")]
+    MissingField { path: PathBuf, field: &'static str },
+
+    #[error("source package does not contain {package}/DESCRIPTION")]
+    DescriptionNotFound { package: String },
+
+    #[error("local repository at {path} does not contain {package} {version}")]
+    PackageVersionNotFound {
+        path: PathBuf,
+        package: String,
+        version: Version,
+    },
+
+    #[error("invalid repository URL {value}")]
+    InvalidUrl { value: String },
+
+    #[error("{url} is not an rrepo API ({rrepo}) or CRAN-like repository ({cran})")]
+    UnrecognizedRepository {
+        url: String,
+        rrepo: Box<RepositoryError>,
+        cran: Box<RepositoryError>,
+    },
+}
+
 #[async_trait]
 pub trait PackageRepository: Any + Debug + Send + Sync {
     fn as_any(&self) -> &dyn Any;
 
     fn equals(&self, other: &dyn PackageRepository) -> bool;
 
-    async fn packages(&self) -> Result<BTreeMap<String, Version>, String>;
+    async fn packages(
+        &self,
+        client: &http::HttpClient,
+    ) -> Result<BTreeMap<String, PackageVersion>, RepositoryError>;
 
-    async fn versions(&self, package: &str) -> Result<BTreeSet<Version>, String>;
+    async fn versions(
+        &self,
+        client: &http::HttpClient,
+        package: &str,
+    ) -> Result<BTreeSet<PackageVersion>, RepositoryError>;
 
     async fn description(
         &self,
+        client: &http::HttpClient,
         package: &str,
         version: &Version,
-    ) -> Result<Arc<RDescription>, String>;
+    ) -> Result<Arc<RDescription>, RepositoryError>;
 }
 
 impl dyn PackageRepository {
@@ -52,21 +124,25 @@ impl dyn PackageRepository {
     pub async fn from_url(
         client: &http::HttpClient,
         value: &str,
-    ) -> Result<Arc<dyn PackageRepository>, String> {
-        let normalized_url = normalize_repository_url(value);
-        let url = Url::parse(&normalized_url)
-            .map_err(|error| format!("invalid repository URL {normalized_url}: {error}"))?;
+    ) -> Result<Arc<dyn PackageRepository>, RepositoryError> {
+        let value = value.trim();
+        let url = Url::parse(value).map_err(|_| RepositoryError::InvalidUrl {
+            value: value.to_string(),
+        })?;
 
         let rrepo_url = url.clone();
         let rrepo_probe = async {
             http::rrepo_repository_packages(client, &rrepo_url)
                 .await
-                .map_err(|error| error.to_string())?
+                .map_err(|source| RepositoryError::Request {
+                    source: Arc::new(source),
+                })?
                 .error_for_status()
-                .map_err(|error| error.to_string())?;
+                .map_err(|source| RepositoryError::Response {
+                    source: Arc::new(source),
+                })?;
 
-            Ok::<Arc<dyn PackageRepository>, String>(Arc::new(RrepoRepository::new(
-                client.clone(),
+            Ok::<Arc<dyn PackageRepository>, RepositoryError>(Arc::new(RrepoRepository::new(
                 rrepo_url,
             )))
         };
@@ -76,16 +152,24 @@ impl dyn PackageRepository {
             let packages_probe = async {
                 http::cran_packages(client, &cran_url)
                     .await
-                    .map_err(|error| error.to_string())?
+                    .map_err(|source| RepositoryError::Request {
+                        source: Arc::new(source),
+                    })?
                     .error_for_status()
-                    .map_err(|error| error.to_string())
+                    .map_err(|source| RepositoryError::Response {
+                        source: Arc::new(source),
+                    })
             };
             let archive_probe = async {
                 http::cran_archive_root(client, &cran_url)
                     .await
-                    .map_err(|error| error.to_string())?
+                    .map_err(|source| RepositoryError::Request {
+                        source: Arc::new(source),
+                    })?
                     .error_for_status()
-                    .map_err(|error| error.to_string())
+                    .map_err(|source| RepositoryError::Response {
+                        source: Arc::new(source),
+                    })
             };
 
             let (packages_result, archive_result) = tokio::join!(packages_probe, archive_probe);
@@ -93,18 +177,19 @@ impl dyn PackageRepository {
 
             let archives = match archive_result {
                 Ok(_) => ArchiveSupport::Available,
-                Err(error)
-                    if error.contains("404 Not Found") || error.contains("403 Forbidden") =>
+                Err(RepositoryError::Response { source })
+                    if matches!(
+                        source.status(),
+                        Some(reqwest::StatusCode::NOT_FOUND | reqwest::StatusCode::FORBIDDEN)
+                    ) =>
                 {
                     ArchiveSupport::Unavailable
                 }
                 Err(error) => return Err(error),
             };
 
-            Ok::<Arc<dyn PackageRepository>, String>(Arc::new(CranRepository::new(
-                client.clone(),
-                cran_url,
-                archives,
+            Ok::<Arc<dyn PackageRepository>, RepositoryError>(Arc::new(CranRepository::new(
+                cran_url, archives,
             )))
         };
 
@@ -118,9 +203,11 @@ impl dyn PackageRepository {
                     Err(rrepo_error) => {
                         match cran_probe.await {
                             Ok(repository) => Ok(repository),
-                            Err(cran_error) => Err(format!(
-                                "not an rrepo API ({rrepo_error}) or CRAN-like repository ({cran_error})"
-                            )),
+                            Err(cran_error) => Err(RepositoryError::UnrecognizedRepository {
+                                url: value.to_string(),
+                                rrepo: Box::new(rrepo_error),
+                                cran: Box::new(cran_error),
+                            }),
                         }
                     }
                 }
@@ -132,9 +219,11 @@ impl dyn PackageRepository {
                     Err(cran_error) => {
                         match rrepo_probe.await {
                             Ok(repository) => Ok(repository),
-                            Err(rrepo_error) => Err(format!(
-                                "not an rrepo API ({rrepo_error}) or CRAN-like repository ({cran_error})"
-                            )),
+                            Err(rrepo_error) => Err(RepositoryError::UnrecognizedRepository {
+                                url: value.to_string(),
+                                rrepo: Box::new(rrepo_error),
+                                cran: Box::new(cran_error),
+                            }),
                         }
                     }
                 }
@@ -151,6 +240,7 @@ impl PartialEq for dyn PackageRepository {
 
 impl Eq for dyn PackageRepository {}
 
+#[deprecated(note = "parse into Url and canonicalize with path_segments_mut().pop_if_empty()")]
 pub fn normalize_repository_url(value: &str) -> String {
     value.trim().trim_end_matches('/').to_string()
 }

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     any::Any,
     collections::{BTreeMap, BTreeSet},
-    fmt::Debug,
+    fmt::{Debug, Display},
     path::PathBuf,
     sync::Arc,
 };
@@ -92,7 +92,7 @@ pub enum RepositoryError {
 }
 
 #[async_trait]
-pub trait PackageRepository: Any + Debug + Send + Sync {
+pub trait PackageRepository: Any + Debug + Display + Send + Sync {
     fn as_any(&self) -> &dyn Any;
 
     fn equals(&self, other: &dyn PackageRepository) -> bool;

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -44,14 +44,102 @@ pub trait PackageRepository: Any + Debug + Send + Sync {
     ) -> Result<Arc<RDescription>, String>;
 }
 
-#[async_trait]
-pub trait RepositoryFromUrl: PackageRepository + Sized {
-    async fn from_url(client: http::HttpClient, url: Url) -> Result<Self, String>;
-}
-
 impl dyn PackageRepository {
     pub fn downcast_ref<T: PackageRepository + 'static>(&self) -> Option<&T> {
         self.as_any().downcast_ref()
+    }
+
+    pub async fn from_url(
+        client: &http::HttpClient,
+        value: &str,
+    ) -> Result<Arc<dyn PackageRepository>, String> {
+        let normalized_url = normalize_repository_url(value);
+        let url = Url::parse(&normalized_url)
+            .map_err(|error| format!("invalid repository URL {normalized_url}: {error}"))?;
+
+        let rrepo_url = url.clone();
+        let rrepo_probe = async {
+            http::rrepo_repository_packages(client, &rrepo_url)
+                .await
+                .map_err(|error| error.to_string())?
+                .error_for_status()
+                .map_err(|error| error.to_string())?;
+
+            Ok::<Arc<dyn PackageRepository>, String>(Arc::new(RrepoRepository::new(
+                client.clone(),
+                rrepo_url,
+            )))
+        };
+
+        let cran_url = url;
+        let cran_probe = async {
+            let packages_probe = async {
+                http::cran_packages(client, &cran_url)
+                    .await
+                    .map_err(|error| error.to_string())?
+                    .error_for_status()
+                    .map_err(|error| error.to_string())
+            };
+            let archive_probe = async {
+                http::cran_archive_root(client, &cran_url)
+                    .await
+                    .map_err(|error| error.to_string())?
+                    .error_for_status()
+                    .map_err(|error| error.to_string())
+            };
+
+            let (packages_result, archive_result) = tokio::join!(packages_probe, archive_probe);
+            packages_result?;
+
+            let archives = match archive_result {
+                Ok(_) => ArchiveSupport::Available,
+                Err(error)
+                    if error.contains("404 Not Found") || error.contains("403 Forbidden") =>
+                {
+                    ArchiveSupport::Unavailable
+                }
+                Err(error) => return Err(error),
+            };
+
+            Ok::<Arc<dyn PackageRepository>, String>(Arc::new(CranRepository::new(
+                client.clone(),
+                cran_url,
+                archives,
+            )))
+        };
+
+        tokio::pin!(rrepo_probe);
+        tokio::pin!(cran_probe);
+
+        tokio::select! {
+            rrepo_result = &mut rrepo_probe => {
+                match rrepo_result {
+                    Ok(repository) => Ok(repository),
+                    Err(rrepo_error) => {
+                        match cran_probe.await {
+                            Ok(repository) => Ok(repository),
+                            Err(cran_error) => Err(format!(
+                                "not an rrepo API ({rrepo_error}) or CRAN-like repository ({cran_error})"
+                            )),
+                        }
+                    }
+                }
+            }
+
+            cran_result = &mut cran_probe => {
+                match cran_result {
+                    Ok(repository) => Ok(repository),
+                    Err(cran_error) => {
+                        match rrepo_probe.await {
+                            Ok(repository) => Ok(repository),
+                            Err(rrepo_error) => Err(format!(
+                                "not an rrepo API ({rrepo_error}) or CRAN-like repository ({cran_error})"
+                            )),
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -62,50 +150,6 @@ impl PartialEq for dyn PackageRepository {
 }
 
 impl Eq for dyn PackageRepository {}
-
-pub async fn from_url(
-    client: &http::HttpClient,
-    value: &str,
-) -> Result<Arc<dyn PackageRepository>, String> {
-    let normalized_url = normalize_repository_url(value);
-    let url = Url::parse(&normalized_url)
-        .map_err(|error| format!("invalid repository URL {normalized_url}: {error}"))?;
-
-    let rrepo = RrepoRepository::from_url(client.clone(), url.clone());
-    let cran = CranRepository::from_url(client.clone(), url);
-    tokio::pin!(rrepo);
-    tokio::pin!(cran);
-
-    tokio::select! {
-        rrepo_result = &mut rrepo => {
-            match rrepo_result {
-                Ok(repository) => Ok(Arc::new(repository)),
-                Err(rrepo_error) => {
-                    match cran.await {
-                        Ok(repository) => Ok(Arc::new(repository)),
-                        Err(cran_error) => Err(format!(
-                            "not an rrepo API ({rrepo_error}) or CRAN-like repository ({cran_error})"
-                        )),
-                    }
-                }
-            }
-        }
-
-        cran_result = &mut cran => {
-            match cran_result {
-                Ok(repository) => Ok(Arc::new(repository)),
-                Err(cran_error) => {
-                    match rrepo.await {
-                        Ok(repository) => Ok(Arc::new(repository)),
-                        Err(rrepo_error) => Err(format!(
-                            "not an rrepo API ({rrepo_error}) or CRAN-like repository ({cran_error})"
-                        )),
-                    }
-                }
-            }
-        }
-    }
-}
 
 pub fn normalize_repository_url(value: &str) -> String {
     value.trim().trim_end_matches('/').to_string()

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -126,9 +126,7 @@ impl dyn PackageRepository {
         value: &str,
     ) -> Result<Arc<dyn PackageRepository>, RepositoryError> {
         let value = value.trim();
-        let url = Url::parse(value).map_err(|_| RepositoryError::InvalidUrl {
-            value: value.to_string(),
-        })?;
+        let url = parse_repository_url(value)?;
 
         let rrepo_url = url.clone();
         let rrepo_probe = async {
@@ -232,6 +230,19 @@ impl dyn PackageRepository {
     }
 }
 
+pub fn parse_repository_url(value: &str) -> Result<Url, RepositoryError> {
+    let value = value.trim();
+    let mut url = Url::parse(value).map_err(|_| RepositoryError::InvalidUrl {
+        value: value.to_string(),
+    })?;
+    url.path_segments_mut()
+        .map_err(|_| RepositoryError::InvalidUrl {
+            value: value.to_string(),
+        })?
+        .pop_if_empty();
+    Ok(url)
+}
+
 impl PartialEq for dyn PackageRepository {
     fn eq(&self, other: &Self) -> bool {
         self.equals(other)
@@ -239,8 +250,3 @@ impl PartialEq for dyn PackageRepository {
 }
 
 impl Eq for dyn PackageRepository {}
-
-#[deprecated(note = "parse into Url and canonicalize with path_segments_mut().pop_if_empty()")]
-pub fn normalize_repository_url(value: &str) -> String {
-    value.trim().trim_end_matches('/').to_string()
-}

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -1,34 +1,24 @@
+mod cran;
+mod local;
+mod rrepo;
+
 use crate::http;
-use crate::resolver::PackageVersion;
-use moka::future::Cache;
+use async_trait::async_trait;
 use r_description::lossless::{RDescription, Version};
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use std::{
-    cmp::Ordering,
+    any::Any,
     collections::{BTreeMap, BTreeSet},
-    hash::{Hash, Hasher},
+    fmt::Debug,
     sync::Arc,
 };
 
+pub use cran::CranRepository;
+pub use local::LocalRepository;
+pub use rrepo::RrepoRepository;
+
 pub const DEFAULT_REGISTRY_BASE_URL: &str = "https://upstream.rrepo.dev/cran";
-
-#[derive(Debug, Clone)]
-pub struct PackageRepository {
-    url: reqwest::Url,
-    repo_type: RepositoryType,
-    versions: Cache<String, BTreeSet<Version>>,
-    descriptions: Cache<(String, Version), Arc<RDescription>>,
-    rrepo_packages: Cache<(), Arc<http::RrepoPackagesResponse>>,
-    cran_packages: Cache<(), Arc<http::CranPackagesIndex>>,
-    cran_archives: Cache<String, BTreeSet<Version>>,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum RepositoryType {
-    Cran { archives: ArchiveSupport },
-    Rrepo,
-}
 
 #[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[serde(rename_all = "kebab-case")]
@@ -37,538 +27,83 @@ pub enum ArchiveSupport {
     Unavailable,
 }
 
-impl PackageRepository {
-    pub fn new(url: reqwest::Url, repo_type: RepositoryType) -> Self {
-        Self {
-            url,
-            repo_type,
-            versions: Cache::new(1024),
-            descriptions: Cache::new(4096),
-            rrepo_packages: Cache::new(1),
-            cran_packages: Cache::new(1),
-            cran_archives: Cache::new(1024),
-        }
-    }
+#[async_trait]
+pub trait PackageRepository: Any + Debug + Send + Sync {
+    fn as_any(&self) -> &dyn Any;
 
-    pub async fn from_url(client: &http::HttpClient, url: &str) -> Result<Self, String> {
-        let normalized_url = normalize_repository_url(url);
-        let base_url = reqwest::Url::parse(&normalized_url)
-            .map_err(|error| format!("invalid repository URL {normalized_url}: {error}"))?;
+    fn equals(&self, other: &dyn PackageRepository) -> bool;
 
-        let rrepo_base_url = base_url.clone();
-        let rrepo_probe = async move {
-            http::rrepo_repository_packages(client, &rrepo_base_url)
-                .await
-                .map_err(|error| error.to_string())?
-                .error_for_status()
-                .map_err(|error| error.to_string())?;
+    async fn packages(&self) -> Result<BTreeMap<String, Version>, String>;
 
-            Ok::<RepositoryType, String>(RepositoryType::Rrepo)
-        };
+    async fn versions(&self, package: &str) -> Result<BTreeSet<Version>, String>;
 
-        let cran_base_url = base_url.clone();
-        let cran_probe = async move {
-            let packages_probe = async {
-                http::cran_packages(client, &cran_base_url)
-                    .await
-                    .map_err(|error| error.to_string())?
-                    .error_for_status()
-                    .map_err(|error| error.to_string())
-            };
-
-            let archive_probe = async {
-                http::cran_archive_root(client, &cran_base_url)
-                    .await
-                    .map_err(|error| error.to_string())?
-                    .error_for_status()
-                    .map_err(|error| error.to_string())
-            };
-
-            let (packages_result, archive_result) = tokio::join!(packages_probe, archive_probe);
-
-            packages_result?;
-
-            let archives = match archive_result {
-                Ok(_) => ArchiveSupport::Available,
-                Err(error)
-                    if error.contains("404 Not Found") || error.contains("403 Forbidden") =>
-                {
-                    ArchiveSupport::Unavailable
-                }
-                Err(error) => return Err(error),
-            };
-
-            Ok::<RepositoryType, String>(RepositoryType::Cran { archives })
-        };
-
-        tokio::pin!(rrepo_probe);
-        tokio::pin!(cran_probe);
-
-        tokio::select! {
-            rrepo_result = &mut rrepo_probe => {
-                match rrepo_result {
-                    Ok(repo_type) => Ok(Self::new(base_url, repo_type)),
-                    Err(rrepo_error) => {
-                        match cran_probe.await {
-                            Ok(repo_type) => Ok(Self::new(base_url, repo_type)),
-                            Err(cran_error) => Err(format!(
-                                "not an rrepo API ({rrepo_error}) or CRAN-like repository ({cran_error})"
-                            )),
-                        }
-                    }
-                }
-            }
-
-            cran_result = &mut cran_probe => {
-                match cran_result {
-                    Ok(repo_type) => Ok(Self::new(base_url, repo_type)),
-                    Err(cran_error) => {
-                        match rrepo_probe.await {
-                            Ok(repo_type) => Ok(Self::new(base_url, repo_type)),
-                            Err(rrepo_error) => Err(format!(
-                                "not an rrepo API ({rrepo_error}) or CRAN-like repository ({cran_error})"
-                            )),
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    pub(crate) fn repo_type(&self) -> RepositoryType {
-        self.repo_type
-    }
-
-    pub(crate) fn base_url(&self) -> Url {
-        self.url.clone()
-    }
-
-    pub async fn packages(
+    async fn description(
         &self,
-        client: &http::HttpClient,
-    ) -> Result<BTreeMap<String, PackageVersion>, String> {
-        let repository = Arc::new(self.clone());
-
-        match self.repo_type {
-            RepositoryType::Rrepo => {
-                let response = self
-                    .rrepo_packages
-                    .try_get_with((), async {
-                        let response = http::rrepo_repository_packages(client, &self.url)
-                            .await
-                            .map_err(|error| error.to_string())?
-                            .error_for_status()
-                            .map_err(|error| error.to_string())?
-                            .json::<http::RrepoPackagesResponse>()
-                            .await
-                            .map_err(|error| error.to_string())?;
-
-                        Ok::<Arc<http::RrepoPackagesResponse>, String>(Arc::new(response))
-                    })
-                    .await
-                    .map_err(|error| error.as_ref().clone())?;
-
-                Ok(response
-                    .packages
-                    .iter()
-                    .filter_map(|package| {
-                        let version = match package.latest_version.parse::<Version>() {
-                            Ok(version) => version,
-                            Err(error) => {
-                                tracing::debug!(
-                                    package = %package.name,
-                                    version = %package.latest_version,
-                                    repository = %self.url,
-                                    error = %error,
-                                    "skipping package with invalid latest version"
-                                );
-                                return None;
-                            }
-                        };
-
-                        Some((
-                            package.name.clone(),
-                            PackageVersion::new(version, Arc::clone(&repository)),
-                        ))
-                    })
-                    .collect())
-            }
-
-            RepositoryType::Cran { .. } => {
-                let index = self
-                    .cran_packages
-                    .try_get_with((), async {
-                        let text = http::cran_packages(client, &self.url)
-                            .await
-                            .map_err(|error| error.to_string())?
-                            .error_for_status()
-                            .map_err(|error| error.to_string())?
-                            .text()
-                            .await
-                            .map_err(|error| error.to_string())?;
-
-                        let index = text
-                            .parse::<http::CranPackagesIndex>()
-                            .map_err(|error| error.to_string())?;
-
-                        Ok::<Arc<http::CranPackagesIndex>, String>(Arc::new(index))
-                    })
-                    .await
-                    .map_err(|error| error.as_ref().clone())?;
-
-                Ok(index
-                    .packages
-                    .iter()
-                    .filter_map(|package| {
-                        let version = match package.version.parse::<Version>() {
-                            Ok(version) => version,
-                            Err(error) => {
-                                tracing::debug!(
-                                    package = %package.package,
-                                    version = %package.version,
-                                    repository = %self.url,
-                                    error = %error,
-                                    "skipping package with invalid latest version"
-                                );
-                                return None;
-                            }
-                        };
-
-                        Some((
-                            package.package.clone(),
-                            PackageVersion::new(version, Arc::clone(&repository)),
-                        ))
-                    })
-                    .collect())
-            }
-        }
-    }
-
-    pub async fn versions(
-        &self,
-        client: &http::HttpClient,
-        package: &str,
-    ) -> Result<BTreeSet<PackageVersion>, String> {
-        let repository = Arc::new(self.clone());
-
-        let versions = match self.repo_type {
-            RepositoryType::Rrepo => self
-                .versions
-                .try_get_with(package.to_string(), async {
-                    let response = http::rrepo_package_versions(client, &self.url, package)
-                        .await
-                        .map_err(|error| error.to_string())?
-                        .error_for_status()
-                        .map_err(|error| error.to_string())?
-                        .json::<http::RrepoPackageVersionsResponse>()
-                        .await
-                        .map_err(|error| error.to_string())?;
-
-                    response
-                        .versions
-                        .into_iter()
-                        .map(|summary| {
-                            summary.version.parse::<Version>().map_err(|error| {
-                                format!(
-                                    "invalid version {} for {package}: {error}",
-                                    summary.version
-                                )
-                            })
-                        })
-                        .collect::<Result<BTreeSet<_>, String>>()
-                })
-                .await
-                .map_err(|error| error.as_ref().clone())?,
-
-            RepositoryType::Cran { archives } => {
-                let index = self
-                    .cran_packages
-                    .try_get_with((), async {
-                        let text = http::cran_packages(client, &self.url)
-                            .await
-                            .map_err(|error| error.to_string())?
-                            .error_for_status()
-                            .map_err(|error| error.to_string())?
-                            .text()
-                            .await
-                            .map_err(|error| error.to_string())?;
-
-                        let index = text
-                            .parse::<http::CranPackagesIndex>()
-                            .map_err(|error| error.to_string())?;
-
-                        Ok::<Arc<http::CranPackagesIndex>, String>(Arc::new(index))
-                    })
-                    .await
-                    .map_err(|error| error.as_ref().clone())?;
-
-                let mut versions = index
-                    .packages
-                    .iter()
-                    .filter(|entry| entry.package == package)
-                    .map(|entry| {
-                        entry.version.parse::<Version>().map_err(|error| {
-                            format!("invalid version {} for {package}: {error}", entry.version)
-                        })
-                    })
-                    .collect::<Result<BTreeSet<_>, String>>()?;
-
-                if archives == ArchiveSupport::Available {
-                    let archived_versions = self
-                        .cran_archives
-                        .try_get_with(package.to_string(), async {
-                            let listing =
-                                http::cran_package_archive_listing(client, &self.url, package)
-                                    .await
-                                    .map_err(|error| error.to_string())?
-                                    .error_for_status()
-                                    .map_err(|error| error.to_string())?
-                                    .text()
-                                    .await
-                                    .map_err(|error| error.to_string())?;
-
-                            let listing = listing
-                                .parse::<http::CranPackageArchiveListing>()
-                                .map_err(|error| error.to_string())?;
-
-                            Ok::<BTreeSet<Version>, String>(listing.versions.into_iter().collect())
-                        })
-                        .await
-                        .map_err(|error| error.as_ref().clone())?;
-
-                    versions.extend(archived_versions);
-                }
-
-                versions
-            }
-        };
-
-        tracing::trace!(
-            package,
-            repository = %self.url,
-            versions = versions.len(),
-            "loaded package versions"
-        );
-
-        Ok(versions
-            .into_iter()
-            .map(|version| PackageVersion::new(version, Arc::clone(&repository)))
-            .collect())
-    }
-
-    pub async fn description(
-        &self,
-        client: &http::HttpClient,
         package: &str,
         version: &Version,
-    ) -> Result<Arc<RDescription>, String> {
-        let key = (package.to_string(), version.clone());
+    ) -> Result<Arc<RDescription>, String>;
+}
 
-        self.descriptions
-            .try_get_with(key, async {
-                let description = match self.repo_type {
-                    RepositoryType::Rrepo => http::rrepo_package_description(
-                        client,
-                        &self.url,
-                        package,
-                        &version.to_string(),
-                    )
-                    .await
-                    .map_err(|error| error.to_string())?
-                    .error_for_status()
-                    .map_err(|error| error.to_string())?
-                    .text()
-                    .await
-                    .map_err(|error| error.to_string())?
-                    .parse::<RDescription>()
-                    .map_err(|error| {
-                        format!("failed to parse DESCRIPTION for {package} {version}: {error}")
-                    })?,
+#[async_trait]
+pub trait RepositoryFromUrl: PackageRepository + Sized {
+    async fn from_url(client: http::HttpClient, url: Url) -> Result<Self, String>;
+}
 
-                    RepositoryType::Cran { .. } => {
-                        let index = self
-                            .cran_packages
-                            .try_get_with((), async {
-                                let text = http::cran_packages(client, &self.url)
-                                    .await
-                                    .map_err(|error| error.to_string())?
-                                    .error_for_status()
-                                    .map_err(|error| error.to_string())?
-                                    .text()
-                                    .await
-                                    .map_err(|error| error.to_string())?;
+impl dyn PackageRepository {
+    pub fn downcast_ref<T: PackageRepository + 'static>(&self) -> Option<&T> {
+        self.as_any().downcast_ref()
+    }
+}
 
-                                let index = text
-                                    .parse::<http::CranPackagesIndex>()
-                                    .map_err(|error| error.to_string())?;
+impl PartialEq for dyn PackageRepository {
+    fn eq(&self, other: &Self) -> bool {
+        self.equals(other)
+    }
+}
 
-                                Ok::<Arc<http::CranPackagesIndex>, String>(Arc::new(index))
-                            })
-                            .await
-                            .map_err(|error| error.as_ref().clone())?;
+impl Eq for dyn PackageRepository {}
 
-                        let version_string = version.to_string();
+pub async fn from_url(
+    client: &http::HttpClient,
+    value: &str,
+) -> Result<Arc<dyn PackageRepository>, String> {
+    let normalized_url = normalize_repository_url(value);
+    let url = Url::parse(&normalized_url)
+        .map_err(|error| format!("invalid repository URL {normalized_url}: {error}"))?;
 
-                        if let Some(entry) = index.packages.iter().find(|entry| {
-                            entry.package == package && entry.version == version_string
-                        }) {
-                            cran_packages_entry_to_description(entry)?
-                        } else {
-                            let response = http::cran_archive_source_tarball(
-                                client,
-                                &self.url,
-                                package,
-                                &version_string,
-                            )
-                            .await
-                            .map_err(|error| error.to_string())?
-                            .error_for_status()
-                            .map_err(|error| error.to_string())?;
+    let rrepo = RrepoRepository::from_url(client.clone(), url.clone());
+    let cran = CranRepository::from_url(client.clone(), url);
+    tokio::pin!(rrepo);
+    tokio::pin!(cran);
 
-                            description_from_source_tarball_response(response, package).await?
-                        }
+    tokio::select! {
+        rrepo_result = &mut rrepo => {
+            match rrepo_result {
+                Ok(repository) => Ok(Arc::new(repository)),
+                Err(rrepo_error) => {
+                    match cran.await {
+                        Ok(repository) => Ok(Arc::new(repository)),
+                        Err(cran_error) => Err(format!(
+                            "not an rrepo API ({rrepo_error}) or CRAN-like repository ({cran_error})"
+                        )),
                     }
-                };
-
-                tracing::trace!(
-                    package,
-                    version = %version,
-                    repository = %self.url,
-                    "fetched package description"
-                );
-
-                Ok::<Arc<RDescription>, String>(Arc::new(description))
-            })
-            .await
-            .map_err(|error| error.as_ref().clone())
-    }
-}
-
-fn cran_packages_entry_to_description(
-    entry: &http::CranPackageIndexEntry,
-) -> Result<RDescription, String> {
-    let mut description = RDescription::new();
-
-    description.set_package(&entry.package);
-    description.set_version(&entry.version);
-
-    if !entry.depends.is_empty() {
-        description.set_depends(entry.depends.clone());
-    }
-
-    if !entry.imports.is_empty() {
-        description.set_imports(entry.imports.clone());
-    }
-
-    if !entry.suggests.is_empty() {
-        description.set_suggests(entry.suggests.clone());
-    }
-
-    if !entry.linking_to.is_empty() {
-        description.set_linking_to(entry.linking_to.clone());
-    }
-
-    if let Some(system_requirements) = &entry.system_requirements {
-        description.set_system_requirements(&[system_requirements]);
-    }
-
-    Ok(description)
-}
-
-async fn description_from_source_tarball_response(
-    response: reqwest::Response,
-    package: &str,
-) -> Result<RDescription, String> {
-    use futures_util::TryStreamExt;
-    use std::io::Read;
-
-    let mut bytes = Vec::with_capacity(response.content_length().unwrap_or_default() as usize);
-    let mut stream = response.bytes_stream();
-
-    while let Some(chunk) = stream
-        .try_next()
-        .await
-        .map_err(|error| format!("failed to read source package response body: {error}"))?
-    {
-        bytes.extend_from_slice(&chunk);
-    }
-
-    let decoder = flate2::read::GzDecoder::new(bytes.as_slice());
-    let mut archive = tar::Archive::new(decoder);
-
-    let entries = archive
-        .entries()
-        .map_err(|error| format!("failed to read source package archive: {error}"))?;
-
-    for entry in entries {
-        let mut entry = entry
-            .map_err(|error| format!("failed to read source package archive entry: {error}"))?;
-
-        let is_description = {
-            let path = entry
-                .path()
-                .map_err(|error| format!("failed to read source package archive path: {error}"))?;
-
-            path_is_top_level_description(&path, package)
-        };
-
-        if !is_description {
-            continue;
+                }
+            }
         }
 
-        let mut body = String::new();
-        entry
-            .read_to_string(&mut body)
-            .map_err(|error| format!("failed to read DESCRIPTION from source package: {error}"))?;
-
-        return body.parse::<RDescription>().map_err(|error| {
-            format!("failed to parse DESCRIPTION from source package for {package}: {error}")
-        });
-    }
-
-    Err(format!(
-        "source package does not contain {package}/DESCRIPTION"
-    ))
-}
-
-fn path_is_top_level_description(path: &std::path::Path, package: &str) -> bool {
-    let mut components = path.components().filter_map(|component| {
-        let component = component.as_os_str().to_str()?;
-        (component != ".").then_some(component)
-    });
-
-    components.next() == Some(package)
-        && components.next() == Some("DESCRIPTION")
-        && components.next().is_none()
-}
-
-impl PartialEq for PackageRepository {
-    fn eq(&self, other: &Self) -> bool {
-        self.url == other.url && self.repo_type == other.repo_type
-    }
-}
-
-impl Eq for PackageRepository {}
-
-impl PartialOrd for PackageRepository {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for PackageRepository {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.url
-            .as_str()
-            .cmp(other.url.as_str())
-            .then_with(|| self.repo_type.cmp(&other.repo_type))
-    }
-}
-
-impl Hash for PackageRepository {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.url.as_str().hash(state);
-        self.repo_type.hash(state);
+        cran_result = &mut cran => {
+            match cran_result {
+                Ok(repository) => Ok(Arc::new(repository)),
+                Err(cran_error) => {
+                    match rrepo.await {
+                        Ok(repository) => Ok(Arc::new(repository)),
+                        Err(rrepo_error) => Err(format!(
+                            "not an rrepo API ({rrepo_error}) or CRAN-like repository ({cran_error})"
+                        )),
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/src/repository/cran.rs
+++ b/src/repository/cran.rs
@@ -1,0 +1,323 @@
+use super::{ArchiveSupport, PackageRepository, RepositoryFromUrl};
+use crate::http;
+use async_trait::async_trait;
+use futures_util::TryStreamExt;
+use moka::future::Cache;
+use r_description::lossless::{RDescription, Version};
+use reqwest::Url;
+use std::{
+    any::Any,
+    collections::{BTreeMap, BTreeSet},
+    io::Read,
+    sync::Arc,
+};
+
+#[derive(Debug, Clone)]
+pub struct CranRepository {
+    url: Url,
+    client: http::HttpClient,
+    archives: ArchiveSupport,
+    packages: Cache<(), Arc<http::CranPackagesIndex>>,
+    archive_versions: Cache<String, BTreeSet<Version>>,
+    descriptions: Cache<(String, Version), Arc<RDescription>>,
+}
+
+impl CranRepository {
+    pub fn new(client: http::HttpClient, url: Url, archives: ArchiveSupport) -> Self {
+        Self {
+            url,
+            client,
+            archives,
+            packages: Cache::new(1),
+            archive_versions: Cache::new(1024),
+            descriptions: Cache::new(4096),
+        }
+    }
+
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+
+    pub fn archive_support(&self) -> ArchiveSupport {
+        self.archives
+    }
+
+    async fn packages_index(&self) -> Result<Arc<http::CranPackagesIndex>, String> {
+        self.packages
+            .try_get_with((), async {
+                let text = http::cran_packages(&self.client, &self.url)
+                    .await
+                    .map_err(|error| error.to_string())?
+                    .error_for_status()
+                    .map_err(|error| error.to_string())?
+                    .text()
+                    .await
+                    .map_err(|error| error.to_string())?;
+
+                let index = text
+                    .parse::<http::CranPackagesIndex>()
+                    .map_err(|error| error.to_string())?;
+
+                Ok::<Arc<http::CranPackagesIndex>, String>(Arc::new(index))
+            })
+            .await
+            .map_err(|error| error.as_ref().clone())
+    }
+}
+
+#[async_trait]
+impl RepositoryFromUrl for CranRepository {
+    async fn from_url(client: http::HttpClient, url: Url) -> Result<Self, String> {
+        let packages_probe = async {
+            http::cran_packages(&client, &url)
+                .await
+                .map_err(|error| error.to_string())?
+                .error_for_status()
+                .map_err(|error| error.to_string())
+        };
+        let archive_probe = async {
+            http::cran_archive_root(&client, &url)
+                .await
+                .map_err(|error| error.to_string())?
+                .error_for_status()
+                .map_err(|error| error.to_string())
+        };
+
+        let (packages_result, archive_result) = tokio::join!(packages_probe, archive_probe);
+        packages_result?;
+
+        let archives = match archive_result {
+            Ok(_) => ArchiveSupport::Available,
+            Err(error) if error.contains("404 Not Found") || error.contains("403 Forbidden") => {
+                ArchiveSupport::Unavailable
+            }
+            Err(error) => return Err(error),
+        };
+
+        Ok(Self::new(client, url, archives))
+    }
+}
+
+#[async_trait]
+impl PackageRepository for CranRepository {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn equals(&self, other: &dyn PackageRepository) -> bool {
+        other
+            .as_any()
+            .downcast_ref::<Self>()
+            .is_some_and(|other| self.url == other.url)
+    }
+
+    async fn packages(&self) -> Result<BTreeMap<String, Version>, String> {
+        let index = self.packages_index().await?;
+
+        Ok(index
+            .packages
+            .iter()
+            .filter_map(|package| {
+                let version = match package.version.parse::<Version>() {
+                    Ok(version) => version,
+                    Err(error) => {
+                        tracing::debug!(
+                            package = %package.package,
+                            version = %package.version,
+                            repository = %self.url,
+                            error = %error,
+                            "skipping package with invalid latest version"
+                        );
+                        return None;
+                    }
+                };
+
+                Some((package.package.clone(), version))
+            })
+            .collect())
+    }
+
+    async fn versions(&self, package: &str) -> Result<BTreeSet<Version>, String> {
+        let index = self.packages_index().await?;
+        let mut versions = index
+            .packages
+            .iter()
+            .filter(|entry| entry.package == package)
+            .map(|entry| {
+                entry.version.parse::<Version>().map_err(|error| {
+                    format!("invalid version {} for {package}: {error}", entry.version)
+                })
+            })
+            .collect::<Result<BTreeSet<_>, String>>()?;
+
+        if self.archives == ArchiveSupport::Available {
+            let archived_versions = self
+                .archive_versions
+                .try_get_with(package.to_string(), async {
+                    let listing =
+                        http::cran_package_archive_listing(&self.client, &self.url, package)
+                            .await
+                            .map_err(|error| error.to_string())?
+                            .error_for_status()
+                            .map_err(|error| error.to_string())?
+                            .text()
+                            .await
+                            .map_err(|error| error.to_string())?
+                            .parse::<http::CranPackageArchiveListing>()
+                            .map_err(|error| error.to_string())?;
+
+                    Ok::<BTreeSet<Version>, String>(listing.versions.into_iter().collect())
+                })
+                .await
+                .map_err(|error| error.as_ref().clone())?;
+
+            versions.extend(archived_versions);
+        }
+
+        tracing::trace!(
+            package,
+            repository = %self.url,
+            versions = versions.len(),
+            "loaded package versions"
+        );
+
+        Ok(versions)
+    }
+
+    async fn description(
+        &self,
+        package: &str,
+        version: &Version,
+    ) -> Result<Arc<RDescription>, String> {
+        let key = (package.to_string(), version.clone());
+
+        self.descriptions
+            .try_get_with(key, async {
+                let index = self.packages_index().await?;
+                let version_string = version.to_string();
+
+                let description = if let Some(entry) = index
+                    .packages
+                    .iter()
+                    .find(|entry| entry.package == package && entry.version == version_string)
+                {
+                    packages_entry_to_description(entry)
+                } else {
+                    let response = http::cran_archive_source_tarball(
+                        &self.client,
+                        &self.url,
+                        package,
+                        &version_string,
+                    )
+                    .await
+                    .map_err(|error| error.to_string())?
+                    .error_for_status()
+                    .map_err(|error| error.to_string())?;
+
+                    description_from_source_tarball_response(response, package).await?
+                };
+
+                tracing::trace!(
+                    package,
+                    version = %version,
+                    repository = %self.url,
+                    "fetched package description"
+                );
+
+                Ok::<Arc<RDescription>, String>(Arc::new(description))
+            })
+            .await
+            .map_err(|error| error.as_ref().clone())
+    }
+}
+
+fn packages_entry_to_description(entry: &http::CranPackageIndexEntry) -> RDescription {
+    let mut description = RDescription::new();
+
+    description.set_package(&entry.package);
+    description.set_version(&entry.version);
+
+    if !entry.depends.is_empty() {
+        description.set_depends(entry.depends.clone());
+    }
+
+    if !entry.imports.is_empty() {
+        description.set_imports(entry.imports.clone());
+    }
+
+    if !entry.suggests.is_empty() {
+        description.set_suggests(entry.suggests.clone());
+    }
+
+    if !entry.linking_to.is_empty() {
+        description.set_linking_to(entry.linking_to.clone());
+    }
+
+    if let Some(system_requirements) = &entry.system_requirements {
+        description.set_system_requirements(&[system_requirements]);
+    }
+
+    description
+}
+
+async fn description_from_source_tarball_response(
+    response: reqwest::Response,
+    package: &str,
+) -> Result<RDescription, String> {
+    let mut bytes = Vec::with_capacity(response.content_length().unwrap_or_default() as usize);
+    let mut stream = response.bytes_stream();
+
+    while let Some(chunk) = stream
+        .try_next()
+        .await
+        .map_err(|error| format!("failed to read source package response body: {error}"))?
+    {
+        bytes.extend_from_slice(&chunk);
+    }
+
+    let decoder = flate2::read::GzDecoder::new(bytes.as_slice());
+    let mut archive = tar::Archive::new(decoder);
+    let entries = archive
+        .entries()
+        .map_err(|error| format!("failed to read source package archive: {error}"))?;
+
+    for entry in entries {
+        let mut entry = entry
+            .map_err(|error| format!("failed to read source package archive entry: {error}"))?;
+        let is_description = {
+            let path = entry
+                .path()
+                .map_err(|error| format!("failed to read source package archive path: {error}"))?;
+
+            path_is_top_level_description(&path, package)
+        };
+
+        if !is_description {
+            continue;
+        }
+
+        let mut body = String::new();
+        entry
+            .read_to_string(&mut body)
+            .map_err(|error| format!("failed to read DESCRIPTION from source package: {error}"))?;
+
+        return body.parse::<RDescription>().map_err(|error| {
+            format!("failed to parse DESCRIPTION from source package for {package}: {error}")
+        });
+    }
+
+    Err(format!(
+        "source package does not contain {package}/DESCRIPTION"
+    ))
+}
+
+fn path_is_top_level_description(path: &std::path::Path, package: &str) -> bool {
+    let mut components = path.components().filter_map(|component| {
+        let component = component.as_os_str().to_str()?;
+        (component != ".").then_some(component)
+    });
+
+    components.next() == Some(package)
+        && components.next() == Some("DESCRIPTION")
+        && components.next().is_none()
+}

--- a/src/repository/cran.rs
+++ b/src/repository/cran.rs
@@ -1,4 +1,4 @@
-use super::{ArchiveSupport, PackageRepository, RepositoryFromUrl};
+use super::{ArchiveSupport, PackageRepository};
 use crate::http;
 use async_trait::async_trait;
 use futures_util::TryStreamExt;
@@ -62,39 +62,6 @@ impl CranRepository {
             })
             .await
             .map_err(|error| error.as_ref().clone())
-    }
-}
-
-#[async_trait]
-impl RepositoryFromUrl for CranRepository {
-    async fn from_url(client: http::HttpClient, url: Url) -> Result<Self, String> {
-        let packages_probe = async {
-            http::cran_packages(&client, &url)
-                .await
-                .map_err(|error| error.to_string())?
-                .error_for_status()
-                .map_err(|error| error.to_string())
-        };
-        let archive_probe = async {
-            http::cran_archive_root(&client, &url)
-                .await
-                .map_err(|error| error.to_string())?
-                .error_for_status()
-                .map_err(|error| error.to_string())
-        };
-
-        let (packages_result, archive_result) = tokio::join!(packages_probe, archive_probe);
-        packages_result?;
-
-        let archives = match archive_result {
-            Ok(_) => ArchiveSupport::Available,
-            Err(error) if error.contains("404 Not Found") || error.contains("403 Forbidden") => {
-                ArchiveSupport::Unavailable
-            }
-            Err(error) => return Err(error),
-        };
-
-        Ok(Self::new(client, url, archives))
     }
 }
 

--- a/src/repository/cran.rs
+++ b/src/repository/cran.rs
@@ -1,5 +1,5 @@
-use super::{ArchiveSupport, PackageRepository};
-use crate::http;
+use super::{ArchiveSupport, PackageRepository, RepositoryError};
+use crate::{http, resolver::PackageVersion};
 use async_trait::async_trait;
 use futures_util::TryStreamExt;
 use moka::future::Cache;
@@ -15,7 +15,6 @@ use std::{
 #[derive(Debug, Clone)]
 pub struct CranRepository {
     url: Url,
-    client: http::HttpClient,
     archives: ArchiveSupport,
     packages: Cache<(), Arc<http::CranPackagesIndex>>,
     archive_versions: Cache<String, BTreeSet<Version>>,
@@ -23,10 +22,13 @@ pub struct CranRepository {
 }
 
 impl CranRepository {
-    pub fn new(client: http::HttpClient, url: Url, archives: ArchiveSupport) -> Self {
+    pub fn new(mut url: Url, archives: ArchiveSupport) -> Self {
+        url.path_segments_mut()
+            .expect("repository base URL should support path segments")
+            .pop_if_empty();
+
         Self {
             url,
-            client,
             archives,
             packages: Cache::new(1),
             archive_versions: Cache::new(1024),
@@ -42,26 +44,37 @@ impl CranRepository {
         self.archives
     }
 
-    async fn packages_index(&self) -> Result<Arc<http::CranPackagesIndex>, String> {
+    async fn packages_index(
+        &self,
+        client: &http::HttpClient,
+    ) -> Result<Arc<http::CranPackagesIndex>, RepositoryError> {
         self.packages
             .try_get_with((), async {
-                let text = http::cran_packages(&self.client, &self.url)
+                let text = http::cran_packages(client, &self.url)
                     .await
-                    .map_err(|error| error.to_string())?
+                    .map_err(|source| RepositoryError::Request {
+                        source: Arc::new(source),
+                    })?
                     .error_for_status()
-                    .map_err(|error| error.to_string())?
+                    .map_err(|source| RepositoryError::Response {
+                        source: Arc::new(source),
+                    })?
                     .text()
                     .await
-                    .map_err(|error| error.to_string())?;
+                    .map_err(|source| RepositoryError::Response {
+                        source: Arc::new(source),
+                    })?;
+                let index = text.parse::<http::CranPackagesIndex>().map_err(|details| {
+                    RepositoryError::InvalidData {
+                        resource: "CRAN PACKAGES index".to_string(),
+                        details,
+                    }
+                })?;
 
-                let index = text
-                    .parse::<http::CranPackagesIndex>()
-                    .map_err(|error| error.to_string())?;
-
-                Ok::<Arc<http::CranPackagesIndex>, String>(Arc::new(index))
+                Ok::<Arc<http::CranPackagesIndex>, RepositoryError>(Arc::new(index))
             })
             .await
-            .map_err(|error| error.as_ref().clone())
+            .map_err(Arc::unwrap_or_clone)
     }
 }
 
@@ -75,11 +88,15 @@ impl PackageRepository for CranRepository {
         other
             .as_any()
             .downcast_ref::<Self>()
-            .is_some_and(|other| self.url == other.url)
+            .is_some_and(|other| self.url == other.url && self.archives == other.archives)
     }
 
-    async fn packages(&self) -> Result<BTreeMap<String, Version>, String> {
-        let index = self.packages_index().await?;
+    async fn packages(
+        &self,
+        client: &http::HttpClient,
+    ) -> Result<BTreeMap<String, PackageVersion>, RepositoryError> {
+        let repository: Arc<dyn PackageRepository> = Arc::new(self.clone());
+        let index = self.packages_index(client).await?;
 
         Ok(index
             .packages
@@ -99,44 +116,69 @@ impl PackageRepository for CranRepository {
                     }
                 };
 
-                Some((package.package.clone(), version))
+                Some((
+                    package.package.clone(),
+                    PackageVersion::new(version, Arc::clone(&repository)),
+                ))
             })
             .collect())
     }
 
-    async fn versions(&self, package: &str) -> Result<BTreeSet<Version>, String> {
-        let index = self.packages_index().await?;
+    async fn versions(
+        &self,
+        client: &http::HttpClient,
+        package: &str,
+    ) -> Result<BTreeSet<PackageVersion>, RepositoryError> {
+        let repository: Arc<dyn PackageRepository> = Arc::new(self.clone());
+        let index = self.packages_index(client).await?;
         let mut versions = index
             .packages
             .iter()
             .filter(|entry| entry.package == package)
             .map(|entry| {
-                entry.version.parse::<Version>().map_err(|error| {
-                    format!("invalid version {} for {package}: {error}", entry.version)
-                })
+                entry
+                    .version
+                    .parse::<Version>()
+                    .map_err(|details| RepositoryError::InvalidData {
+                        resource: "package version".to_string(),
+                        details,
+                    })
             })
-            .collect::<Result<BTreeSet<_>, String>>()?;
+            .collect::<Result<BTreeSet<_>, RepositoryError>>()?;
+
+        if versions.is_empty() {
+            return Ok(BTreeSet::new());
+        }
 
         if self.archives == ArchiveSupport::Available {
             let archived_versions = self
                 .archive_versions
                 .try_get_with(package.to_string(), async {
+                    let text = http::cran_package_archive_listing(client, &self.url, package)
+                        .await
+                        .map_err(|source| RepositoryError::Request {
+                            source: Arc::new(source),
+                        })?
+                        .error_for_status()
+                        .map_err(|source| RepositoryError::Response {
+                            source: Arc::new(source),
+                        })?
+                        .text()
+                        .await
+                        .map_err(|source| RepositoryError::Response {
+                            source: Arc::new(source),
+                        })?;
                     let listing =
-                        http::cran_package_archive_listing(&self.client, &self.url, package)
-                            .await
-                            .map_err(|error| error.to_string())?
-                            .error_for_status()
-                            .map_err(|error| error.to_string())?
-                            .text()
-                            .await
-                            .map_err(|error| error.to_string())?
-                            .parse::<http::CranPackageArchiveListing>()
-                            .map_err(|error| error.to_string())?;
+                        text.parse::<http::CranPackageArchiveListing>()
+                            .map_err(|details| RepositoryError::InvalidData {
+                                resource: "CRAN package archive listing".to_string(),
+                                details,
+                            })?;
 
-                    Ok::<BTreeSet<Version>, String>(listing.versions.into_iter().collect())
+                    Ok::<BTreeSet<Version>, RepositoryError>(listing.versions.into_iter().collect())
                 })
                 .await
-                .map_err(|error| error.as_ref().clone())?;
+                .map_err(Arc::unwrap_or_clone)?;
 
             versions.extend(archived_versions);
         }
@@ -148,19 +190,23 @@ impl PackageRepository for CranRepository {
             "loaded package versions"
         );
 
-        Ok(versions)
+        Ok(versions
+            .into_iter()
+            .map(|version| PackageVersion::new(version, Arc::clone(&repository)))
+            .collect())
     }
 
     async fn description(
         &self,
+        client: &http::HttpClient,
         package: &str,
         version: &Version,
-    ) -> Result<Arc<RDescription>, String> {
+    ) -> Result<Arc<RDescription>, RepositoryError> {
         let key = (package.to_string(), version.clone());
 
         self.descriptions
             .try_get_with(key, async {
-                let index = self.packages_index().await?;
+                let index = self.packages_index(client).await?;
                 let version_string = version.to_string();
 
                 let description = if let Some(entry) = index
@@ -171,15 +217,19 @@ impl PackageRepository for CranRepository {
                     packages_entry_to_description(entry)
                 } else {
                     let response = http::cran_archive_source_tarball(
-                        &self.client,
+                        client,
                         &self.url,
                         package,
                         &version_string,
                     )
                     .await
-                    .map_err(|error| error.to_string())?
+                    .map_err(|source| RepositoryError::Request {
+                        source: Arc::new(source),
+                    })?
                     .error_for_status()
-                    .map_err(|error| error.to_string())?;
+                    .map_err(|source| RepositoryError::Response {
+                        source: Arc::new(source),
+                    })?;
 
                     description_from_source_tarball_response(response, package).await?
                 };
@@ -191,10 +241,10 @@ impl PackageRepository for CranRepository {
                     "fetched package description"
                 );
 
-                Ok::<Arc<RDescription>, String>(Arc::new(description))
+                Ok::<Arc<RDescription>, RepositoryError>(Arc::new(description))
             })
             .await
-            .map_err(|error| error.as_ref().clone())
+            .map_err(Arc::unwrap_or_clone)
     }
 }
 
@@ -230,14 +280,16 @@ fn packages_entry_to_description(entry: &http::CranPackageIndexEntry) -> RDescri
 async fn description_from_source_tarball_response(
     response: reqwest::Response,
     package: &str,
-) -> Result<RDescription, String> {
+) -> Result<RDescription, RepositoryError> {
     let mut bytes = Vec::with_capacity(response.content_length().unwrap_or_default() as usize);
     let mut stream = response.bytes_stream();
 
     while let Some(chunk) = stream
         .try_next()
         .await
-        .map_err(|error| format!("failed to read source package response body: {error}"))?
+        .map_err(|source| RepositoryError::Response {
+            source: Arc::new(source),
+        })?
     {
         bytes.extend_from_slice(&chunk);
     }
@@ -246,15 +298,18 @@ async fn description_from_source_tarball_response(
     let mut archive = tar::Archive::new(decoder);
     let entries = archive
         .entries()
-        .map_err(|error| format!("failed to read source package archive: {error}"))?;
+        .map_err(|source| RepositoryError::Archive {
+            source: Arc::new(source),
+        })?;
 
     for entry in entries {
-        let mut entry = entry
-            .map_err(|error| format!("failed to read source package archive entry: {error}"))?;
+        let mut entry = entry.map_err(|source| RepositoryError::Archive {
+            source: Arc::new(source),
+        })?;
         let is_description = {
-            let path = entry
-                .path()
-                .map_err(|error| format!("failed to read source package archive path: {error}"))?;
+            let path = entry.path().map_err(|source| RepositoryError::Archive {
+                source: Arc::new(source),
+            })?;
 
             path_is_top_level_description(&path, package)
         };
@@ -266,16 +321,21 @@ async fn description_from_source_tarball_response(
         let mut body = String::new();
         entry
             .read_to_string(&mut body)
-            .map_err(|error| format!("failed to read DESCRIPTION from source package: {error}"))?;
+            .map_err(|source| RepositoryError::Archive {
+                source: Arc::new(source),
+            })?;
 
-        return body.parse::<RDescription>().map_err(|error| {
-            format!("failed to parse DESCRIPTION from source package for {package}: {error}")
-        });
+        return body
+            .parse::<RDescription>()
+            .map_err(|source| RepositoryError::Description {
+                location: format!("in source package for {package}"),
+                source: Arc::new(source),
+            });
     }
 
-    Err(format!(
-        "source package does not contain {package}/DESCRIPTION"
-    ))
+    Err(RepositoryError::DescriptionNotFound {
+        package: package.to_string(),
+    })
 }
 
 fn path_is_top_level_description(path: &std::path::Path, package: &str) -> bool {

--- a/src/repository/cran.rs
+++ b/src/repository/cran.rs
@@ -21,6 +21,12 @@ pub struct CranRepository {
     descriptions: Cache<(String, Version), Arc<RDescription>>,
 }
 
+impl std::fmt::Display for CranRepository {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.url.fmt(formatter)
+    }
+}
+
 impl CranRepository {
     pub fn new(mut url: Url, archives: ArchiveSupport) -> Self {
         url.path_segments_mut()

--- a/src/repository/local.rs
+++ b/src/repository/local.rs
@@ -1,4 +1,5 @@
-use super::PackageRepository;
+use super::{PackageRepository, RepositoryError};
+use crate::{http, resolver::PackageVersion};
 use async_trait::async_trait;
 use r_description::lossless::{RDescription, Version};
 use std::{
@@ -31,36 +32,48 @@ impl LocalRepository {
         &self.path
     }
 
-    async fn effective_description(&self) -> Result<Arc<RDescription>, String> {
+    async fn effective_description(&self) -> Result<Arc<RDescription>, RepositoryError> {
         if let Some(description) = &self.description_override {
             return Ok(Arc::clone(description));
         }
 
         let path = self.path.join("DESCRIPTION");
-        let contents = tokio::fs::read_to_string(&path).await.map_err(|error| {
-            format!("failed to read DESCRIPTION at {}: {error}", path.display())
-        })?;
-        let description = contents.parse::<RDescription>().map_err(|error| {
-            format!("failed to parse DESCRIPTION at {}: {error}", path.display())
-        })?;
+        let contents =
+            tokio::fs::read_to_string(&path)
+                .await
+                .map_err(|source| RepositoryError::FileRead {
+                    path: path.clone(),
+                    source: Arc::new(source),
+                })?;
+        let description =
+            contents
+                .parse::<RDescription>()
+                .map_err(|source| RepositoryError::Description {
+                    location: format!("at {}", path.display()),
+                    source: Arc::new(source),
+                })?;
 
         Ok(Arc::new(description))
     }
 
-    async fn package_and_version(&self) -> Result<(String, Version), String> {
+    async fn package_and_version(&self) -> Result<(String, Version), RepositoryError> {
         let description = self.effective_description().await?;
         let package = description
             .package()
-            .ok_or_else(|| format!("DESCRIPTION at {} is missing Package", self.path.display()))?;
+            .ok_or_else(|| RepositoryError::MissingField {
+                path: self.path.join("DESCRIPTION"),
+                field: "Package",
+            })?;
         let version = description
             .version()
-            .ok_or_else(|| format!("DESCRIPTION at {} is missing Version", self.path.display()))?
+            .ok_or_else(|| RepositoryError::MissingField {
+                path: self.path.join("DESCRIPTION"),
+                field: "Version",
+            })?
             .parse::<Version>()
-            .map_err(|error| {
-                format!(
-                    "invalid Version in DESCRIPTION at {}: {error}",
-                    self.path.display()
-                )
+            .map_err(|details| RepositoryError::InvalidData {
+                resource: format!("Version in DESCRIPTION at {}", self.path.display()),
+                details,
             })?;
 
         Ok((package, version))
@@ -80,16 +93,28 @@ impl PackageRepository for LocalRepository {
             .is_some_and(|other| self.path == other.path)
     }
 
-    async fn packages(&self) -> Result<BTreeMap<String, Version>, String> {
+    async fn packages(
+        &self,
+        _client: &http::HttpClient,
+    ) -> Result<BTreeMap<String, PackageVersion>, RepositoryError> {
+        let repository: Arc<dyn PackageRepository> = Arc::new(self.clone());
         let (package, version) = self.package_and_version().await?;
-        Ok(BTreeMap::from([(package, version)]))
+        Ok(BTreeMap::from([(
+            package,
+            PackageVersion::new(version, repository),
+        )]))
     }
 
-    async fn versions(&self, package: &str) -> Result<BTreeSet<Version>, String> {
+    async fn versions(
+        &self,
+        _client: &http::HttpClient,
+        package: &str,
+    ) -> Result<BTreeSet<PackageVersion>, RepositoryError> {
+        let repository: Arc<dyn PackageRepository> = Arc::new(self.clone());
         let (local_package, version) = self.package_and_version().await?;
 
         if package == local_package {
-            Ok(BTreeSet::from([version]))
+            Ok(BTreeSet::from([PackageVersion::new(version, repository)]))
         } else {
             Ok(BTreeSet::new())
         }
@@ -97,29 +122,35 @@ impl PackageRepository for LocalRepository {
 
     async fn description(
         &self,
+        _client: &http::HttpClient,
         package: &str,
         version: &Version,
-    ) -> Result<Arc<RDescription>, String> {
+    ) -> Result<Arc<RDescription>, RepositoryError> {
         let description = self.effective_description().await?;
         let local_package = description
             .package()
-            .ok_or_else(|| format!("DESCRIPTION at {} is missing Package", self.path.display()))?;
+            .ok_or_else(|| RepositoryError::MissingField {
+                path: self.path.join("DESCRIPTION"),
+                field: "Package",
+            })?;
         let local_version = description
             .version()
-            .ok_or_else(|| format!("DESCRIPTION at {} is missing Version", self.path.display()))?
+            .ok_or_else(|| RepositoryError::MissingField {
+                path: self.path.join("DESCRIPTION"),
+                field: "Version",
+            })?
             .parse::<Version>()
-            .map_err(|error| {
-                format!(
-                    "invalid Version in DESCRIPTION at {}: {error}",
-                    self.path.display()
-                )
+            .map_err(|details| RepositoryError::InvalidData {
+                resource: format!("Version in DESCRIPTION at {}", self.path.display()),
+                details,
             })?;
 
         if package != local_package || version != &local_version {
-            return Err(format!(
-                "local repository at {} does not contain {package} {version}",
-                self.path.display()
-            ));
+            return Err(RepositoryError::PackageVersionNotFound {
+                path: self.path.clone(),
+                package: package.to_string(),
+                version: version.clone(),
+            });
         }
 
         Ok(description)

--- a/src/repository/local.rs
+++ b/src/repository/local.rs
@@ -1,0 +1,127 @@
+use super::PackageRepository;
+use async_trait::async_trait;
+use r_description::lossless::{RDescription, Version};
+use std::{
+    any::Any,
+    collections::{BTreeMap, BTreeSet},
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+#[derive(Debug, Clone)]
+pub struct LocalRepository {
+    path: PathBuf,
+    description_override: Option<Arc<RDescription>>,
+}
+
+impl LocalRepository {
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            description_override: None,
+        }
+    }
+
+    pub fn with_description(mut self, description: RDescription) -> Self {
+        self.description_override = Some(Arc::new(description));
+        self
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    async fn effective_description(&self) -> Result<Arc<RDescription>, String> {
+        if let Some(description) = &self.description_override {
+            return Ok(Arc::clone(description));
+        }
+
+        let path = self.path.join("DESCRIPTION");
+        let contents = tokio::fs::read_to_string(&path).await.map_err(|error| {
+            format!("failed to read DESCRIPTION at {}: {error}", path.display())
+        })?;
+        let description = contents.parse::<RDescription>().map_err(|error| {
+            format!("failed to parse DESCRIPTION at {}: {error}", path.display())
+        })?;
+
+        Ok(Arc::new(description))
+    }
+
+    async fn package_and_version(&self) -> Result<(String, Version), String> {
+        let description = self.effective_description().await?;
+        let package = description
+            .package()
+            .ok_or_else(|| format!("DESCRIPTION at {} is missing Package", self.path.display()))?;
+        let version = description
+            .version()
+            .ok_or_else(|| format!("DESCRIPTION at {} is missing Version", self.path.display()))?
+            .parse::<Version>()
+            .map_err(|error| {
+                format!(
+                    "invalid Version in DESCRIPTION at {}: {error}",
+                    self.path.display()
+                )
+            })?;
+
+        Ok((package, version))
+    }
+}
+
+#[async_trait]
+impl PackageRepository for LocalRepository {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn equals(&self, other: &dyn PackageRepository) -> bool {
+        other
+            .as_any()
+            .downcast_ref::<Self>()
+            .is_some_and(|other| self.path == other.path)
+    }
+
+    async fn packages(&self) -> Result<BTreeMap<String, Version>, String> {
+        let (package, version) = self.package_and_version().await?;
+        Ok(BTreeMap::from([(package, version)]))
+    }
+
+    async fn versions(&self, package: &str) -> Result<BTreeSet<Version>, String> {
+        let (local_package, version) = self.package_and_version().await?;
+
+        if package == local_package {
+            Ok(BTreeSet::from([version]))
+        } else {
+            Ok(BTreeSet::new())
+        }
+    }
+
+    async fn description(
+        &self,
+        package: &str,
+        version: &Version,
+    ) -> Result<Arc<RDescription>, String> {
+        let description = self.effective_description().await?;
+        let local_package = description
+            .package()
+            .ok_or_else(|| format!("DESCRIPTION at {} is missing Package", self.path.display()))?;
+        let local_version = description
+            .version()
+            .ok_or_else(|| format!("DESCRIPTION at {} is missing Version", self.path.display()))?
+            .parse::<Version>()
+            .map_err(|error| {
+                format!(
+                    "invalid Version in DESCRIPTION at {}: {error}",
+                    self.path.display()
+                )
+            })?;
+
+        if package != local_package || version != &local_version {
+            return Err(format!(
+                "local repository at {} does not contain {package} {version}",
+                self.path.display()
+            ));
+        }
+
+        Ok(description)
+    }
+}

--- a/src/repository/local.rs
+++ b/src/repository/local.rs
@@ -12,7 +12,7 @@ use std::{
 #[derive(Debug, Clone)]
 pub struct LocalRepository {
     path: PathBuf,
-    description_override: Option<Arc<RDescription>>,
+    description: Option<Arc<RDescription>>,
 }
 
 impl std::fmt::Display for LocalRepository {
@@ -25,21 +25,25 @@ impl LocalRepository {
     pub fn new(path: PathBuf) -> Self {
         Self {
             path,
-            description_override: None,
+            description: None,
         }
     }
 
     pub fn with_description(mut self, description: RDescription) -> Self {
-        self.description_override = Some(Arc::new(description));
+        self.set_description(description);
         self
+    }
+
+    pub fn set_description(&mut self, description: RDescription) {
+        self.description = Some(Arc::new(description));
     }
 
     pub fn path(&self) -> &Path {
         &self.path
     }
 
-    async fn effective_description(&self) -> Result<Arc<RDescription>, RepositoryError> {
-        if let Some(description) = &self.description_override {
+    pub async fn description(&self) -> Result<Arc<RDescription>, RepositoryError> {
+        if let Some(description) = &self.description {
             return Ok(Arc::clone(description));
         }
 
@@ -62,8 +66,8 @@ impl LocalRepository {
         Ok(Arc::new(description))
     }
 
-    async fn package_and_version(&self) -> Result<(String, Version), RepositoryError> {
-        let description = self.effective_description().await?;
+    pub async fn package(self: &Arc<Self>) -> Result<(String, PackageVersion), RepositoryError> {
+        let description = self.description().await?;
         let package = description
             .package()
             .ok_or_else(|| RepositoryError::MissingField {
@@ -82,7 +86,8 @@ impl LocalRepository {
                 details,
             })?;
 
-        Ok((package, version))
+        let repository: Arc<dyn PackageRepository> = self.clone();
+        Ok((package, PackageVersion::new(version, repository)))
     }
 }
 
@@ -103,12 +108,9 @@ impl PackageRepository for LocalRepository {
         &self,
         _client: &http::HttpClient,
     ) -> Result<BTreeMap<String, PackageVersion>, RepositoryError> {
-        let repository: Arc<dyn PackageRepository> = Arc::new(self.clone());
-        let (package, version) = self.package_and_version().await?;
-        Ok(BTreeMap::from([(
-            package,
-            PackageVersion::new(version, repository),
-        )]))
+        let repository = Arc::new(self.clone());
+        let (package, version) = repository.package().await?;
+        Ok(BTreeMap::from([(package, version)]))
     }
 
     async fn versions(
@@ -116,11 +118,11 @@ impl PackageRepository for LocalRepository {
         _client: &http::HttpClient,
         package: &str,
     ) -> Result<BTreeSet<PackageVersion>, RepositoryError> {
-        let repository: Arc<dyn PackageRepository> = Arc::new(self.clone());
-        let (local_package, version) = self.package_and_version().await?;
+        let repository = Arc::new(self.clone());
+        let (local_package, version) = repository.package().await?;
 
         if package == local_package {
-            Ok(BTreeSet::from([PackageVersion::new(version, repository)]))
+            Ok(BTreeSet::from([version]))
         } else {
             Ok(BTreeSet::new())
         }
@@ -132,7 +134,7 @@ impl PackageRepository for LocalRepository {
         package: &str,
         version: &Version,
     ) -> Result<Arc<RDescription>, RepositoryError> {
-        let description = self.effective_description().await?;
+        let description = self.description().await?;
         let local_package = description
             .package()
             .ok_or_else(|| RepositoryError::MissingField {
@@ -160,5 +162,69 @@ impl PackageRepository for LocalRepository {
         }
 
         Ok(description)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    #[tokio::test]
+    async fn package_uses_staged_description_and_preserves_repository() {
+        let initial: RDescription = "Package: initial\nVersion: 0.1.0\n"
+            .parse()
+            .expect("description should parse");
+        let staged: RDescription = "Package: project\nVersion: 1.2.3\n"
+            .parse()
+            .expect("description should parse");
+        let mut repository =
+            LocalRepository::new(PathBuf::from("unused")).with_description(initial);
+        repository.set_description(staged);
+        let repository = Arc::new(repository);
+        let expected_repository: Arc<dyn PackageRepository> = repository.clone();
+
+        let description = repository
+            .description()
+            .await
+            .expect("description should load");
+        let (package, version) = repository.package().await.expect("package should load");
+
+        assert_eq!(description.package().as_deref(), Some("project"));
+        assert_eq!(package, "project");
+        assert_eq!(version.version().to_string(), "1.2.3");
+        assert!(Arc::ptr_eq(version.repository(), &expected_repository));
+    }
+
+    #[tokio::test]
+    async fn description_falls_back_to_disk() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be valid")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "rpx-local-repository-{}-{unique}",
+            std::process::id()
+        ));
+        tokio::fs::create_dir(&path)
+            .await
+            .expect("test directory should be created");
+        tokio::fs::write(
+            path.join("DESCRIPTION"),
+            "Package: diskproject\nVersion: 2.0.0\n",
+        )
+        .await
+        .expect("description should be written");
+        let repository = LocalRepository::new(path.clone());
+
+        let description = repository
+            .description()
+            .await
+            .expect("description should load");
+
+        assert_eq!(description.package().as_deref(), Some("diskproject"));
+        tokio::fs::remove_dir_all(path)
+            .await
+            .expect("test directory should be removed");
     }
 }

--- a/src/repository/local.rs
+++ b/src/repository/local.rs
@@ -15,6 +15,12 @@ pub struct LocalRepository {
     description_override: Option<Arc<RDescription>>,
 }
 
+impl std::fmt::Display for LocalRepository {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.path.display().fmt(formatter)
+    }
+}
+
 impl LocalRepository {
     pub fn new(path: PathBuf) -> Self {
         Self {

--- a/src/repository/rrepo.rs
+++ b/src/repository/rrepo.rs
@@ -1,4 +1,4 @@
-use super::{PackageRepository, RepositoryFromUrl};
+use super::PackageRepository;
 use crate::http;
 use async_trait::async_trait;
 use moka::future::Cache;
@@ -32,19 +32,6 @@ impl RrepoRepository {
 
     pub fn url(&self) -> &Url {
         &self.url
-    }
-}
-
-#[async_trait]
-impl RepositoryFromUrl for RrepoRepository {
-    async fn from_url(client: http::HttpClient, url: Url) -> Result<Self, String> {
-        http::rrepo_repository_packages(&client, &url)
-            .await
-            .map_err(|error| error.to_string())?
-            .error_for_status()
-            .map_err(|error| error.to_string())?;
-
-        Ok(Self::new(client, url))
     }
 }
 

--- a/src/repository/rrepo.rs
+++ b/src/repository/rrepo.rs
@@ -1,5 +1,5 @@
-use super::PackageRepository;
-use crate::http;
+use super::{PackageRepository, RepositoryError};
+use crate::{http, resolver::PackageVersion};
 use async_trait::async_trait;
 use moka::future::Cache;
 use r_description::lossless::{RDescription, Version};
@@ -13,17 +13,19 @@ use std::{
 #[derive(Debug, Clone)]
 pub struct RrepoRepository {
     url: Url,
-    client: http::HttpClient,
     packages: Cache<(), Arc<http::RrepoPackagesResponse>>,
     versions: Cache<String, BTreeSet<Version>>,
     descriptions: Cache<(String, Version), Arc<RDescription>>,
 }
 
 impl RrepoRepository {
-    pub fn new(client: http::HttpClient, url: Url) -> Self {
+    pub fn new(mut url: Url) -> Self {
+        url.path_segments_mut()
+            .expect("repository base URL should support path segments")
+            .pop_if_empty();
+
         Self {
             url,
-            client,
             packages: Cache::new(1),
             versions: Cache::new(1024),
             descriptions: Cache::new(4096),
@@ -48,23 +50,33 @@ impl PackageRepository for RrepoRepository {
             .is_some_and(|other| self.url == other.url)
     }
 
-    async fn packages(&self) -> Result<BTreeMap<String, Version>, String> {
+    async fn packages(
+        &self,
+        client: &http::HttpClient,
+    ) -> Result<BTreeMap<String, PackageVersion>, RepositoryError> {
+        let repository: Arc<dyn PackageRepository> = Arc::new(self.clone());
         let response = self
             .packages
             .try_get_with((), async {
-                let response = http::rrepo_repository_packages(&self.client, &self.url)
+                let response = http::rrepo_repository_packages(client, &self.url)
                     .await
-                    .map_err(|error| error.to_string())?
+                    .map_err(|source| RepositoryError::Request {
+                        source: Arc::new(source),
+                    })?
                     .error_for_status()
-                    .map_err(|error| error.to_string())?
+                    .map_err(|source| RepositoryError::Response {
+                        source: Arc::new(source),
+                    })?
                     .json::<http::RrepoPackagesResponse>()
                     .await
-                    .map_err(|error| error.to_string())?;
+                    .map_err(|source| RepositoryError::Response {
+                        source: Arc::new(source),
+                    })?;
 
-                Ok::<Arc<http::RrepoPackagesResponse>, String>(Arc::new(response))
+                Ok::<Arc<http::RrepoPackagesResponse>, RepositoryError>(Arc::new(response))
             })
             .await
-            .map_err(|error| error.as_ref().clone())?;
+            .map_err(Arc::unwrap_or_clone)?;
 
         Ok(response
             .packages
@@ -84,40 +96,56 @@ impl PackageRepository for RrepoRepository {
                     }
                 };
 
-                Some((package.name.clone(), version))
+                Some((
+                    package.name.clone(),
+                    PackageVersion::new(version, Arc::clone(&repository)),
+                ))
             })
             .collect())
     }
 
-    async fn versions(&self, package: &str) -> Result<BTreeSet<Version>, String> {
-        if !self.packages().await?.contains_key(package) {
-            return Ok(BTreeSet::new());
-        }
-
+    async fn versions(
+        &self,
+        client: &http::HttpClient,
+        package: &str,
+    ) -> Result<BTreeSet<PackageVersion>, RepositoryError> {
+        let repository: Arc<dyn PackageRepository> = Arc::new(self.clone());
         let versions = self
             .versions
             .try_get_with(package.to_string(), async {
-                let response = http::rrepo_package_versions(&self.client, &self.url, package)
+                let response = http::rrepo_package_versions(client, &self.url, package)
                     .await
-                    .map_err(|error| error.to_string())?
+                    .map_err(|source| RepositoryError::Request {
+                        source: Arc::new(source),
+                    })?
                     .error_for_status()
-                    .map_err(|error| error.to_string())?
+                    .map_err(|source| RepositoryError::Response {
+                        source: Arc::new(source),
+                    })?
                     .json::<http::RrepoPackageVersionsResponse>()
                     .await
-                    .map_err(|error| error.to_string())?;
+                    .map_err(|source| RepositoryError::Response {
+                        source: Arc::new(source),
+                    })?;
 
                 response
                     .versions
                     .into_iter()
                     .map(|summary| {
-                        summary.version.parse::<Version>().map_err(|error| {
-                            format!("invalid version {} for {package}: {error}", summary.version)
+                        summary.version.parse::<Version>().map_err(|details| {
+                            RepositoryError::InvalidData {
+                                resource: format!(
+                                    "package version {} for {package}",
+                                    summary.version
+                                ),
+                                details,
+                            }
                         })
                     })
-                    .collect::<Result<BTreeSet<_>, String>>()
+                    .collect::<Result<BTreeSet<_>, RepositoryError>>()
             })
             .await
-            .map_err(|error| error.as_ref().clone())?;
+            .map_err(Arc::unwrap_or_clone)?;
 
         tracing::trace!(
             package,
@@ -126,34 +154,45 @@ impl PackageRepository for RrepoRepository {
             "loaded package versions"
         );
 
-        Ok(versions)
+        Ok(versions
+            .into_iter()
+            .map(|version| PackageVersion::new(version, Arc::clone(&repository)))
+            .collect())
     }
 
     async fn description(
         &self,
+        client: &http::HttpClient,
         package: &str,
         version: &Version,
-    ) -> Result<Arc<RDescription>, String> {
+    ) -> Result<Arc<RDescription>, RepositoryError> {
         let key = (package.to_string(), version.clone());
 
         self.descriptions
             .try_get_with(key, async {
                 let description = http::rrepo_package_description(
-                    &self.client,
+                    client,
                     &self.url,
                     package,
                     &version.to_string(),
                 )
                 .await
-                .map_err(|error| error.to_string())?
+                .map_err(|source| RepositoryError::Request {
+                    source: Arc::new(source),
+                })?
                 .error_for_status()
-                .map_err(|error| error.to_string())?
+                .map_err(|source| RepositoryError::Response {
+                    source: Arc::new(source),
+                })?
                 .text()
                 .await
-                .map_err(|error| error.to_string())?
+                .map_err(|source| RepositoryError::Response {
+                    source: Arc::new(source),
+                })?
                 .parse::<RDescription>()
-                .map_err(|error| {
-                    format!("failed to parse DESCRIPTION for {package} {version}: {error}")
+                .map_err(|source| RepositoryError::Description {
+                    location: format!("for {package} {version}"),
+                    source: Arc::new(source),
                 })?;
 
                 tracing::trace!(
@@ -163,9 +202,9 @@ impl PackageRepository for RrepoRepository {
                     "fetched package description"
                 );
 
-                Ok::<Arc<RDescription>, String>(Arc::new(description))
+                Ok::<Arc<RDescription>, RepositoryError>(Arc::new(description))
             })
             .await
-            .map_err(|error| error.as_ref().clone())
+            .map_err(Arc::unwrap_or_clone)
     }
 }

--- a/src/repository/rrepo.rs
+++ b/src/repository/rrepo.rs
@@ -1,0 +1,184 @@
+use super::{PackageRepository, RepositoryFromUrl};
+use crate::http;
+use async_trait::async_trait;
+use moka::future::Cache;
+use r_description::lossless::{RDescription, Version};
+use reqwest::Url;
+use std::{
+    any::Any,
+    collections::{BTreeMap, BTreeSet},
+    sync::Arc,
+};
+
+#[derive(Debug, Clone)]
+pub struct RrepoRepository {
+    url: Url,
+    client: http::HttpClient,
+    packages: Cache<(), Arc<http::RrepoPackagesResponse>>,
+    versions: Cache<String, BTreeSet<Version>>,
+    descriptions: Cache<(String, Version), Arc<RDescription>>,
+}
+
+impl RrepoRepository {
+    pub fn new(client: http::HttpClient, url: Url) -> Self {
+        Self {
+            url,
+            client,
+            packages: Cache::new(1),
+            versions: Cache::new(1024),
+            descriptions: Cache::new(4096),
+        }
+    }
+
+    pub fn url(&self) -> &Url {
+        &self.url
+    }
+}
+
+#[async_trait]
+impl RepositoryFromUrl for RrepoRepository {
+    async fn from_url(client: http::HttpClient, url: Url) -> Result<Self, String> {
+        http::rrepo_repository_packages(&client, &url)
+            .await
+            .map_err(|error| error.to_string())?
+            .error_for_status()
+            .map_err(|error| error.to_string())?;
+
+        Ok(Self::new(client, url))
+    }
+}
+
+#[async_trait]
+impl PackageRepository for RrepoRepository {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn equals(&self, other: &dyn PackageRepository) -> bool {
+        other
+            .as_any()
+            .downcast_ref::<Self>()
+            .is_some_and(|other| self.url == other.url)
+    }
+
+    async fn packages(&self) -> Result<BTreeMap<String, Version>, String> {
+        let response = self
+            .packages
+            .try_get_with((), async {
+                let response = http::rrepo_repository_packages(&self.client, &self.url)
+                    .await
+                    .map_err(|error| error.to_string())?
+                    .error_for_status()
+                    .map_err(|error| error.to_string())?
+                    .json::<http::RrepoPackagesResponse>()
+                    .await
+                    .map_err(|error| error.to_string())?;
+
+                Ok::<Arc<http::RrepoPackagesResponse>, String>(Arc::new(response))
+            })
+            .await
+            .map_err(|error| error.as_ref().clone())?;
+
+        Ok(response
+            .packages
+            .iter()
+            .filter_map(|package| {
+                let version = match package.latest_version.parse::<Version>() {
+                    Ok(version) => version,
+                    Err(error) => {
+                        tracing::debug!(
+                            package = %package.name,
+                            version = %package.latest_version,
+                            repository = %self.url,
+                            error = %error,
+                            "skipping package with invalid latest version"
+                        );
+                        return None;
+                    }
+                };
+
+                Some((package.name.clone(), version))
+            })
+            .collect())
+    }
+
+    async fn versions(&self, package: &str) -> Result<BTreeSet<Version>, String> {
+        if !self.packages().await?.contains_key(package) {
+            return Ok(BTreeSet::new());
+        }
+
+        let versions = self
+            .versions
+            .try_get_with(package.to_string(), async {
+                let response = http::rrepo_package_versions(&self.client, &self.url, package)
+                    .await
+                    .map_err(|error| error.to_string())?
+                    .error_for_status()
+                    .map_err(|error| error.to_string())?
+                    .json::<http::RrepoPackageVersionsResponse>()
+                    .await
+                    .map_err(|error| error.to_string())?;
+
+                response
+                    .versions
+                    .into_iter()
+                    .map(|summary| {
+                        summary.version.parse::<Version>().map_err(|error| {
+                            format!("invalid version {} for {package}: {error}", summary.version)
+                        })
+                    })
+                    .collect::<Result<BTreeSet<_>, String>>()
+            })
+            .await
+            .map_err(|error| error.as_ref().clone())?;
+
+        tracing::trace!(
+            package,
+            repository = %self.url,
+            versions = versions.len(),
+            "loaded package versions"
+        );
+
+        Ok(versions)
+    }
+
+    async fn description(
+        &self,
+        package: &str,
+        version: &Version,
+    ) -> Result<Arc<RDescription>, String> {
+        let key = (package.to_string(), version.clone());
+
+        self.descriptions
+            .try_get_with(key, async {
+                let description = http::rrepo_package_description(
+                    &self.client,
+                    &self.url,
+                    package,
+                    &version.to_string(),
+                )
+                .await
+                .map_err(|error| error.to_string())?
+                .error_for_status()
+                .map_err(|error| error.to_string())?
+                .text()
+                .await
+                .map_err(|error| error.to_string())?
+                .parse::<RDescription>()
+                .map_err(|error| {
+                    format!("failed to parse DESCRIPTION for {package} {version}: {error}")
+                })?;
+
+                tracing::trace!(
+                    package,
+                    version = %version,
+                    repository = %self.url,
+                    "fetched package description"
+                );
+
+                Ok::<Arc<RDescription>, String>(Arc::new(description))
+            })
+            .await
+            .map_err(|error| error.as_ref().clone())
+    }
+}

--- a/src/repository/rrepo.rs
+++ b/src/repository/rrepo.rs
@@ -18,6 +18,12 @@ pub struct RrepoRepository {
     descriptions: Cache<(String, Version), Arc<RDescription>>,
 }
 
+impl std::fmt::Display for RrepoRepository {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.url.fmt(formatter)
+    }
+}
+
 impl RrepoRepository {
     pub fn new(mut url: Url) -> Self {
         url.path_segments_mut()

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -8,7 +8,6 @@ use r_description::{
 };
 use std::{
     collections::{BTreeMap, BTreeSet},
-    str::FromStr,
     sync::Arc,
 };
 use thiserror::Error;
@@ -18,10 +17,9 @@ use tracing_indicatif::span_ext::IndicatifSpanExt;
 
 use crate::{
     http,
-    repository::{DEFAULT_REGISTRY_BASE_URL, PackageRepository, RepositoryError, RrepoRepository},
+    repository::{PackageRepository, RepositoryError},
 };
 
-const ROOT_PACKAGE: &str = "__rpx_root__";
 const DESCRIPTION_PREFETCH_WORKERS: usize = 50;
 const BASE_PACKAGES: &[&str] = &[
     "base",
@@ -54,9 +52,6 @@ pub(crate) enum ProviderError {
 
 #[derive(Debug, Error)]
 pub(crate) enum ResolutionError {
-    #[error("no repositories configured")]
-    NoRepositories,
-
     #[error(transparent)]
     PubGrub(#[from] PubGrubError<RDependencyProvider>),
 
@@ -122,6 +117,8 @@ impl std::fmt::Display for PackageVersion {
 pub(crate) struct RDependencyProvider {
     client: http::HttpClient,
     repositories: Vec<Arc<dyn PackageRepository>>,
+    root_package: String,
+    root_version: PackageVersion,
     root_dependencies: BTreeMap<String, Ranges<PackageVersion>>,
     preferred_versions: BTreeMap<String, PackageVersion>,
     description_prefetch_permits: Arc<Semaphore>,
@@ -131,12 +128,16 @@ impl RDependencyProvider {
     fn new(
         client: http::HttpClient,
         repositories: Vec<Arc<dyn PackageRepository>>,
+        root_package: String,
+        root_version: PackageVersion,
         root_dependencies: BTreeMap<String, Ranges<PackageVersion>>,
         preferred_versions: BTreeMap<String, PackageVersion>,
     ) -> Self {
         Self {
             client,
             repositories,
+            root_package,
+            root_version,
             root_dependencies,
             preferred_versions,
             description_prefetch_permits: Arc::new(Semaphore::new(DESCRIPTION_PREFETCH_WORKERS)),
@@ -150,6 +151,10 @@ impl RDependencyProvider {
         let parent_span = tracing::Span::current();
 
         for (package, range) in constraints {
+            if package == &self.root_package {
+                continue;
+            }
+
             let client = self.client.clone();
             let repositories = self.repositories.clone();
             let preferred_versions = self.preferred_versions.clone();
@@ -241,10 +246,10 @@ impl DependencyProvider for RDependencyProvider {
         package: &Self::P,
         range: &Self::VS,
     ) -> Result<Option<Self::V>, Self::Err> {
-        if package == ROOT_PACKAGE {
-            let root = root_package_version();
-
-            return Ok(range.contains(&root).then_some(root));
+        if package == &self.root_package {
+            return Ok(range
+                .contains(&self.root_version)
+                .then(|| self.root_version.clone()));
         }
 
         tokio::runtime::Handle::current().block_on(choose_package_version(
@@ -261,7 +266,7 @@ impl DependencyProvider for RDependencyProvider {
         package: &Self::P,
         version: &Self::V,
     ) -> Result<Dependencies<Self::P, Self::VS, Self::M>, Self::Err> {
-        if package == ROOT_PACKAGE {
+        if package == &self.root_package {
             let constraints = self
                 .root_dependencies
                 .iter()
@@ -381,18 +386,6 @@ fn dependency_constraints_from_description(
         .collect()
 }
 
-fn root_package_version() -> PackageVersion {
-    let url = reqwest::Url::parse(DEFAULT_REGISTRY_BASE_URL)
-        .expect("default registry URL should be valid");
-
-    let repository: Arc<dyn PackageRepository> = Arc::new(RrepoRepository::new(url));
-
-    PackageVersion::new(
-        Version::from_str("0.0.0").expect("root version should parse"),
-        repository,
-    )
-}
-
 fn relation_package_range(
     repository: Arc<dyn PackageRepository>,
     relation: &Relation,
@@ -425,6 +418,8 @@ pub fn is_base_package(package: &str) -> bool {
 pub(crate) async fn resolve_from_registry(
     client: http::HttpClient,
     repositories: Vec<Arc<dyn PackageRepository>>,
+    root_package: String,
+    root_version: PackageVersion,
     root_relations: BTreeSet<Relation>,
     preferred_versions: BTreeMap<String, PackageVersion>,
 ) -> Result<Vec<(String, PackageVersion)>, ResolutionError> {
@@ -433,7 +428,7 @@ pub(crate) async fn resolve_from_registry(
     }
 
     let root_count = root_relations.len();
-    let root_dependencies = root_dependency_ranges(&repositories, &root_relations)?;
+    let root_dependencies = root_dependency_ranges(&root_version, &root_relations);
 
     let span = tracing::info_span!(
         "resolve_dependencies",
@@ -447,21 +442,25 @@ pub(crate) async fn resolve_from_registry(
     span.pb_set_message("resolve dependencies");
     span.pb_start();
 
-    let root_version = root_package_version();
-
-    let provider =
-        RDependencyProvider::new(client, repositories, root_dependencies, preferred_versions);
+    let provider = RDependencyProvider::new(
+        client,
+        repositories,
+        root_package.clone(),
+        root_version.clone(),
+        root_dependencies,
+        preferred_versions,
+    );
 
     let resolve_span = span.clone();
     let selected = tokio::task::spawn_blocking(move || {
         let _enter = resolve_span.enter();
         resolve_span.record("stage", "solving");
 
-        let selected = resolve(&provider, ROOT_PACKAGE.to_string(), root_version)?;
+        let selected = resolve(&provider, root_package.clone(), root_version)?;
 
         let mut selected = selected
             .into_iter()
-            .filter(|(package, _)| package != ROOT_PACKAGE)
+            .filter(|(package, _)| package != &root_package)
             .collect::<Vec<_>>();
 
         selected.sort_by(|left, right| left.0.cmp(&right.0));
@@ -479,9 +478,9 @@ pub(crate) async fn resolve_from_registry(
 }
 
 fn root_dependency_ranges(
-    repositories: &[Arc<dyn PackageRepository>],
+    root_version: &PackageVersion,
     roots: &BTreeSet<Relation>,
-) -> Result<BTreeMap<String, Ranges<PackageVersion>>, ResolutionError> {
+) -> BTreeMap<String, Ranges<PackageVersion>> {
     let mut root_dependencies: BTreeMap<String, Ranges<PackageVersion>> = BTreeMap::new();
 
     for relation in roots {
@@ -490,11 +489,7 @@ fn root_dependency_ranges(
             continue;
         }
 
-        let repository = repositories
-            .first()
-            .map(Arc::clone)
-            .ok_or(ResolutionError::NoRepositories)?;
-        let range = relation_package_range(Arc::clone(&repository), relation);
+        let range = relation_package_range(Arc::clone(root_version.repository()), relation);
         match root_dependencies.entry(package) {
             std::collections::btree_map::Entry::Occupied(mut entry) => {
                 let combined = entry.get().intersection(&range);
@@ -506,5 +501,312 @@ fn root_dependency_ranges(
         }
     }
 
-    Ok(root_dependencies)
+    root_dependencies
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use async_trait::async_trait;
+    use std::{
+        any::Any,
+        fmt,
+        str::FromStr,
+        sync::{
+            Mutex,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
+
+    #[derive(Debug)]
+    struct TestRepository {
+        name: &'static str,
+        packages: BTreeMap<String, PackageVersion>,
+        versions: BTreeMap<String, BTreeSet<PackageVersion>>,
+        descriptions: BTreeMap<(String, Version), Arc<RDescription>>,
+        package_queries: AtomicUsize,
+        version_queries: Mutex<Vec<String>>,
+        description_queries: Mutex<Vec<String>>,
+    }
+
+    impl TestRepository {
+        fn empty(name: &'static str) -> Self {
+            Self {
+                name,
+                packages: BTreeMap::new(),
+                versions: BTreeMap::new(),
+                descriptions: BTreeMap::new(),
+                package_queries: AtomicUsize::new(0),
+                version_queries: Mutex::new(Vec::new()),
+                description_queries: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl fmt::Display for TestRepository {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str(self.name)
+        }
+    }
+
+    #[async_trait]
+    impl PackageRepository for TestRepository {
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn equals(&self, other: &dyn PackageRepository) -> bool {
+            other
+                .downcast_ref::<Self>()
+                .is_some_and(|other| self.name == other.name)
+        }
+
+        async fn packages(
+            &self,
+            _client: &http::HttpClient,
+        ) -> Result<BTreeMap<String, PackageVersion>, RepositoryError> {
+            self.package_queries.fetch_add(1, Ordering::SeqCst);
+            Ok(self.packages.clone())
+        }
+
+        async fn versions(
+            &self,
+            _client: &http::HttpClient,
+            package: &str,
+        ) -> Result<BTreeSet<PackageVersion>, RepositoryError> {
+            self.version_queries
+                .lock()
+                .expect("version query lock should not be poisoned")
+                .push(package.to_string());
+            Ok(self.versions.get(package).cloned().unwrap_or_default())
+        }
+
+        async fn description(
+            &self,
+            _client: &http::HttpClient,
+            package: &str,
+            version: &Version,
+        ) -> Result<Arc<RDescription>, RepositoryError> {
+            self.description_queries
+                .lock()
+                .expect("description query lock should not be poisoned")
+                .push(package.to_string());
+            self.descriptions
+                .get(&(package.to_string(), version.clone()))
+                .cloned()
+                .ok_or_else(|| RepositoryError::InvalidData {
+                    resource: format!("{package} {version}"),
+                    details: "missing test description".to_string(),
+                })
+        }
+    }
+
+    fn version(value: &str, repository: Arc<dyn PackageRepository>) -> PackageVersion {
+        PackageVersion::new(
+            Version::from_str(value).expect("valid test version"),
+            repository,
+        )
+    }
+
+    #[test]
+    fn root_name_is_reserved_for_the_supplied_version() {
+        let local_repository: Arc<dyn PackageRepository> = Arc::new(TestRepository::empty("local"));
+        let candidate_repository: Arc<dyn PackageRepository> =
+            Arc::new(TestRepository::empty("candidate"));
+        let mut packages = BTreeMap::new();
+        packages.insert(
+            "project".to_string(),
+            version("9.0.0", candidate_repository),
+        );
+        let remote_repository = Arc::new(TestRepository {
+            name: "remote",
+            packages,
+            versions: BTreeMap::new(),
+            descriptions: BTreeMap::new(),
+            package_queries: AtomicUsize::new(0),
+            version_queries: Mutex::new(Vec::new()),
+            description_queries: Mutex::new(Vec::new()),
+        });
+        let root_version = version("1.0.0", local_repository);
+        let provider = RDependencyProvider::new(
+            http::client(),
+            vec![remote_repository.clone()],
+            "project".to_string(),
+            root_version.clone(),
+            BTreeMap::new(),
+            BTreeMap::new(),
+        );
+
+        assert_eq!(
+            provider
+                .choose_version(&"project".to_string(), &Ranges::full())
+                .expect("root selection should succeed"),
+            Some(root_version.clone())
+        );
+        let incompatible =
+            Ranges::higher_than(version("2.0.0", Arc::clone(root_version.repository())));
+        assert_eq!(
+            provider
+                .choose_version(&"project".to_string(), &incompatible)
+                .expect("root selection should succeed"),
+            None
+        );
+        assert_eq!(remote_repository.package_queries.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn prefetch_does_not_query_the_root_package() {
+        let local_repository: Arc<dyn PackageRepository> = Arc::new(TestRepository::empty("local"));
+        let remote_repository = Arc::new(TestRepository::empty("remote"));
+        let provider = RDependencyProvider::new(
+            http::client(),
+            vec![remote_repository.clone()],
+            "project".to_string(),
+            version("1.0.0", local_repository),
+            BTreeMap::new(),
+            BTreeMap::new(),
+        );
+        let constraints =
+            DependencyConstraints::from_iter([("project".to_string(), Ranges::full())]);
+
+        provider.prefetch_descriptions(&constraints);
+
+        assert_eq!(remote_repository.package_queries.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn root_dependencies_preserve_explicit_constraints() {
+        let local_repository: Arc<dyn PackageRepository> = Arc::new(TestRepository::empty("local"));
+        let root_version = version("1.0.0", Arc::clone(&local_repository));
+        let suggested_version = Version::from_str("2.0.0").expect("valid test version");
+        let suggested = Relation::new(
+            "suggested",
+            Some((VersionConstraint::GreaterThanEqual, suggested_version)),
+        );
+        let roots = BTreeSet::from([suggested]);
+        let root_dependencies = root_dependency_ranges(&root_version, &roots);
+        let provider = RDependencyProvider::new(
+            http::client(),
+            Vec::new(),
+            "project".to_string(),
+            root_version.clone(),
+            root_dependencies,
+            BTreeMap::new(),
+        );
+
+        let Dependencies::Available(constraints) = provider
+            .get_dependencies(&"project".to_string(), &root_version)
+            .expect("root dependencies should be available")
+        else {
+            panic!("root dependencies should be available");
+        };
+        let range = constraints
+            .get("suggested")
+            .expect("caller-supplied relation should be preserved");
+
+        assert!(!range.contains(&version("1.9.9", Arc::clone(&local_repository))));
+        assert!(range.contains(&version("2.0.0", local_repository)));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn resolution_filters_the_actual_root_without_remote_queries() {
+        let local_repository: Arc<dyn PackageRepository> = Arc::new(TestRepository::empty("local"));
+        let remote_repository = Arc::new(TestRepository::empty("remote"));
+        let selected = resolve_from_registry(
+            http::client(),
+            vec![remote_repository.clone()],
+            "project".to_string(),
+            version("1.0.0", local_repository),
+            BTreeSet::from([Relation::simple("base")]),
+            BTreeMap::new(),
+        )
+        .await
+        .expect("root-only resolution should succeed");
+
+        assert!(selected.is_empty());
+        assert_eq!(remote_repository.package_queries.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn backtracks_instead_of_replacing_the_fixed_root() {
+        let local_repository: Arc<dyn PackageRepository> = Arc::new(TestRepository::empty("local"));
+        let mut metadata_repository = TestRepository::empty("remote metadata");
+        metadata_repository.descriptions.insert(
+            (
+                "testthat".to_string(),
+                Version::from_str("3.2.0").expect("valid test version"),
+            ),
+            Arc::new(
+                "Package: testthat\nVersion: 3.2.0\nTitle: Testthat\nDescription: Test package.\nLicense: MIT\nDepends: project (>= 1.1.0)\n"
+                    .parse()
+                    .expect("valid test DESCRIPTION"),
+            ),
+        );
+        metadata_repository.descriptions.insert(
+            (
+                "testthat".to_string(),
+                Version::from_str("3.0.0").expect("valid test version"),
+            ),
+            Arc::new(
+                "Package: testthat\nVersion: 3.0.0\nTitle: Testthat\nDescription: Test package.\nLicense: MIT\nDepends: project (>= 1.0.0)\n"
+                    .parse()
+                    .expect("valid test DESCRIPTION"),
+            ),
+        );
+        let metadata_repository = Arc::new(metadata_repository);
+        let metadata: Arc<dyn PackageRepository> = metadata_repository.clone();
+        let testthat_3_2 = version("3.2.0", Arc::clone(&metadata));
+        let testthat_3_0 = version("3.0.0", Arc::clone(&metadata));
+        let mut remote_repository = TestRepository::empty("remote index");
+        remote_repository
+            .packages
+            .insert("testthat".to_string(), testthat_3_2.clone());
+        remote_repository.packages.insert(
+            "project".to_string(),
+            version("9.0.0", Arc::clone(&metadata)),
+        );
+        remote_repository.versions.insert(
+            "testthat".to_string(),
+            BTreeSet::from([testthat_3_0.clone(), testthat_3_2]),
+        );
+        remote_repository.versions.insert(
+            "project".to_string(),
+            BTreeSet::from([version("9.0.0", Arc::clone(&metadata))]),
+        );
+        let remote_repository = Arc::new(remote_repository);
+        let selected = resolve_from_registry(
+            http::client(),
+            vec![remote_repository.clone()],
+            "project".to_string(),
+            version("1.0.1", local_repository),
+            BTreeSet::from([Relation::new(
+                "testthat",
+                Some((
+                    VersionConstraint::GreaterThanEqual,
+                    Version::from_str("3.0.0").expect("valid test version"),
+                )),
+            )]),
+            BTreeMap::new(),
+        )
+        .await
+        .expect("resolution should backtrack to a root-compatible version");
+
+        assert_eq!(selected, vec![("testthat".to_string(), testthat_3_0)]);
+        assert!(
+            !remote_repository
+                .version_queries
+                .lock()
+                .expect("version query lock should not be poisoned")
+                .iter()
+                .any(|package| package == "project")
+        );
+        assert!(
+            !metadata_repository
+                .description_queries
+                .lock()
+                .expect("description query lock should not be poisoned")
+                .iter()
+                .any(|package| package == "project")
+        );
+    }
 }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,6 +1,6 @@
 use pubgrub::{
-    Dependencies, DependencyConstraints, DependencyProvider, PackageResolutionStatistics, Ranges,
-    resolve,
+    Dependencies, DependencyConstraints, DependencyProvider, PackageResolutionStatistics,
+    PubGrubError, Ranges, resolve,
 };
 use r_description::{
     VersionConstraint,
@@ -8,18 +8,17 @@ use r_description::{
 };
 use std::{
     collections::{BTreeMap, BTreeSet},
-    error::Error,
-    fmt,
     str::FromStr,
     sync::Arc,
 };
+use thiserror::Error;
 use tokio::sync::Semaphore;
 use tracing::Instrument;
 use tracing_indicatif::span_ext::IndicatifSpanExt;
 
 use crate::{
     http,
-    repository::{DEFAULT_REGISTRY_BASE_URL, PackageRepository, RepositoryType},
+    repository::{DEFAULT_REGISTRY_BASE_URL, PackageRepository, RepositoryError, RrepoRepository},
 };
 
 const ROOT_PACKAGE: &str = "__rpx_root__";
@@ -40,31 +39,39 @@ const BASE_PACKAGES: &[&str] = &[
     "tools",
     "utils",
 ];
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct ResolverError(String);
+#[derive(Debug, Clone, Error)]
+pub(crate) enum ProviderError {
+    #[error(transparent)]
+    Repository(#[from] RepositoryError),
 
-impl fmt::Display for ResolverError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.0)
-    }
+    #[error("failed to load dependency metadata from {repository}")]
+    DependencyMetadata {
+        repository: String,
+        #[source]
+        source: RepositoryError,
+    },
 }
 
-impl Error for ResolverError {}
+#[derive(Debug, Error)]
+pub(crate) enum ResolutionError {
+    #[error("no repositories configured")]
+    NoRepositories,
 
-impl From<String> for ResolverError {
-    fn from(value: String) -> Self {
-        Self(value)
-    }
+    #[error(transparent)]
+    PubGrub(#[from] PubGrubError<RDependencyProvider>),
+
+    #[error(transparent)]
+    Join(#[from] tokio::task::JoinError),
 }
 
 #[derive(Debug, Clone)]
 pub struct PackageVersion {
     version: Version,
-    repository: Arc<PackageRepository>,
+    repository: Arc<dyn PackageRepository>,
 }
 
 impl PackageVersion {
-    pub fn new(version: Version, repository: Arc<PackageRepository>) -> Self {
+    pub fn new(version: Version, repository: Arc<dyn PackageRepository>) -> Self {
         Self {
             version,
             repository,
@@ -75,24 +82,8 @@ impl PackageVersion {
         &self.version
     }
 
-    pub fn repository(&self) -> &Arc<PackageRepository> {
+    pub fn repository(&self) -> &Arc<dyn PackageRepository> {
         &self.repository
-    }
-
-    pub fn source_url(&self, package: &str) -> String {
-        let base_url = self.repository.base_url().to_string();
-        let base_url = base_url.trim_end_matches('/');
-
-        match self.repository.repo_type() {
-            RepositoryType::Rrepo => format!(
-                "{}/packages/{package}/versions/{}/source",
-                base_url, self.version
-            ),
-            RepositoryType::Cran { .. } => format!(
-                "{}/src/contrib/Archive/{package}/{package}_{}.tar.gz",
-                base_url, self.version
-            ),
-        }
     }
 }
 
@@ -123,14 +114,14 @@ impl std::hash::Hash for PackageVersion {
 }
 impl std::fmt::Display for PackageVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} from {}", self.version, self.repository.base_url())
+        write!(f, "{} from {}", self.version, self.repository)
     }
 }
 
 #[derive(Debug)]
-struct RDependencyProvider {
+pub(crate) struct RDependencyProvider {
     client: http::HttpClient,
-    repositories: Vec<PackageRepository>,
+    repositories: Vec<Arc<dyn PackageRepository>>,
     root_dependencies: BTreeMap<String, Ranges<PackageVersion>>,
     preferred_versions: BTreeMap<String, PackageVersion>,
     description_prefetch_permits: Arc<Semaphore>,
@@ -139,17 +130,17 @@ struct RDependencyProvider {
 impl RDependencyProvider {
     fn new(
         client: http::HttpClient,
-        repositories: Vec<PackageRepository>,
+        repositories: Vec<Arc<dyn PackageRepository>>,
         root_dependencies: BTreeMap<String, Ranges<PackageVersion>>,
         preferred_versions: BTreeMap<String, PackageVersion>,
-    ) -> Result<Self, ResolverError> {
-        Ok(Self {
+    ) -> Self {
+        Self {
             client,
             repositories,
             root_dependencies,
             preferred_versions,
             description_prefetch_permits: Arc::new(Semaphore::new(DESCRIPTION_PREFETCH_WORKERS)),
-        })
+        }
     }
 
     fn prefetch_descriptions(
@@ -204,8 +195,10 @@ impl RDependencyProvider {
                     };
 
                     tracing::Span::current().record("version", version.version().to_string());
-                    tracing::Span::current()
-                        .record("repository", version.repository().base_url().to_string());
+                    tracing::Span::current().record(
+                        "repository",
+                        version.repository().to_string(),
+                    );
                     tracing::Span::current().record("stage", "fetching description");
 
                     if let Err(error) = version
@@ -232,7 +225,7 @@ impl DependencyProvider for RDependencyProvider {
     type VS = Ranges<PackageVersion>;
     type Priority = u32;
     type M = String;
-    type Err = ResolverError;
+    type Err = ProviderError;
 
     fn prioritize(
         &self,
@@ -249,22 +242,18 @@ impl DependencyProvider for RDependencyProvider {
         range: &Self::VS,
     ) -> Result<Option<Self::V>, Self::Err> {
         if package == ROOT_PACKAGE {
-            let root = tokio::runtime::Handle::current()
-                .block_on(root_package_version())
-                .map_err(ResolverError::from)?;
+            let root = root_package_version();
 
             return Ok(range.contains(&root).then_some(root));
         }
 
-        tokio::runtime::Handle::current()
-            .block_on(choose_package_version(
-                &self.client,
-                &self.repositories,
-                &self.preferred_versions,
-                package,
-                range,
-            ))
-            .map_err(ResolverError::from)
+        tokio::runtime::Handle::current().block_on(choose_package_version(
+            &self.client,
+            &self.repositories,
+            &self.preferred_versions,
+            package,
+            range,
+        ))
     }
 
     fn get_dependencies(
@@ -294,16 +283,13 @@ impl DependencyProvider for RDependencyProvider {
                     .repository
                     .description(&self.client, package, &version.version),
             )
-            .map_err(|err| {
-                ResolverError(format!(
-                    "failed to parse dependency metadata for {package} {} from {}: {err}",
-                    version.version,
-                    version.repository.base_url(),
-                ))
+            .map_err(|source| ProviderError::DependencyMetadata {
+                repository: version.repository.to_string(),
+                source,
             })?;
 
         let constraints =
-            dependency_constraints_from_description(Arc::clone(&version.repository), &description)?;
+            dependency_constraints_from_description(Arc::clone(&version.repository), &description);
 
         self.prefetch_descriptions(&constraints);
 
@@ -313,11 +299,11 @@ impl DependencyProvider for RDependencyProvider {
 
 async fn choose_package_version(
     client: &http::HttpClient,
-    repositories: &[PackageRepository],
+    repositories: &[Arc<dyn PackageRepository>],
     preferred_versions: &BTreeMap<String, PackageVersion>,
     package: &str,
     range: &Ranges<PackageVersion>,
-) -> Result<Option<PackageVersion>, String> {
+) -> Result<Option<PackageVersion>, ProviderError> {
     if let Some(preferred) = preferred_versions.get(package) {
         if range.contains(preferred) {
             return Ok(Some(preferred.clone()));
@@ -326,14 +312,15 @@ async fn choose_package_version(
 
     let candidates = futures_util::future::join_all(repositories.iter().enumerate().map(
         |(repository_index, repository)| async move {
-            let version = choose_repository_version(client, repository, package, range).await?;
+            let version =
+                choose_repository_version(client, repository.as_ref(), package, range).await?;
 
-            Ok::<_, String>(version.map(|version| (version, repository_index)))
+            Ok::<_, ProviderError>(version.map(|version| (version, repository_index)))
         },
     ))
     .await
     .into_iter()
-    .collect::<Result<Vec<_>, String>>()?;
+    .collect::<Result<Vec<_>, ProviderError>>()?;
 
     Ok(candidates
         .into_iter()
@@ -351,20 +338,18 @@ async fn choose_package_version(
 
 async fn choose_repository_version(
     client: &http::HttpClient,
-    repository: &PackageRepository,
+    repository: &dyn PackageRepository,
     package: &str,
     range: &Ranges<PackageVersion>,
-) -> Result<Option<PackageVersion>, String> {
+) -> Result<Option<PackageVersion>, ProviderError> {
     let packages = repository.packages(client).await?;
 
-    let should_fall_back_to_versions = match packages.get(package) {
-        Some(latest) if range.contains(latest) => return Ok(Some(latest.clone())),
-        Some(_) => true,
-        None => matches!(repository.repo_type(), RepositoryType::Cran { .. }),
+    let Some(latest) = packages.get(package) else {
+        return Ok(None);
     };
 
-    if !should_fall_back_to_versions {
-        return Ok(None);
+    if range.contains(latest) {
+        return Ok(Some(latest.clone()));
     }
 
     Ok(repository
@@ -376,9 +361,9 @@ async fn choose_repository_version(
 }
 
 fn dependency_constraints_from_description(
-    repository: Arc<PackageRepository>,
+    repository: Arc<dyn PackageRepository>,
     description: &RDescription,
-) -> Result<DependencyConstraints<String, Ranges<PackageVersion>>, ResolverError> {
+) -> DependencyConstraints<String, Ranges<PackageVersion>> {
     description
         .depends()
         .into_iter()
@@ -388,36 +373,34 @@ fn dependency_constraints_from_description(
         .filter(|relation| relation.name() != "R")
         .filter(|relation| !is_base_package(&relation.name()))
         .map(|relation| {
-            Ok((
+            (
                 relation.name().to_string(),
-                relation_package_range(Arc::clone(&repository), &relation)?,
-            ))
+                relation_package_range(Arc::clone(&repository), &relation),
+            )
         })
         .collect()
 }
 
-async fn root_package_version() -> Result<PackageVersion, ResolverError> {
-    let url = reqwest::Url::parse(DEFAULT_REGISTRY_BASE_URL).map_err(|error| {
-        ResolverError::from(format!(
-            "invalid default registry URL {}: {error}",
-            DEFAULT_REGISTRY_BASE_URL
-        ))
-    })?;
+fn root_package_version() -> PackageVersion {
+    let url = reqwest::Url::parse(DEFAULT_REGISTRY_BASE_URL)
+        .expect("default registry URL should be valid");
 
-    Ok(PackageVersion {
-        version: Version::from_str("0.0.0").expect("root version should parse"),
-        repository: Arc::new(PackageRepository::new(url, RepositoryType::Rrepo)),
-    })
+    let repository: Arc<dyn PackageRepository> = Arc::new(RrepoRepository::new(url));
+
+    PackageVersion::new(
+        Version::from_str("0.0.0").expect("root version should parse"),
+        repository,
+    )
 }
 
 fn relation_package_range(
-    repository: Arc<PackageRepository>,
+    repository: Arc<dyn PackageRepository>,
     relation: &Relation,
-) -> Result<Ranges<PackageVersion>, ResolverError> {
+) -> Ranges<PackageVersion> {
     let relation_version = relation.version();
 
     let Some((operator, version)) = relation_version.as_ref() else {
-        return Ok(Ranges::full());
+        return Ranges::full();
     };
 
     let bound = PackageVersion {
@@ -425,33 +408,32 @@ fn relation_package_range(
         repository,
     };
 
-    Ok(match operator {
+    match operator {
         VersionConstraint::Equal => Ranges::singleton(bound),
         VersionConstraint::GreaterThan => Ranges::strictly_higher_than(bound),
         VersionConstraint::GreaterThanEqual => Ranges::higher_than(bound),
         VersionConstraint::LessThan => Ranges::strictly_lower_than(bound),
         VersionConstraint::LessThanEqual => Ranges::lower_than(bound),
         VersionConstraint::NotEqual => Ranges::singleton(bound).complement(),
-    })
+    }
 }
 
 pub fn is_base_package(package: &str) -> bool {
     BASE_PACKAGES.contains(&package)
 }
 
-pub async fn resolve_from_registry(
+pub(crate) async fn resolve_from_registry(
     client: http::HttpClient,
-    repositories: Vec<PackageRepository>,
+    repositories: Vec<Arc<dyn PackageRepository>>,
     root_relations: BTreeSet<Relation>,
     preferred_versions: BTreeMap<String, PackageVersion>,
-) -> Result<Vec<(String, PackageVersion)>, String> {
+) -> Result<Vec<(String, PackageVersion)>, ResolutionError> {
     if root_relations.is_empty() {
         return Ok(Vec::new());
     }
 
     let root_count = root_relations.len();
-    let root_dependencies = root_dependency_ranges(&repositories, &root_relations)
-        .map_err(|error| error.to_string())?;
+    let root_dependencies = root_dependency_ranges(&repositories, &root_relations)?;
 
     let span = tracing::info_span!(
         "resolve_dependencies",
@@ -465,21 +447,17 @@ pub async fn resolve_from_registry(
     span.pb_set_message("resolve dependencies");
     span.pb_start();
 
-    let root_version = root_package_version()
-        .await
-        .map_err(|error| error.to_string())?;
+    let root_version = root_package_version();
 
     let provider =
-        RDependencyProvider::new(client, repositories, root_dependencies, preferred_versions)
-            .map_err(|error| error.to_string())?;
+        RDependencyProvider::new(client, repositories, root_dependencies, preferred_versions);
 
     let resolve_span = span.clone();
     let selected = tokio::task::spawn_blocking(move || {
         let _enter = resolve_span.enter();
         resolve_span.record("stage", "solving");
 
-        let selected = resolve(&provider, ROOT_PACKAGE.to_string(), root_version)
-            .map_err(|error| error.to_string())?;
+        let selected = resolve(&provider, ROOT_PACKAGE.to_string(), root_version)?;
 
         let mut selected = selected
             .into_iter()
@@ -489,10 +467,9 @@ pub async fn resolve_from_registry(
         selected.sort_by(|left, right| left.0.cmp(&right.0));
         resolve_span.record("selected", selected.len());
 
-        Ok::<_, String>(selected)
+        Ok::<_, PubGrubError<RDependencyProvider>>(selected)
     })
-    .await
-    .map_err(|error| format!("failed to join resolver task: {error}"))??;
+    .await??;
 
     span.record("stage", "done");
     span.record("selected", selected.len());
@@ -502,9 +479,9 @@ pub async fn resolve_from_registry(
 }
 
 fn root_dependency_ranges(
-    repositories: &[PackageRepository],
+    repositories: &[Arc<dyn PackageRepository>],
     roots: &BTreeSet<Relation>,
-) -> Result<BTreeMap<String, Ranges<PackageVersion>>, ResolverError> {
+) -> Result<BTreeMap<String, Ranges<PackageVersion>>, ResolutionError> {
     let mut root_dependencies: BTreeMap<String, Ranges<PackageVersion>> = BTreeMap::new();
 
     for relation in roots {
@@ -515,10 +492,9 @@ fn root_dependency_ranges(
 
         let repository = repositories
             .first()
-            .cloned()
-            .ok_or_else(|| ResolverError("no repositories configured".to_string()))?;
-        let repository = Arc::new(repository);
-        let range = relation_package_range(Arc::clone(&repository), relation)?;
+            .map(Arc::clone)
+            .ok_or(ResolutionError::NoRepositories)?;
+        let range = relation_package_range(Arc::clone(&repository), relation);
         match root_dependencies.entry(package) {
             std::collections::btree_map::Entry::Occupied(mut entry) => {
                 let combined = entry.get().intersection(&range);

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -17,7 +17,7 @@ use tracing_indicatif::span_ext::IndicatifSpanExt;
 
 use crate::{
     http,
-    repository::{PackageRepository, RepositoryError},
+    repository::{LocalRepository, PackageRepository, RepositoryError},
 };
 
 const DESCRIPTION_PREFETCH_WORKERS: usize = 50;
@@ -52,6 +52,9 @@ pub(crate) enum ProviderError {
 
 #[derive(Debug, Error)]
 pub(crate) enum ResolutionError {
+    #[error(transparent)]
+    Provider(#[from] ProviderError),
+
     #[error(transparent)]
     PubGrub(#[from] PubGrubError<RDependencyProvider>),
 
@@ -117,8 +120,7 @@ impl std::fmt::Display for PackageVersion {
 pub(crate) struct RDependencyProvider {
     client: http::HttpClient,
     repositories: Vec<Arc<dyn PackageRepository>>,
-    root_package: String,
-    root_version: PackageVersion,
+    root: Arc<LocalRepository>,
     root_dependencies: BTreeMap<String, Ranges<PackageVersion>>,
     preferred_versions: BTreeMap<String, PackageVersion>,
     description_prefetch_permits: Arc<Semaphore>,
@@ -128,16 +130,14 @@ impl RDependencyProvider {
     fn new(
         client: http::HttpClient,
         repositories: Vec<Arc<dyn PackageRepository>>,
-        root_package: String,
-        root_version: PackageVersion,
+        root: Arc<LocalRepository>,
         root_dependencies: BTreeMap<String, Ranges<PackageVersion>>,
         preferred_versions: BTreeMap<String, PackageVersion>,
     ) -> Self {
         Self {
             client,
             repositories,
-            root_package,
-            root_version,
+            root,
             root_dependencies,
             preferred_versions,
             description_prefetch_permits: Arc::new(Semaphore::new(DESCRIPTION_PREFETCH_WORKERS)),
@@ -147,11 +147,12 @@ impl RDependencyProvider {
     fn prefetch_descriptions(
         &self,
         constraints: &DependencyConstraints<String, Ranges<PackageVersion>>,
-    ) {
+    ) -> Result<(), ProviderError> {
+        let (root_package, _) = self.root_package()?;
         let parent_span = tracing::Span::current();
 
         for (package, range) in constraints {
-            if package == &self.root_package {
+            if package == &root_package {
                 continue;
             }
 
@@ -221,6 +222,14 @@ impl RDependencyProvider {
                 .instrument(span),
             );
         }
+
+        Ok(())
+    }
+
+    fn root_package(&self) -> Result<(String, PackageVersion), ProviderError> {
+        tokio::runtime::Handle::current()
+            .block_on(self.root.package())
+            .map_err(Into::into)
     }
 }
 
@@ -246,10 +255,9 @@ impl DependencyProvider for RDependencyProvider {
         package: &Self::P,
         range: &Self::VS,
     ) -> Result<Option<Self::V>, Self::Err> {
-        if package == &self.root_package {
-            return Ok(range
-                .contains(&self.root_version)
-                .then(|| self.root_version.clone()));
+        let (root_package, root_version) = self.root_package()?;
+        if package == &root_package {
+            return Ok(range.contains(&root_version).then_some(root_version));
         }
 
         tokio::runtime::Handle::current().block_on(choose_package_version(
@@ -266,14 +274,15 @@ impl DependencyProvider for RDependencyProvider {
         package: &Self::P,
         version: &Self::V,
     ) -> Result<Dependencies<Self::P, Self::VS, Self::M>, Self::Err> {
-        if package == &self.root_package {
+        let (root_package, _) = self.root_package()?;
+        if package == &root_package {
             let constraints = self
                 .root_dependencies
                 .iter()
                 .map(|(package, range)| (package.clone(), range.clone()))
                 .collect::<DependencyConstraints<_, _>>();
 
-            self.prefetch_descriptions(&constraints);
+            self.prefetch_descriptions(&constraints)?;
 
             return Ok(Dependencies::Available(constraints));
         }
@@ -296,7 +305,7 @@ impl DependencyProvider for RDependencyProvider {
         let constraints =
             dependency_constraints_from_description(Arc::clone(&version.repository), &description);
 
-        self.prefetch_descriptions(&constraints);
+        self.prefetch_descriptions(&constraints)?;
 
         Ok(Dependencies::Available(constraints))
     }
@@ -418,8 +427,7 @@ pub fn is_base_package(package: &str) -> bool {
 pub(crate) async fn resolve_from_registry(
     client: http::HttpClient,
     repositories: Vec<Arc<dyn PackageRepository>>,
-    root_package: String,
-    root_version: PackageVersion,
+    root: Arc<LocalRepository>,
     root_relations: BTreeSet<Relation>,
     preferred_versions: BTreeMap<String, PackageVersion>,
 ) -> Result<Vec<(String, PackageVersion)>, ResolutionError> {
@@ -428,8 +436,6 @@ pub(crate) async fn resolve_from_registry(
     }
 
     let root_count = root_relations.len();
-    let root_dependencies = root_dependency_ranges(&root_version, &root_relations);
-
     let span = tracing::info_span!(
         "resolve_dependencies",
         roots = root_count,
@@ -442,19 +448,22 @@ pub(crate) async fn resolve_from_registry(
     span.pb_set_message("resolve dependencies");
     span.pb_start();
 
-    let provider = RDependencyProvider::new(
-        client,
-        repositories,
-        root_package.clone(),
-        root_version.clone(),
-        root_dependencies,
-        preferred_versions,
-    );
-
     let resolve_span = span.clone();
     let selected = tokio::task::spawn_blocking(move || {
         let _enter = resolve_span.enter();
         resolve_span.record("stage", "solving");
+
+        let (root_package, root_version) = tokio::runtime::Handle::current()
+            .block_on(root.package())
+            .map_err(ProviderError::from)?;
+        let root_dependencies = root_dependency_ranges(&root_version, &root_relations);
+        let provider = RDependencyProvider::new(
+            client,
+            repositories,
+            root,
+            root_dependencies,
+            preferred_versions,
+        );
 
         let selected = resolve(&provider, root_package.clone(), root_version)?;
 
@@ -466,7 +475,7 @@ pub(crate) async fn resolve_from_registry(
         selected.sort_by(|left, right| left.0.cmp(&right.0));
         resolve_span.record("selected", selected.len());
 
-        Ok::<_, PubGrubError<RDependencyProvider>>(selected)
+        Ok::<_, ResolutionError>(selected)
     })
     .await??;
 
@@ -608,9 +617,18 @@ mod tests {
         )
     }
 
-    #[test]
-    fn root_name_is_reserved_for_the_supplied_version() {
-        let local_repository: Arc<dyn PackageRepository> = Arc::new(TestRepository::empty("local"));
+    fn local_repository(package: &str, version: &str) -> Arc<LocalRepository> {
+        let description = format!("Package: {package}\nVersion: {version}\n")
+            .parse()
+            .expect("valid local DESCRIPTION");
+        Arc::new(
+            LocalRepository::new(std::path::PathBuf::from("unused")).with_description(description),
+        )
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn root_name_is_reserved_for_the_supplied_version() {
+        let local_repository = local_repository("project", "1.0.0");
         let candidate_repository: Arc<dyn PackageRepository> =
             Arc::new(TestRepository::empty("candidate"));
         let mut packages = BTreeMap::new();
@@ -627,57 +645,65 @@ mod tests {
             version_queries: Mutex::new(Vec::new()),
             description_queries: Mutex::new(Vec::new()),
         });
-        let root_version = version("1.0.0", local_repository);
+        let (_, root_version) = local_repository.package().await.expect("root should load");
         let provider = RDependencyProvider::new(
             http::client(),
             vec![remote_repository.clone()],
-            "project".to_string(),
-            root_version.clone(),
+            local_repository,
             BTreeMap::new(),
             BTreeMap::new(),
         );
-
-        assert_eq!(
-            provider
-                .choose_version(&"project".to_string(), &Ranges::full())
-                .expect("root selection should succeed"),
-            Some(root_version.clone())
-        );
+        let expected = root_version.clone();
         let incompatible =
             Ranges::higher_than(version("2.0.0", Arc::clone(root_version.repository())));
-        assert_eq!(
-            provider
-                .choose_version(&"project".to_string(), &incompatible)
-                .expect("root selection should succeed"),
-            None
-        );
+        tokio::task::spawn_blocking(move || {
+            assert_eq!(
+                provider
+                    .choose_version(&"project".to_string(), &Ranges::full())
+                    .expect("root selection should succeed"),
+                Some(expected)
+            );
+            assert_eq!(
+                provider
+                    .choose_version(&"project".to_string(), &incompatible)
+                    .expect("root selection should succeed"),
+                None
+            );
+        })
+        .await
+        .expect("root selection task should join");
         assert_eq!(remote_repository.package_queries.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]
     async fn prefetch_does_not_query_the_root_package() {
-        let local_repository: Arc<dyn PackageRepository> = Arc::new(TestRepository::empty("local"));
+        let local_repository = local_repository("project", "1.0.0");
         let remote_repository = Arc::new(TestRepository::empty("remote"));
         let provider = RDependencyProvider::new(
             http::client(),
             vec![remote_repository.clone()],
-            "project".to_string(),
-            version("1.0.0", local_repository),
+            local_repository,
             BTreeMap::new(),
             BTreeMap::new(),
         );
         let constraints =
             DependencyConstraints::from_iter([("project".to_string(), Ranges::full())]);
 
-        provider.prefetch_descriptions(&constraints);
+        tokio::task::spawn_blocking(move || {
+            provider
+                .prefetch_descriptions(&constraints)
+                .expect("prefetch should succeed");
+        })
+        .await
+        .expect("prefetch task should join");
 
         assert_eq!(remote_repository.package_queries.load(Ordering::SeqCst), 0);
     }
 
     #[tokio::test]
     async fn root_dependencies_preserve_explicit_constraints() {
-        let local_repository: Arc<dyn PackageRepository> = Arc::new(TestRepository::empty("local"));
-        let root_version = version("1.0.0", Arc::clone(&local_repository));
+        let local_repository = local_repository("project", "1.0.0");
+        let (_, root_version) = local_repository.package().await.expect("root should load");
         let suggested_version = Version::from_str("2.0.0").expect("valid test version");
         let suggested = Relation::new(
             "suggested",
@@ -688,35 +714,37 @@ mod tests {
         let provider = RDependencyProvider::new(
             http::client(),
             Vec::new(),
-            "project".to_string(),
-            root_version.clone(),
+            Arc::clone(&local_repository),
             root_dependencies,
             BTreeMap::new(),
         );
 
-        let Dependencies::Available(constraints) = provider
-            .get_dependencies(&"project".to_string(), &root_version)
-            .expect("root dependencies should be available")
-        else {
+        let Dependencies::Available(constraints) = tokio::task::spawn_blocking(move || {
+            provider
+                .get_dependencies(&"project".to_string(), &root_version)
+                .expect("root dependencies should be available")
+        })
+        .await
+        .expect("root dependency task should join") else {
             panic!("root dependencies should be available");
         };
         let range = constraints
             .get("suggested")
             .expect("caller-supplied relation should be preserved");
 
+        let local_repository: Arc<dyn PackageRepository> = local_repository;
         assert!(!range.contains(&version("1.9.9", Arc::clone(&local_repository))));
         assert!(range.contains(&version("2.0.0", local_repository)));
     }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn resolution_filters_the_actual_root_without_remote_queries() {
-        let local_repository: Arc<dyn PackageRepository> = Arc::new(TestRepository::empty("local"));
+        let local_repository = local_repository("project", "1.0.0");
         let remote_repository = Arc::new(TestRepository::empty("remote"));
         let selected = resolve_from_registry(
             http::client(),
             vec![remote_repository.clone()],
-            "project".to_string(),
-            version("1.0.0", local_repository),
+            local_repository,
             BTreeSet::from([Relation::simple("base")]),
             BTreeMap::new(),
         )
@@ -729,7 +757,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn backtracks_instead_of_replacing_the_fixed_root() {
-        let local_repository: Arc<dyn PackageRepository> = Arc::new(TestRepository::empty("local"));
+        let local_repository = local_repository("project", "1.0.1");
         let mut metadata_repository = TestRepository::empty("remote metadata");
         metadata_repository.descriptions.insert(
             (
@@ -777,8 +805,7 @@ mod tests {
         let selected = resolve_from_registry(
             http::client(),
             vec![remote_repository.clone()],
-            "project".to_string(),
-            version("1.0.1", local_repository),
+            local_repository,
             BTreeSet::from([Relation::new(
                 "testthat",
                 Some((

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -109,7 +109,7 @@ impl std::hash::Hash for PackageVersion {
 }
 impl std::fmt::Display for PackageVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{} from {}", self.version, self.repository)
+        self.version.fmt(f)
     }
 }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -59,7 +59,7 @@ pub fn create_package_project(
     project_path: &str,
 ) {
     let command = format!(
-        "mkdir -p {project_path} && cat > {project_path}/DESCRIPTION <<'EOF'\nPackage: testpkg\nVersion: 0.1.0\nTitle: Test Package\nDescription: Test package for rpx integration tests.\nLicense: MIT\nAuthor: Test Author\nMaintainer: Test Author <test@example.com>\nEOF"
+        "mkdir -p {project_path} && touch {project_path}/NAMESPACE && cat > {project_path}/DESCRIPTION <<'EOF'\nPackage: testpkg\nVersion: 0.1.0\nTitle: Test Package\nDescription: Test package for rpx integration tests.\nLicense: MIT\nAuthor: Test Author\nMaintainer: Test Author <test@example.com>\nEOF"
     );
     let (exit_code, stdout, stderr) = run_shell_command(container, &command);
     assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");

--- a/tests/deps.rs
+++ b/tests/deps.rs
@@ -59,6 +59,38 @@ fn relation_names(relations: Option<r_description::lossless::Relations>) -> Vec<
 }
 
 #[test]
+fn reports_pubgrub_no_solution_explanation() {
+    let container = start_container();
+    let project_path = "/tmp/rpx-project-no-solution";
+    write_description(
+        &container,
+        project_path,
+        "Package: rlang\nVersion: 1.0.1\nTitle: Local rlang\nDescription: Resolver conflict fixture.\nLicense: MIT\nAuthor: Test Author\nMaintainer: Test Author <test@example.com>",
+    );
+
+    let command = format!("cd {project_path} && rpx add 'testthat@>=3.1.8'");
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &command);
+
+    assert_eq!(exit_code, 1, "stdout was: {stdout}\nstderr was: {stderr}");
+    assert!(
+        stderr.contains("rpx::lock::no_solution"),
+        "stdout was: {stdout}\nstderr was: {stderr}"
+    );
+    assert!(
+        stderr.contains("package requirements are incompatible"),
+        "stdout was: {stdout}\nstderr was: {stderr}"
+    );
+    assert!(
+        stderr.contains("testthat") && stderr.contains("rlang"),
+        "stdout was: {stdout}\nstderr was: {stderr}"
+    );
+    assert!(
+        !stderr.contains("There is no solution"),
+        "stdout was: {stdout}\nstderr was: {stderr}"
+    );
+}
+
+#[test]
 fn runs_rpx_add_inside_custom_r_image() {
     let container = start_container();
     let project_path = "/tmp/rpx-project-add";

--- a/tests/deps.rs
+++ b/tests/deps.rs
@@ -9,7 +9,7 @@ fn write_description(
     contents: &str,
 ) {
     let command = format!(
-        "mkdir -p {project_path} && cat > {project_path}/DESCRIPTION <<'EOF'\n{contents}\nEOF"
+        "mkdir -p {project_path} && touch {project_path}/NAMESPACE && cat > {project_path}/DESCRIPTION <<'EOF'\n{contents}\nEOF"
     );
     let (exit_code, stdout, stderr) = run_shell_command(container, &command);
     assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
@@ -74,6 +74,7 @@ fn runs_rpx_add_inside_custom_r_image() {
         "stdout was: {stdout}\nstderr was: {stderr}"
     );
     assert_package_state(&container, working_path, "digest", "TRUE");
+    assert_package_state(&container, working_path, "testpkg", "TRUE");
 
     let lockfile = read_project_file(&container, project_path, "rpx.lock");
     assert!(lockfile.contains("\"digest\""), "lockfile was: {lockfile}");
@@ -89,6 +90,10 @@ fn runs_rpx_add_inside_custom_r_image() {
     assert!(
         lockfile.contains("\"packages\""),
         "lockfile was: {lockfile}"
+    );
+    assert!(
+        !lockfile.contains("\"testpkg\""),
+        "project package should not be locked: {lockfile}"
     );
 
     let description = read_project_file(&container, project_path, "DESCRIPTION");

--- a/tests/status.rs
+++ b/tests/status.rs
@@ -40,11 +40,11 @@ fn runs_rpx_status_for_lockfile_drift() {
     let (exit_code, stdout, stderr) = run_shell_command(&container, &status_command);
     assert_eq!(exit_code, 1, "stdout was: {stdout}\nstderr was: {stderr}");
     assert!(
-        stdout.contains("Lockfile is out of date"),
+        stdout.contains("Project is out of sync"),
         "stdout was: {stdout}\nstderr was: {stderr}"
     );
     assert!(
-        stdout.contains("Run: rpx lock"),
+        stdout.contains("Run: rpx lock && rpx sync"),
         "stdout was: {stdout}\nstderr was: {stderr}"
     );
     assert!(
@@ -149,7 +149,7 @@ fn runs_rpx_status_for_missing_library_package() {
     assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
 
     let remove_package_dir = format!(
-        "cd {project_path} && rm -rf \"$(rpx run Rscript -e \"cat(file.path(.libPaths()[1], 'digest'))\")\""
+        "cd {project_path} && rm -rf \"$(rpx run Rscript -e \"cat(file.path(.libPaths()[1], 'digest'))\")\" \"$(rpx run Rscript -e \"cat(file.path(.libPaths()[1], 'testpkg'))\")\""
     );
     let (exit_code, stdout, stderr) = run_shell_command(&container, &remove_package_dir);
     assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
@@ -166,11 +166,15 @@ fn runs_rpx_status_for_missing_library_package() {
         "stdout was: {stdout}\nstderr was: {stderr}"
     );
     assert!(
-        stdout.contains("Packages locked but not installed:"),
+        stdout.contains("Required packages not installed:"),
         "stdout was: {stdout}\nstderr was: {stderr}"
     );
     assert!(
         stdout.contains("- digest"),
+        "stdout was: {stdout}\nstderr was: {stderr}"
+    );
+    assert!(
+        stdout.contains("- testpkg"),
         "stdout was: {stdout}\nstderr was: {stderr}"
     );
 }
@@ -198,7 +202,7 @@ fn runs_rpx_status_for_extra_library_package() {
         "stdout was: {stdout}\nstderr was: {stderr}"
     );
     assert!(
-        stdout.contains("Packages installed but not locked:"),
+        stdout.contains("Unexpected packages installed:"),
         "stdout was: {stdout}\nstderr was: {stderr}"
     );
     assert!(
@@ -222,6 +226,10 @@ fn runs_rpx_status_for_version_mismatch() {
     );
     let (exit_code, stdout, stderr) = run_shell_command(&container, &mutate_lockfile);
     assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
+    let mutate_description =
+        format!("cd {project_path} && perl -0pi -e 's/Version: 0.1.0/Version: 0.2.0/' DESCRIPTION");
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &mutate_description);
+    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
 
     let status_command = format!("cd {project_path} && rpx status");
     let (exit_code, stdout, stderr) = run_shell_command(&container, &status_command);
@@ -231,7 +239,7 @@ fn runs_rpx_status_for_version_mismatch() {
         "stdout was: {stdout}\nstderr was: {stderr}"
     );
     assert!(
-        stdout.contains("Installed versions that differ from rpx.lock:"),
+        stdout.contains("Installed versions that differ from expected versions:"),
         "stdout was: {stdout}\nstderr was: {stderr}"
     );
     assert!(
@@ -240,6 +248,10 @@ fn runs_rpx_status_for_version_mismatch() {
     );
     assert!(
         stdout.contains("0.0.1 locked"),
+        "stdout was: {stdout}\nstderr was: {stderr}"
+    );
+    assert!(
+        stdout.contains("- testpkg (0.1.0 installed, 0.2.0 expected)"),
         "stdout was: {stdout}\nstderr was: {stderr}"
     );
 }

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -8,7 +8,7 @@ fn write_description(
     contents: &str,
 ) {
     let command = format!(
-        "mkdir -p {project_path} && cat > {project_path}/DESCRIPTION <<'EOF'\n{contents}\nEOF"
+        "mkdir -p {project_path} && touch {project_path}/NAMESPACE && cat > {project_path}/DESCRIPTION <<'EOF'\n{contents}\nEOF"
     );
     let (exit_code, stdout, stderr) = run_shell_command(container, &command);
     assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");


### PR DESCRIPTION
Right now we let the user perform the package install themselves. Thing is this produces really bad edge cases for things like circular dependencies on the root package so the optimal solution is to include the root in resolution and then to prevent sync failures (on missing dependencies) we also need to install the root package.