### PR TITLE
feat: add dependency type flags to rpx add

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,22 +40,31 @@ Imports:
     examplepkg (< 2.0.0)
 ```
 
-The lower bound prevents the solver from choosing a version older than the one you added. The upper bound prevents an automatic jump to the next major version unless you change the constraint.
+The lower bound prevents the solver from choosing a version older than the one you added. The upper bound prevents an automatic jump to the next major version unless you change the constraint. Packages are added to `Imports` by default; use a dependency-type flag to select another field:
+
+```bash
+rpx add --depends package
+rpx add --imports package
+rpx add --linking-to package
+rpx add --suggests package
+```
+
+The flags are mutually exclusive. `--dev` is an alias for `--suggests`. `Enhances` is not currently supported.
 
 This uses semver because the major version is the common place to signal breaking changes. R packages do not universally follow semver, so this is not a guarantee that every `1.x` release is compatible or every `2.x` release is incompatible. It is a default constraint that is safer than leaving the dependency open-ended.
 
 For `0.x` packages, `rpx` records the selected version as the lower bound and `< 1.0.0` as the upper bound.
 
 To set a constraint yourself, use `PACKAGE@OPERATORVERSION`. For example, this writes
-`digest (>= 0.6.37)` to `Imports`:
+`digest (>= 0.6.37)` to `Suggests`:
 
 ```bash
-rpx add 'digest@>=0.6.37'
+rpx add --dev 'digest@>=0.6.37'
 ```
 
 Supported operators are `<`, `<=`, `==`, `!=`, `>=`, and `>`. A constrained add replaces every
 existing relation for that package in `DESCRIPTION` before adding the requested relation to
-`Imports`.
+the selected field.
 
 ## Install
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,7 @@
 use clap::{Args, Parser, Subcommand, ValueEnum};
 
+use crate::description::DependencyField;
+
 #[derive(Parser, Debug)]
 #[command(name = "rpx")]
 #[command(
@@ -25,6 +27,9 @@ pub enum Commands {
         long_about = "Install one or more packages for this project. Each package is recorded in DESCRIPTION, then rpx regenerates rpx.lock and syncs the project library."
     )]
     Add {
+        #[command(flatten)]
+        dependency_type: AddDependencyTypeArgs,
+
         #[arg(
             help = "Packages to add, optionally with a constraint such as digest@>=0.6.37",
             value_name = "PACKAGE[@CONSTRAINTVERSION]",
@@ -104,6 +109,37 @@ pub enum Commands {
         #[command(subcommand)]
         command: RepoCommands,
     },
+}
+
+#[derive(Args, Debug)]
+#[group(multiple = false)]
+#[allow(clippy::struct_excessive_bools)]
+pub struct AddDependencyTypeArgs {
+    #[arg(long, help = "Add packages to Depends")]
+    depends: bool,
+
+    #[arg(long, help = "Add packages to Imports (default)")]
+    imports: bool,
+
+    #[arg(long, help = "Add packages to LinkingTo")]
+    linking_to: bool,
+
+    #[arg(long, visible_alias = "dev", help = "Add packages to Suggests")]
+    suggests: bool,
+}
+
+impl From<AddDependencyTypeArgs> for DependencyField {
+    fn from(args: AddDependencyTypeArgs) -> Self {
+        [
+            (args.depends, Self::Depends),
+            (args.imports, Self::Imports),
+            (args.linking_to, Self::LinkingTo),
+            (args.suggests, Self::Suggests),
+        ]
+        .into_iter()
+        .find_map(|(selected, field)| selected.then_some(field))
+        .unwrap_or_default()
+    }
 }
 
 #[derive(Subcommand, Debug)]
@@ -222,11 +258,75 @@ pub enum RepositoryType {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::CommandFactory;
 
     fn parse(arguments: &[&str]) -> Commands {
         Cli::try_parse_from(arguments)
             .expect("command should parse")
             .command
+    }
+
+    #[test]
+    fn parses_add_dependency_fields() {
+        for (flag, expected) in [
+            (None, DependencyField::Imports),
+            (Some("--depends"), DependencyField::Depends),
+            (Some("--imports"), DependencyField::Imports),
+            (Some("--linking-to"), DependencyField::LinkingTo),
+            (Some("--suggests"), DependencyField::Suggests),
+            (Some("--dev"), DependencyField::Suggests),
+        ] {
+            let mut arguments = vec!["rpx", "add"];
+            arguments.extend(flag);
+            arguments.push("digest@>=0.6.37");
+
+            let Commands::Add {
+                packages,
+                dependency_type,
+            } = parse(&arguments)
+            else {
+                panic!("add command should parse");
+            };
+
+            assert_eq!(packages, ["digest@>=0.6.37"]);
+            assert_eq!(DependencyField::from(dependency_type), expected);
+        }
+    }
+
+    #[test]
+    fn rejects_multiple_add_dependency_fields() {
+        let flags = ["--depends", "--imports", "--linking-to", "--suggests"];
+
+        assert!(flags.iter().enumerate().all(|(index, first)| {
+            flags
+                .iter()
+                .skip(index + 1)
+                .all(|second| Cli::try_parse_from(["rpx", "add", first, second, "digest"]).is_err())
+        }));
+        assert!(Cli::try_parse_from(["rpx", "add", "--enhances", "digest"]).is_err());
+    }
+
+    #[test]
+    fn add_help_lists_supported_dependency_fields() {
+        let mut command = Cli::command();
+        let help = command
+            .find_subcommand_mut("add")
+            .expect("add command should exist")
+            .render_long_help()
+            .to_string();
+
+        assert!(
+            [
+                "--depends",
+                "--imports",
+                "--linking-to",
+                "--suggests",
+                "--dev",
+            ]
+            .iter()
+            .all(|flag| help.contains(flag))
+        );
+        assert!(!help.contains("--enhances"));
     }
 
     #[test]

--- a/src/description.rs
+++ b/src/description.rs
@@ -20,6 +20,15 @@ use crate::repository::{
 pub const DESCRIPTION_NAME: &str = "DESCRIPTION";
 pub const BASE_REPOSITORY_FIELD: &str = "Config/rpx/base-repository";
 
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum DependencyField {
+    Depends,
+    #[default]
+    Imports,
+    LinkingTo,
+    Suggests,
+}
+
 #[derive(Debug, Error, Diagnostic)]
 #[error("failed to parse DESCRIPTION ({count} errors)")]
 #[diagnostic(code(rpx::description::parse_failed))]
@@ -533,6 +542,7 @@ pub fn add_dependencies(
     path: &Path,
     description: &mut RDescription,
     dependencies: &BTreeSet<Relation>,
+    field: DependencyField,
 ) -> Result<(), DescriptionParseError> {
     if dependencies.is_empty() {
         return Ok(());
@@ -642,9 +652,15 @@ pub fn add_dependencies(
 
     depends.retain(|dependency| !added_packages.contains(dependency.package()));
     imports.retain(|dependency| !added_packages.contains(dependency.package()));
-    imports.extend(dependencies.iter().cloned());
     linking_to.retain(|dependency| !added_packages.contains(dependency.package()));
     suggests.retain(|dependency| !added_packages.contains(dependency.package()));
+
+    match field {
+        DependencyField::Depends => depends.extend(dependencies.iter().cloned()),
+        DependencyField::Imports => imports.extend(dependencies.iter().cloned()),
+        DependencyField::LinkingTo => linking_to.extend(dependencies.iter().cloned()),
+        DependencyField::Suggests => suggests.extend(dependencies.iter().cloned()),
+    }
 
     description.set_depends(depends);
     description.set_imports(imports);
@@ -1341,29 +1357,44 @@ mod tests {
     }
 
     #[test]
-    fn add_moves_packages_to_imports_and_leaves_enhances_untouched() {
-        let mut description = RDescription::parse(
-            "Package: project\nVersion: 1.0.0\nDepends: dplyr (>= 1.0.0), keepDepends\nImports: dplyr (< 2.0.0), keepImports\nLinkingTo: dplyr, keepLinking\nSuggests: dplyr, keepSuggests\nEnhances: dplyr, keepEnhances\n",
-        );
+    fn add_moves_packages_to_selected_field_and_leaves_enhances_untouched() {
+        for (field, selected_index) in [
+            (DependencyField::Depends, 0),
+            (DependencyField::Imports, 1),
+            (DependencyField::LinkingTo, 2),
+            (DependencyField::Suggests, 3),
+        ] {
+            let mut description = RDescription::parse(
+                "Package: project\nVersion: 1.0.0\nDepends: R (>= 4.2), dplyr (>= 1.0.0), keepDepends\nImports: dplyr (< 2.0.0), keepImports\nLinkingTo: dplyr, keepLinking\nSuggests: dplyr, keepSuggests\nEnhances: dplyr, keepEnhances\n",
+            );
 
-        add_dependencies(
-            Path::new("."),
-            &mut description,
-            &relation_set(&["dplyr (== 1.1.0)"]),
-        )
-        .expect("dependency should be added");
+            add_dependencies(
+                Path::new("."),
+                &mut description,
+                &relation_set(&["dplyr (== 1.1.0)"]),
+                field,
+            )
+            .expect("dependency should be added");
 
-        assert_eq!(relation_strings(description.depends()), ["keepDepends"]);
-        assert_eq!(
-            relation_strings(description.imports()),
-            ["dplyr (== 1.1.0)", "keepImports"]
-        );
-        assert_eq!(relation_strings(description.linking_to()), ["keepLinking"]);
-        assert_eq!(relation_strings(description.suggests()), ["keepSuggests"]);
-        assert_eq!(
-            relation_strings(description.enhances()),
-            ["dplyr", "keepEnhances"]
-        );
+            let managed_fields = [
+                relation_strings(description.depends()),
+                relation_strings(description.imports()),
+                relation_strings(description.linking_to()),
+                relation_strings(description.suggests()),
+            ];
+            assert!(managed_fields[selected_index].contains(&"dplyr (== 1.1.0)".to_string()));
+            assert!(managed_fields.iter().enumerate().all(|(index, relations)| {
+                index == selected_index
+                    || !relations
+                        .iter()
+                        .any(|relation| relation.starts_with("dplyr"))
+            }));
+            assert!(managed_fields[0].contains(&"R (>= 4.2)".to_string()));
+            assert_eq!(
+                relation_strings(description.enhances()),
+                ["dplyr", "keepEnhances"]
+            );
+        }
     }
 
     #[test]
@@ -1376,6 +1407,7 @@ mod tests {
             Path::new("."),
             &mut description,
             &relation_set(&["askpass", "cli"]),
+            DependencyField::Imports,
         )
         .expect("dependencies should be added");
 
@@ -1394,8 +1426,13 @@ mod tests {
             "Package: project\nVersion: 1.0.0\nImports: cli (>= 1.0.0), cli (< 2.0.0)\n",
         );
 
-        add_dependencies(Path::new("."), &mut description, &relation_set(&["digest"]))
-            .expect("dependency should be added");
+        add_dependencies(
+            Path::new("."),
+            &mut description,
+            &relation_set(&["digest"]),
+            DependencyField::Imports,
+        )
+        .expect("dependency should be added");
 
         assert_eq!(
             relation_strings(description.imports()),
@@ -1415,6 +1452,7 @@ mod tests {
                 Path::new("."),
                 &mut description,
                 &relation_set(&["jsonlite"]),
+                DependencyField::Imports,
             )
             .is_err()
         );
@@ -1427,8 +1465,13 @@ mod tests {
             RDescription::parse("Package: project\nVersion: 1.0.0\nImports: cli, cli\n");
         let original = description.to_string();
 
-        add_dependencies(Path::new("."), &mut description, &BTreeSet::new())
-            .expect("empty add should succeed");
+        add_dependencies(
+            Path::new("."),
+            &mut description,
+            &BTreeSet::new(),
+            DependencyField::Suggests,
+        )
+        .expect("empty add should succeed");
 
         assert_eq!(description.to_string(), original);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,7 +68,7 @@ use ui::SystemDepsUi;
 use crate::{
     cache::CompiledPackageCacheKey,
     description::{
-        DescriptionParseError, DescriptionReadError, DescriptionWriteError,
+        DependencyField, DescriptionParseError, DescriptionReadError, DescriptionWriteError,
         InitialDescriptionError, NamespaceWriteError, PackageNameDerivationError,
         RepositoriesFromDescriptionError, add_dependencies, derive_package_name,
         initial_description, project_dependencies, read_description, remove_dependencies,
@@ -205,7 +205,10 @@ pub async fn run() -> miette::Result<()> {
 
     match cli.command {
         Commands::Init => cmd_init()?,
-        Commands::Add { packages } => cmd_add(&packages).await?,
+        Commands::Add {
+            packages,
+            dependency_type,
+        } => cmd_add(&packages, dependency_type.into()).await?,
         Commands::Remove { packages } => cmd_remove(&packages).await?,
         Commands::Run { command } => cmd_run(&command).await?,
         Commands::Lock {} => cmd_lock().await?,
@@ -366,7 +369,7 @@ enum AddError {
     Install(#[from] SyncError),
 }
 
-async fn cmd_add(packages: &[String]) -> Result<(), AddError> {
+async fn cmd_add(packages: &[String], dependency_field: DependencyField) -> Result<(), AddError> {
     let current_dir = find_project_root()?;
     let added_relations = packages
         .iter()
@@ -391,7 +394,12 @@ async fn cmd_add(packages: &[String]) -> Result<(), AddError> {
     };
     let r_version = r_version_async().await?;
 
-    add_dependencies(&current_dir, &mut description, &added_relations)?;
+    add_dependencies(
+        &current_dir,
+        &mut description,
+        &added_relations,
+        dependency_field,
+    )?;
 
     let desired_roots = project_dependencies(&current_dir, &description)?;
     let (root_name, root_version) = root_package(&current_dir, &description)?;
@@ -514,7 +522,12 @@ async fn cmd_add(packages: &[String]) -> Result<(), AddError> {
         });
 
     if final_added_relations != added_relations {
-        add_dependencies(&current_dir, &mut description, &final_added_relations)?;
+        add_dependencies(
+            &current_dir,
+            &mut description,
+            &final_added_relations,
+            dependency_field,
+        )?;
         lockfile.requirements = project_dependencies(&current_dir, &description)?;
     }
 

--- a/tests/deps.rs
+++ b/tests/deps.rs
@@ -398,7 +398,7 @@ Imports: digest",
 }
 
 #[test]
-fn moves_added_package_from_depends_to_imports() {
+fn adds_dependency_to_selected_description_field() {
     let container = start_container();
     let project_path = "/tmp/rpx-project-add-depends";
     write_description(
@@ -411,25 +411,59 @@ Description: Test package for rpx integration tests.
 License: MIT
 Author: Test Author
 Maintainer: Test Author <test@example.com>
-Depends: R (>= 4.3), digest",
+Depends: R (>= 4.3), digest
+Enhances: digest",
     );
 
-    let command = format!("cd {project_path} && rpx add digest");
-    let (exit_code, stdout, stderr) = run_shell_command(&container, &command);
+    for (flag, selected_index) in [
+        ("--depends", 0),
+        ("--imports", 1),
+        ("--linking-to", 2),
+        ("--suggests", 3),
+    ] {
+        let command = format!("cd {project_path} && rpx add {flag} digest");
+        let (exit_code, stdout, stderr) = run_shell_command(&container, &command);
+        assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
 
-    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
-    let description = read_project_file(&container, project_path, "DESCRIPTION");
-    let parsed = parsed_description(&description);
-    let depends = relation_names(parsed.depends().expect("Depends should parse"));
-    let imports = relation_names(parsed.imports().expect("Imports should parse"));
-    assert!(
-        !depends.contains(&"digest".to_string()) && depends.contains(&"R".to_string()),
-        "DESCRIPTION was: {description}"
-    );
-    assert!(
-        imports.contains(&"digest".to_string()),
-        "DESCRIPTION was: {description}"
-    );
+        let description = read_project_file(&container, project_path, "DESCRIPTION");
+        let parsed = parsed_description(&description);
+        let managed_fields = [
+            relation_names(parsed.depends().expect("Depends should parse")),
+            relation_names(parsed.imports().expect("Imports should parse")),
+            relation_names(parsed.linking_to().expect("LinkingTo should parse")),
+            relation_names(parsed.suggests().expect("Suggests should parse")),
+        ];
+        assert!(managed_fields.iter().enumerate().all(|(index, relations)| {
+            relations.contains(&"digest".to_string()) == (index == selected_index)
+        }));
+        assert!(managed_fields[0].contains(&"R".to_string()));
+        assert!(
+            relation_names(parsed.enhances().expect("Enhances should parse"))
+                .contains(&"digest".to_string())
+        );
+
+        let selected_relations = match selected_index {
+            0 => parsed.depends().expect("Depends should parse"),
+            1 => parsed.imports().expect("Imports should parse"),
+            2 => parsed.linking_to().expect("LinkingTo should parse"),
+            3 => parsed.suggests().expect("Suggests should parse"),
+            _ => unreachable!(),
+        }
+        .filter(|relation| relation.package() == "digest")
+        .map(|relation| relation.to_string())
+        .collect::<Vec<_>>();
+        assert_eq!(selected_relations.len(), 2);
+        assert!(
+            selected_relations
+                .iter()
+                .any(|relation| relation.contains(">="))
+        );
+        assert!(
+            selected_relations
+                .iter()
+                .any(|relation| relation.contains('<'))
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add mutually exclusive `--depends`, `--imports`, `--linking-to`, and `--suggests` flags to `rpx add`
- support `--dev` as an alias for `--suggests` while preserving `Imports` as the default
- move dependencies between managed DESCRIPTION fields without duplication and keep generated bounds in the selected field
- leave `Enhances` untouched and document the supported behavior

## Tests
- `cargo test`
- `cargo test --lib`
- `cargo clippy --all-targets`

Closes #81