### PR TITLE
fix: diagnose invalid CRAN package indexes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -675,12 +675,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deb822-fast"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "114c474fa4cd5d6d24bb5e68b36fa4ef70f5b830e3cc14a9b66a12e71a15aeb9"
-
-[[package]]
 name = "deb822-lossless"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2476,7 +2470,7 @@ dependencies = [
  "bytes",
  "clap",
  "cliclack",
- "deb822-fast",
+ "deb822-lossless",
  "directories",
  "flate2",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ async-trait = "0.1"
 clap = { version = "4.6.0", features = ["derive"] }
 bytes = "1"
 cliclack = "0.5.6"
-deb822-fast = "0.2.3"
+deb822-lossless = "0.5.18"
 directories = "6.0.0"
 flate2 = "1.1.5"
 futures-core = "0.3"

--- a/src/http.rs
+++ b/src/http.rs
@@ -508,6 +508,8 @@ fn parse_packages_relations_field(
 
     value
         .split(',')
+        .map(str::trim)
+        .filter(|relation| !relation.is_empty())
         .map(|relation| {
             relation
                 .parse()
@@ -742,4 +744,35 @@ pub async fn cran_macos_binary(
         ]);
 
     client().get(url).send().await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CranPackagesIndex;
+
+    #[test]
+    fn parses_trailing_commas_in_cran_package_relations() {
+        let index = "Package: first\nVersion: 1.0.0\nDepends: R (>= 4.0.0),\nImports: cli, digest,\nSuggests: testthat,\nLinkingTo: cpp11,\n\nPackage: second\nVersion: 2.0.0\nImports: first\n";
+
+        let index = index
+            .parse::<CranPackagesIndex>()
+            .expect("trailing commas should be accepted");
+
+        assert_eq!(index.packages.len(), 2);
+        let first = &index.packages[0];
+        assert_eq!(first.depends.len(), 1);
+        assert_eq!(first.imports.len(), 2);
+        assert_eq!(first.suggests.len(), 1);
+        assert_eq!(first.linking_to.len(), 1);
+        assert_eq!(index.packages[1].package, "second");
+    }
+
+    #[test]
+    fn rejects_malformed_nonempty_cran_package_relations() {
+        let error = "Package: example\nVersion: 1.0.0\nImports: cli (>= invalid),\n"
+            .parse::<CranPackagesIndex>()
+            .expect_err("malformed nonempty relations should be rejected");
+
+        assert!(error.contains("failed to parse Imports"));
+    }
 }

--- a/src/http.rs
+++ b/src/http.rs
@@ -1,15 +1,17 @@
 use async_trait::async_trait;
+use deb822_lossless::{Entry as DcfEntry, Paragraph, PositionedParseError};
 use http::Extensions;
 use keyring::Entry;
+use miette::{Diagnostic, NamedSource, SourceSpan};
 use moka::future::Cache;
-use r_description::{Relation, Version};
+use r_description::{PositionedRelationParseError, Relation, Version, VersionParseError};
 use reqwest::header::{AUTHORIZATION, HeaderValue};
 use reqwest_middleware::{ClientBuilder, Middleware, Next};
 use reqwest_tracing::{
     ReqwestOtelSpanBackend, TracingMiddleware, default_on_request_end, reqwest_otel_span,
 };
 use std::hash::{DefaultHasher, Hash, Hasher};
-use std::io::{Cursor, IsTerminal};
+use std::io::IsTerminal;
 use std::str::FromStr;
 use std::sync::{Arc, LazyLock};
 use thiserror::Error;
@@ -298,7 +300,7 @@ impl ReqwestOtelSpanBackend for RpxHttpProgressTrace {
         let span = reqwest_otel_span!(
             name = "http_request",
             req,
-            url.full = %remove_credentials(req.url()),
+            url.full = %display_safe_url(req.url()),
             indicatif.pb_show = true,
         );
         span.pb_set_message(&message);
@@ -319,10 +321,12 @@ fn request_progress_message(req: &reqwest::Request) -> String {
     format!("{} {}", req.method(), req.url().path())
 }
 
-fn remove_credentials(url: &reqwest::Url) -> reqwest::Url {
+pub(crate) fn display_safe_url(url: &reqwest::Url) -> reqwest::Url {
     let mut url = url.clone();
     let _ = url.set_username("");
     let _ = url.set_password(None);
+    url.set_query(None);
+    url.set_fragment(None);
     url
 }
 
@@ -331,63 +335,293 @@ pub struct CranPackagesIndex {
     pub packages: Vec<CranPackageIndexEntry>,
 }
 
+#[derive(Clone, Debug, Error, Diagnostic)]
+#[error("failed to parse CRAN PACKAGES index ({count} errors)")]
+#[diagnostic(
+    code(rpx::repository::cran_packages_parse_failed),
+    help(
+        "The repository returned invalid metadata. Try another mirror or contact the repository maintainer."
+    )
+)]
+pub struct CranPackagesParseError {
+    count: usize,
+
+    #[source_code]
+    source_code: NamedSource<String>,
+
+    #[related]
+    issues: Vec<CranPackagesParseIssue>,
+}
+
+impl CranPackagesParseError {
+    fn new(
+        source_name: impl Into<String>,
+        source: String,
+        issues: Vec<CranPackagesParseIssue>,
+    ) -> Self {
+        let source_name = source_name.into();
+        Self {
+            count: issues.len(),
+            source_code: NamedSource::new(source_name, source),
+            issues,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Error, Diagnostic)]
+pub enum CranPackagesParseIssue {
+    #[error("{error}")]
+    Syntax {
+        error: PositionedParseError,
+        #[label("{error}")]
+        span: SourceSpan,
+    },
+
+    #[error("required {field} field is missing")]
+    MissingField {
+        field: &'static str,
+        #[label("{field} is required in this package record")]
+        span: SourceSpan,
+    },
+
+    #[error("{field} field is empty")]
+    EmptyField {
+        field: &'static str,
+        #[label("{field} must not be empty")]
+        span: SourceSpan,
+    },
+
+    #[error("{field} field is declared multiple times")]
+    DuplicateField {
+        field: &'static str,
+        #[label("duplicate {field} field")]
+        span: SourceSpan,
+    },
+
+    #[error("invalid Version field: {source}")]
+    InvalidVersion {
+        #[source]
+        source: VersionParseError,
+        #[label("{source}")]
+        span: SourceSpan,
+    },
+
+    #[error("failed to parse {field}: {source}")]
+    InvalidRelation {
+        field: &'static str,
+        #[source]
+        source: PositionedRelationParseError,
+        #[label("{source}")]
+        span: SourceSpan,
+    },
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CranPackageIndexEntry {
     pub package: String,
-    pub version: String,
+    pub version: Version,
     pub depends: Vec<Relation>,
     pub imports: Vec<Relation>,
     pub suggests: Vec<Relation>,
     pub linking_to: Vec<Relation>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
-pub struct CranArchiveRootListing {
-    pub packages: Vec<String>,
+impl CranPackagesIndex {
+    pub fn parse(
+        source_name: impl Into<String>,
+        source: String,
+    ) -> Result<Self, CranPackagesParseError> {
+        let parsed = deb822_lossless::Deb822::parse(&source);
+        let syntax_issues = parsed
+            .positioned_errors()
+            .iter()
+            .map(|error| {
+                let start = usize::from(error.range.start());
+                let end = usize::from(error.range.end());
+                CranPackagesParseIssue::Syntax {
+                    error: error.clone(),
+                    span: (start..end).into(),
+                }
+            })
+            .collect::<Vec<_>>();
+        if !syntax_issues.is_empty() {
+            return Err(CranPackagesParseError::new(
+                source_name,
+                source,
+                syntax_issues,
+            ));
+        }
+
+        let document = parsed.tree();
+        let (packages, issues): (Vec<_>, Vec<_>) = document
+            .paragraphs()
+            .map(|paragraph| cran_package_index_entry_from_paragraph(&paragraph))
+            .partition(Result::is_ok);
+        let packages = packages.into_iter().map(Result::unwrap).collect::<Vec<_>>();
+        let issues = issues
+            .into_iter()
+            .flat_map(Result::unwrap_err)
+            .collect::<Vec<_>>();
+
+        if !issues.is_empty() {
+            return Err(CranPackagesParseError::new(source_name, source, issues));
+        }
+
+        Ok(Self { packages })
+    }
+}
+
+fn cran_package_index_entry_from_paragraph(
+    paragraph: &Paragraph,
+) -> Result<CranPackageIndexEntry, Vec<CranPackagesParseIssue>> {
+    let package = parse_required_packages_field(paragraph, "Package", |value, _entry| {
+        Ok::<_, CranPackagesParseIssue>(value.to_string())
+    });
+    let version = parse_required_packages_field(paragraph, "Version", |value, entry| {
+        value
+            .parse::<Version>()
+            .map_err(|source| CranPackagesParseIssue::InvalidVersion {
+                source,
+                span: packages_field_span(entry),
+            })
+    });
+    let depends = parse_packages_relations_field(paragraph, "Depends");
+    let imports = parse_packages_relations_field(paragraph, "Imports");
+    let suggests = parse_packages_relations_field(paragraph, "Suggests");
+    let linking_to = parse_packages_relations_field(paragraph, "LinkingTo");
+
+    match (package, version, depends, imports, suggests, linking_to) {
+        (Ok(package), Ok(version), Ok(depends), Ok(imports), Ok(suggests), Ok(linking_to)) => {
+            Ok(CranPackageIndexEntry {
+                package,
+                version,
+                depends,
+                imports,
+                suggests,
+                linking_to,
+            })
+        }
+        (package, version, depends, imports, suggests, linking_to) => Err([
+            package.err(),
+            version.err(),
+            depends.err(),
+            imports.err(),
+            suggests.err(),
+            linking_to.err(),
+        ]
+        .into_iter()
+        .flatten()
+        .flatten()
+        .collect()),
+    }
+}
+
+fn parse_required_packages_field<T>(
+    paragraph: &Paragraph,
+    field: &'static str,
+    parse: impl FnOnce(&str, &DcfEntry) -> Result<T, CranPackagesParseIssue>,
+) -> Result<T, Vec<CranPackagesParseIssue>> {
+    let entry = unique_packages_field(paragraph, field)?.ok_or_else(|| {
+        vec![CranPackagesParseIssue::MissingField {
+            field,
+            span: text_range_span(paragraph.text_range()),
+        }]
+    })?;
+    let value = entry.value();
+    let value = value.trim();
+
+    if value.is_empty() {
+        Err(vec![CranPackagesParseIssue::EmptyField {
+            field,
+            span: packages_field_span(&entry),
+        }])
+    } else {
+        parse(value, &entry).map_err(|issue| vec![issue])
+    }
+}
+
+fn unique_packages_field(
+    paragraph: &Paragraph,
+    field: &'static str,
+) -> Result<Option<DcfEntry>, Vec<CranPackagesParseIssue>> {
+    let entries = paragraph
+        .entries()
+        .filter(|entry| {
+            entry
+                .key()
+                .is_some_and(|key| key.eq_ignore_ascii_case(field))
+        })
+        .collect::<Vec<_>>();
+
+    match entries.len() {
+        0 => Ok(None),
+        1 => Ok(entries.into_iter().next()),
+        _ => Err(entries
+            .iter()
+            .map(|entry| CranPackagesParseIssue::DuplicateField {
+                field,
+                span: packages_field_span(entry),
+            })
+            .collect()),
+    }
+}
+
+fn parse_packages_relations_field(
+    paragraph: &Paragraph,
+    field: &'static str,
+) -> Result<Vec<Relation>, Vec<CranPackagesParseIssue>> {
+    let Some(entry) = unique_packages_field(paragraph, field)? else {
+        return Ok(Vec::new());
+    };
+    let value = entry.value();
+    let value = value.trim();
+    if value.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let value = value.strip_suffix(',').unwrap_or(value);
+    let (relations, issues): (Vec<_>, Vec<_>) = value
+        .split(',')
+        .map(str::trim)
+        .map(|relation| {
+            relation
+                .parse()
+                .map_err(|source| CranPackagesParseIssue::InvalidRelation {
+                    field,
+                    source,
+                    span: packages_field_span(&entry),
+                })
+        })
+        .partition(Result::is_ok);
+    let relations = relations
+        .into_iter()
+        .map(Result::unwrap)
+        .collect::<Vec<_>>();
+    let issues = issues
+        .into_iter()
+        .map(Result::unwrap_err)
+        .collect::<Vec<_>>();
+
+    if issues.is_empty() {
+        Ok(relations)
+    } else {
+        Err(issues)
+    }
+}
+
+fn packages_field_span(entry: &DcfEntry) -> SourceSpan {
+    text_range_span(entry.value_range().unwrap_or_else(|| entry.text_range()))
+}
+
+fn text_range_span(range: deb822_lossless::TextRange) -> SourceSpan {
+    let start = usize::from(range.start());
+    let end = usize::from(range.end());
+    (start..end).into()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CranPackageArchiveListing {
     pub versions: Vec<Version>,
-}
-
-impl FromStr for CranPackagesIndex {
-    type Err = String;
-
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
-        let reader = Cursor::new(input);
-        let packages = deb822_fast::ParagraphReader::new(reader)
-            .map(|paragraph| {
-                paragraph
-                    .map_err(|error| error.to_string())
-                    .and_then(|paragraph| cran_package_index_entry_from_paragraph(&paragraph))
-            })
-            .collect::<Result<Vec<_>, String>>()?;
-
-        Ok(Self { packages })
-    }
-}
-
-impl FromStr for CranArchiveRootListing {
-    type Err = String;
-
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
-        let mut packages = Vec::new();
-        for part in archive_listing_parts(input) {
-            if part.starts_with('/') || !part.ends_with('/') || part.contains('?') {
-                continue;
-            }
-
-            let package = part.trim_end_matches('/');
-            if package.is_empty() || packages.iter().any(|seen| seen == package) {
-                continue;
-            }
-
-            packages.push(html_unescape_minimal(package));
-        }
-
-        Ok(Self { packages })
-    }
 }
 
 impl FromStr for CranPackageArchiveListing {
@@ -465,57 +699,6 @@ fn html_unescape_minimal(value: &str) -> String {
         .replace("&lt;", "<")
         .replace("&gt;", ">")
         .replace("&quot;", "\"")
-}
-
-fn cran_package_index_entry_from_paragraph(
-    paragraph: &deb822_fast::Paragraph,
-) -> Result<CranPackageIndexEntry, String> {
-    let package = required_packages_field(paragraph, "Package")?;
-    let version = required_packages_field(paragraph, "Version")?;
-
-    Ok(CranPackageIndexEntry {
-        package,
-        version,
-        depends: parse_packages_relations_field(paragraph, "Depends")?,
-        imports: parse_packages_relations_field(paragraph, "Imports")?,
-        suggests: parse_packages_relations_field(paragraph, "Suggests")?,
-        linking_to: parse_packages_relations_field(paragraph, "LinkingTo")?,
-    })
-}
-
-fn required_packages_field(
-    paragraph: &deb822_fast::Paragraph,
-    field: &'static str,
-) -> Result<String, String> {
-    paragraph
-        .get(field)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToString::to_string)
-        .ok_or_else(|| format!("missing required field {field}"))
-}
-
-fn parse_packages_relations_field(
-    paragraph: &deb822_fast::Paragraph,
-    field: &'static str,
-) -> Result<Vec<Relation>, String> {
-    let Some(value) = paragraph.get(field).map(str::trim) else {
-        return Ok(Vec::new());
-    };
-    if value.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    value
-        .split(',')
-        .map(str::trim)
-        .filter(|relation| !relation.is_empty())
-        .map(|relation| {
-            relation
-                .parse()
-                .map_err(|details| format!("failed to parse {field}: {details}"))
-        })
-        .collect()
 }
 
 pub async fn rrepo_repository_packages(
@@ -748,15 +931,32 @@ pub async fn cran_macos_binary(
 
 #[cfg(test)]
 mod tests {
-    use super::CranPackagesIndex;
+    use super::{
+        CranPackagesIndex, CranPackagesParseError, CranPackagesParseIssue, display_safe_url,
+    };
+
+    fn parse_packages_index(input: &str) -> Result<CranPackagesIndex, CranPackagesParseError> {
+        CranPackagesIndex::parse("CRAN PACKAGES fixture", input.to_string())
+    }
+
+    #[test]
+    fn display_safe_url_removes_credentials_query_and_fragment() {
+        let url = reqwest::Url::parse(
+            "https://user:password@example.test/repository/src/contrib/PACKAGES?token=secret#part",
+        )
+        .expect("URL fixture should parse");
+
+        assert_eq!(
+            display_safe_url(&url).as_str(),
+            "https://example.test/repository/src/contrib/PACKAGES"
+        );
+    }
 
     #[test]
     fn parses_trailing_commas_in_cran_package_relations() {
         let index = "Package: first\nVersion: 1.0.0\nDepends: R (>= 4.0.0),\nImports: cli, digest,\nSuggests: testthat,\nLinkingTo: cpp11,\n\nPackage: second\nVersion: 2.0.0\nImports: first\n";
 
-        let index = index
-            .parse::<CranPackagesIndex>()
-            .expect("trailing commas should be accepted");
+        let index = parse_packages_index(index).expect("trailing commas should be accepted");
 
         assert_eq!(index.packages.len(), 2);
         let first = &index.packages[0];
@@ -769,10 +969,90 @@ mod tests {
 
     #[test]
     fn rejects_malformed_nonempty_cran_package_relations() {
-        let error = "Package: example\nVersion: 1.0.0\nImports: cli (>= invalid),\n"
-            .parse::<CranPackagesIndex>()
-            .expect_err("malformed nonempty relations should be rejected");
+        let error =
+            parse_packages_index("Package: example\nVersion: 1.0.0\nImports: cli (>= invalid),\n")
+                .expect_err("malformed nonempty relations should be rejected");
 
-        assert!(error.contains("failed to parse Imports"));
+        assert!(matches!(
+            error.issues.as_slice(),
+            [CranPackagesParseIssue::InvalidRelation {
+                field: "Imports",
+                ..
+            }]
+        ));
+    }
+
+    #[test]
+    fn rejects_empty_relations_except_for_one_trailing_comma() {
+        let error = parse_packages_index(
+            "Package: first\nVersion: 1.0.0\nImports: cli,,digest\n\nPackage: second\nVersion: 2.0.0\nImports: cli,,\n",
+        )
+            .expect_err("internal and repeated empty relations should be rejected");
+
+        assert_eq!(
+            error
+                .issues
+                .iter()
+                .filter(|issue| matches!(
+                    issue,
+                    CranPackagesParseIssue::InvalidRelation {
+                        field: "Imports",
+                        ..
+                    }
+                ))
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn aggregates_invalid_fields_across_package_records() {
+        let error = parse_packages_index(
+            "Version: invalid\nImports: cli,,digest\nSuggests: testthat\nSuggests: knitr\n\nPackage: valid\nVersion: 2.0.0\n",
+        )
+            .expect_err("every invalid package field should be reported");
+
+        assert_eq!(error.count, 5);
+        assert_eq!(error.issues.len(), 5);
+        assert!(error.issues.iter().any(|issue| matches!(
+            issue,
+            CranPackagesParseIssue::MissingField {
+                field: "Package",
+                ..
+            }
+        )));
+        assert!(
+            error
+                .issues
+                .iter()
+                .any(|issue| matches!(issue, CranPackagesParseIssue::InvalidVersion { .. }))
+        );
+        assert_eq!(
+            error
+                .issues
+                .iter()
+                .filter(|issue| matches!(
+                    issue,
+                    CranPackagesParseIssue::DuplicateField {
+                        field: "Suggests",
+                        ..
+                    }
+                ))
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn rejects_structurally_invalid_packages_before_reading_records() {
+        let error = parse_packages_index("Package example\nVersion: 1.0.0\n")
+            .expect_err("invalid DCF syntax should reject the complete index");
+
+        assert!(
+            error
+                .issues
+                .iter()
+                .all(|issue| matches!(issue, CranPackagesParseIssue::Syntax { .. }))
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,6 +189,37 @@ mod tests {
     }
 
     #[test]
+    fn cran_index_diagnostic_survives_pubgrub_resolution_errors() {
+        let parse_error = crate::http::CranPackagesIndex::parse(
+            "https://example.test/src/contrib/PACKAGES",
+            "Package: fixture\nVersion: invalid\n".to_string(),
+        )
+        .expect_err("invalid CRAN version should fail");
+        let source = PubGrubError::ErrorChoosingVersion {
+            package: "fixture".to_string(),
+            source: ProviderError::Repository(RepositoryError::CranPackages(Box::new(parse_error))),
+        };
+
+        let error = ResolveProjectError::from(ResolutionError::from(source));
+
+        assert_eq!(
+            error.code().map(|code| code.to_string()).as_deref(),
+            Some("rpx::repository::cran_packages_parse_failed")
+        );
+        assert!(error.source_code().is_some());
+        let help = error
+            .help()
+            .expect("CRAN parse diagnostic should retain repository guidance")
+            .to_string();
+        assert!(help.contains("repository returned invalid metadata"));
+        assert!(!help.contains("DESCRIPTION"));
+        assert!(matches!(
+            error,
+            ResolveProjectError::Repository(RepositoryError::CranPackages(_))
+        ));
+    }
+
+    #[test]
     fn lockfile_build_error_maps_repository_categories() {
         assert!(matches!(
             LockfileBuildError::from(git_access_error("https://example.test/private.git")),

--- a/src/project.rs
+++ b/src/project.rs
@@ -379,6 +379,10 @@ pub(crate) enum ResolveProjectError {
     #[diagnostic(transparent)]
     BasePackages(#[from] BasePackagesError),
 
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    Repository(RepositoryError),
+
     #[error("could not access Git repository {repository}")]
     #[diagnostic(
         code(rpx::lock::git_repository_unavailable),
@@ -393,10 +397,7 @@ pub(crate) enum ResolveProjectError {
     },
 
     #[error("failed to resolve package set")]
-    #[diagnostic(
-        code(rpx::lock::resolve_failed),
-        help("Check package names and version constraints in DESCRIPTION.")
-    )]
+    #[diagnostic(code(rpx::lock::resolve_failed))]
     Resolution {
         #[source]
         source: Box<ResolutionError>,
@@ -416,6 +417,33 @@ impl From<ResolutionError> for ResolveProjectError {
                     explanation: DefaultStringReporter::report(&derivation_tree),
                 }
             }
+            ResolutionError::PubGrub(
+                PubGrubError::ErrorChoosingVersion {
+                    source:
+                        ProviderError::Repository(source @ RepositoryError::CranPackages(_))
+                        | ProviderError::DependencyMetadata {
+                            source: source @ RepositoryError::CranPackages(_),
+                            ..
+                        },
+                    ..
+                }
+                | PubGrubError::ErrorRetrievingDependencies {
+                    source:
+                        ProviderError::Repository(source @ RepositoryError::CranPackages(_))
+                        | ProviderError::DependencyMetadata {
+                            source: source @ RepositoryError::CranPackages(_),
+                            ..
+                        },
+                    ..
+                }
+                | PubGrubError::ErrorInShouldCancel(
+                    ProviderError::Repository(source @ RepositoryError::CranPackages(_))
+                    | ProviderError::DependencyMetadata {
+                        source: source @ RepositoryError::CranPackages(_),
+                        ..
+                    },
+                ),
+            ) => Self::Repository(source),
             ResolutionError::BasePackages(source) => Self::BasePackages(source),
             ResolutionError::Provider(provider) => {
                 let repository = match &provider {
@@ -424,15 +452,26 @@ impl From<ResolutionError> for ResolveProjectError {
                         inaccessible_git_repository(source).map(str::to_owned)
                     }
                 };
-                let source = ResolutionError::Provider(provider);
                 if let Some(repository) = repository {
                     Self::GitRepositoryUnavailable {
                         repository,
-                        source: Box::new(source),
+                        source: Box::new(ResolutionError::Provider(provider)),
                     }
+                } else if matches!(
+                    provider,
+                    ProviderError::Repository(RepositoryError::CranPackages(_))
+                        | ProviderError::DependencyMetadata {
+                            source: RepositoryError::CranPackages(_),
+                            ..
+                        }
+                ) {
+                    Self::Repository(match provider {
+                        ProviderError::Repository(source)
+                        | ProviderError::DependencyMetadata { source, .. } => source,
+                    })
                 } else {
                     Self::Resolution {
-                        source: Box::new(source),
+                        source: Box::new(ResolutionError::Provider(provider)),
                     }
                 }
             }

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -6,6 +6,7 @@ mod rrepo;
 use crate::http;
 use crate::resolver::PackageVersion;
 use async_trait::async_trait;
+use miette::Diagnostic;
 use r_description::{PackageError, RDescription, Version, VersionError};
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
@@ -48,8 +49,12 @@ pub enum ArchiveSupport {
     Unavailable,
 }
 
-#[derive(Debug, Clone, Error)]
+#[derive(Debug, Clone, Error, Diagnostic)]
 pub enum RepositoryError {
+    #[error(transparent)]
+    #[diagnostic(transparent)]
+    CranPackages(Box<http::CranPackagesParseError>),
+
     #[error("request failed: {source}")]
     Request {
         #[source]

--- a/src/repository/cran.rs
+++ b/src/repository/cran.rs
@@ -49,7 +49,7 @@ impl CranRepository {
     async fn packages_index(&self) -> Result<Arc<http::CranPackagesIndex>, RepositoryError> {
         self.packages
             .try_get_with((), async {
-                let text = http::cran_packages(&self.url)
+                let response = http::cran_packages(&self.url)
                     .await
                     .map_err(|source| RepositoryError::Request {
                         source: Arc::new(source),
@@ -57,18 +57,16 @@ impl CranRepository {
                     .error_for_status()
                     .map_err(|source| RepositoryError::Response {
                         source: Arc::new(source),
-                    })?
+                    })?;
+                let source_name = http::display_safe_url(response.url()).to_string();
+                let text = response
                     .text()
                     .await
                     .map_err(|source| RepositoryError::Response {
                         source: Arc::new(source),
                     })?;
-                let index = text.parse::<http::CranPackagesIndex>().map_err(|details| {
-                    RepositoryError::InvalidData {
-                        resource: "CRAN PACKAGES index".to_string(),
-                        details,
-                    }
-                })?;
+                let index = http::CranPackagesIndex::parse(source_name, text)
+                    .map_err(|source| RepositoryError::CranPackages(Box::new(source)))?;
 
                 Ok::<Arc<http::CranPackagesIndex>, RepositoryError>(Arc::new(index))
             })
@@ -97,25 +95,11 @@ impl PackageRepository for CranRepository {
         Ok(index
             .packages
             .iter()
-            .filter_map(|package| {
-                let version = match package.version.parse::<Version>() {
-                    Ok(version) => version,
-                    Err(error) => {
-                        tracing::debug!(
-                            package = %package.package,
-                            version = %package.version,
-                            repository = %self.url,
-                            error = %error,
-                            "skipping package with invalid latest version"
-                        );
-                        return None;
-                    }
-                };
-
-                Some((
+            .map(|package| {
+                (
                     package.package.clone(),
-                    PackageVersion::new(version, Arc::clone(&repository)),
-                ))
+                    PackageVersion::new(package.version.clone(), Arc::clone(&repository)),
+                )
             })
             .collect())
     }
@@ -127,16 +111,8 @@ impl PackageRepository for CranRepository {
             .packages
             .iter()
             .filter(|entry| entry.package == package)
-            .map(|entry| {
-                entry
-                    .version
-                    .parse::<Version>()
-                    .map_err(|source| RepositoryError::InvalidData {
-                        resource: "package version".to_string(),
-                        details: source.to_string(),
-                    })
-            })
-            .collect::<Result<BTreeSet<_>, RepositoryError>>()?;
+            .map(|entry| entry.version.clone())
+            .collect::<BTreeSet<_>>();
 
         if versions.is_empty() {
             return Ok(BTreeSet::new());
@@ -198,15 +174,14 @@ impl PackageRepository for CranRepository {
         self.descriptions
             .try_get_with(key, async {
                 let index = self.packages_index().await?;
-                let version_string = version.to_string();
-
                 let description = if let Some(entry) = index
                     .packages
                     .iter()
-                    .find(|entry| entry.package == package && entry.version == version_string)
+                    .find(|entry| entry.package == package && &entry.version == version)
                 {
                     packages_entry_to_description(entry)?
                 } else {
+                    let version_string = version.to_string();
                     let response =
                         http::cran_archive_source_tarball(&self.url, package, &version_string)
                             .await
@@ -246,15 +221,7 @@ fn packages_entry_to_description(
             resource: "Package in CRAN PACKAGES index".to_string(),
             details: source.to_string(),
         })?;
-    let version =
-        entry
-            .version
-            .parse::<Version>()
-            .map_err(|source| RepositoryError::InvalidData {
-                resource: "Version in CRAN PACKAGES index".to_string(),
-                details: source.to_string(),
-            })?;
-    description.set_version(&version);
+    description.set_version(&entry.version);
 
     if !entry.depends.is_empty() {
         description.set_depends(entry.depends.clone());


### PR DESCRIPTION
## Summary
- accept one trailing comma in CRAN package relation fields while rejecting malformed nonempty relations
- parse complete `PACKAGES` indexes with lossless source positions and aggregate structural and semantic errors
- preserve typed CRAN index diagnostics through repository resolution and PubGrub without unrelated `DESCRIPTION` help
- sanitize diagnostic source URLs by removing credentials, query parameters, and fragments

## Testing
- `cargo fmt --check`
- `git diff --check`
- `cargo test` (199 tests passed)
- `cargo clippy --all-targets` (passes with existing warnings)
- live `rpx lock` against `https://cran.r-project.org`

Closes #93
Linear: SCA-78