### PR TITLE
fix: isolate source package installation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -819,6 +819,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
 name = "ferroid"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2496,6 +2502,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tar",
+ "tempfile",
  "testcontainers",
  "thiserror",
  "time",
@@ -3061,6 +3068,19 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2502,6 +2502,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tar",
+ "target-lexicon",
  "tempfile",
  "testcontainers",
  "thiserror",
@@ -3069,6 +3070,12 @@ dependencies = [
  "libc",
  "xattr",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
 tar = "0.4.44"
+target-lexicon = "0.13.3"
 tempfile = "3"
 thiserror = "2.0.17"
 time = "0.3.53"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
 tar = "0.4.44"
+tempfile = "3"
 thiserror = "2.0.17"
 time = "0.3.53"
 tokio = { version = "1.51.1", features = ["rt-multi-thread", "macros", "process", "fs", "io-util", "sync"] }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,164 +1,159 @@
-use crate::project::cache_dir_path;
+use crate::{git::GitUrl, project::cache_dir_path};
+use git2::Oid;
+use r_description::Version;
+use semver::Version as RVersion;
 use std::{
     collections::hash_map::DefaultHasher,
-    fmt, fs,
     hash::{Hash, Hasher},
-    path::{Path, PathBuf},
+    path::PathBuf,
 };
+use target_lexicon::{OperatingSystem, Triple};
+use url::Url;
 
-pub(crate) fn artifact_cache_path(package: &str, version: &str, file_name: &str) -> PathBuf {
-    let path = cache_dir_path()
-        .join("artifacts")
-        .join(package)
-        .join(version)
-        .join(file_name);
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent).expect("failed to create cache directory");
-    }
-    path
+const SOURCE_ARTIFACT_CACHE_VERSION: &str = "v1";
+const BINARY_ARTIFACT_CACHE_VERSION: &str = "v1";
+const COMPILED_PACKAGE_CACHE_VERSION: &str = "v1";
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum RegistryIdentity {
+    Cran(Url),
+    Rrepo(Url),
 }
 
-pub(crate) fn build_temp_library_path(package: &str, unique: &str) -> PathBuf {
-    let path = cache_dir_path()
-        .join("build-temp")
-        .join(format!("{package}-{unique}"))
-        .join("library");
-    fs::create_dir_all(&path).expect("failed to create temporary build library");
-    path
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum SourceArtifactIdentity {
+    Registry(RegistryIdentity),
+    Git {
+        remote: GitUrl,
+        commit: Oid,
+        subdirectory: Option<PathBuf>,
+    },
+    Local(PathBuf),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct CompiledPackageCacheKey {
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct SourceArtifactCacheKey {
+    source: SourceArtifactIdentity,
     package: String,
-    version: String,
-    r_version: semver::Version,
-    platform: String,
+    version: Version,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct BinaryArtifactCacheKey {
+    repository: RegistryIdentity,
+    package: String,
+    version: Version,
+    target: Triple,
+    r_version: RVersion,
+}
+
+impl SourceArtifactCacheKey {
+    pub(crate) fn new(
+        source: SourceArtifactIdentity,
+        package: impl Into<String>,
+        version: Version,
+    ) -> Self {
+        Self {
+            source,
+            package: package.into(),
+            version,
+        }
+    }
+}
+
+impl BinaryArtifactCacheKey {
+    pub(crate) fn new(
+        repository: RegistryIdentity,
+        package: impl Into<String>,
+        version: Version,
+        target: Triple,
+        r_version: RVersion,
+    ) -> Self {
+        Self {
+            repository,
+            package: package.into(),
+            version,
+            target,
+            r_version,
+        }
+    }
+}
+
+fn cache_key_digest(key: &impl Hash) -> String {
+    let mut hasher = DefaultHasher::new();
+    key.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+pub(crate) fn source_artifact_cache_path(key: &SourceArtifactCacheKey) -> PathBuf {
+    cache_dir_path()
+        .join("artifacts")
+        .join("source")
+        .join(SOURCE_ARTIFACT_CACHE_VERSION)
+        .join(&key.package)
+        .join(cache_key_digest(key))
+        .join("artifact.tar.gz")
+}
+
+pub(crate) fn binary_artifact_cache_path(key: &BinaryArtifactCacheKey) -> PathBuf {
+    let file_name = match key.target.operating_system {
+        OperatingSystem::Windows => "artifact.zip",
+        OperatingSystem::Darwin(_) | OperatingSystem::MacOSX(_) => "artifact.tgz",
+        _ => "artifact.bin",
+    };
+    cache_dir_path()
+        .join("artifacts")
+        .join("binary")
+        .join(BINARY_ARTIFACT_CACHE_VERSION)
+        .join(&key.package)
+        .join(cache_key_digest(key))
+        .join(file_name)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct CompiledPackageCacheKey {
+    repository: RegistryIdentity,
+    package: String,
+    version: Version,
+    target: Triple,
+    r_version: RVersion,
 }
 
 impl CompiledPackageCacheKey {
-    pub fn new(package: &str, version: &str, r_version: &semver::Version) -> Self {
-        Self::with_platform(package, version, r_version, host_platform_key())
-    }
-
-    pub fn with_platform(
-        package: &str,
-        version: &str,
-        r_version: &semver::Version,
-        platform: impl Into<String>,
+    pub(crate) fn new(
+        repository: RegistryIdentity,
+        package: impl Into<String>,
+        version: Version,
+        target: Triple,
+        r_version: RVersion,
     ) -> Self {
         Self {
-            package: package.to_string(),
-            version: version.to_string(),
-            r_version: r_version.clone(),
-            platform: platform.into(),
+            repository,
+            package: package.into(),
+            version,
+            target,
+            r_version,
         }
     }
-
-    pub fn package(&self) -> &str {
-        &self.package
-    }
-
-    fn cache_dir_name(&self) -> String {
-        format!(
-            "{}-{}-{}-{}",
-            self.package,
-            self.version,
-            self.platform,
-            self.digest()
-        )
-    }
-
-    fn digest(&self) -> String {
-        let input = format!(
-            "{}\n{}\n{}\n{}",
-            self.package, self.version, self.r_version, self.platform
-        );
-        let mut hasher = DefaultHasher::new();
-        input.hash(&mut hasher);
-
-        format!("{:016x}", hasher.finish())
-    }
 }
 
-impl fmt::Display for CompiledPackageCacheKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.cache_dir_name())
-    }
-}
-
-pub async fn exists(key: &CompiledPackageCacheKey) -> bool {
-    package_cache_path(key).exists()
-}
-
-pub async fn restore(key: &CompiledPackageCacheKey, target_library: &Path) -> Result<(), String> {
-    let source = package_cache_path(key);
-    let target = target_library.join(key.package());
-
-    tokio::task::spawn_blocking(move || copy_package_dir(&source, &target))
-        .await
-        .map_err(|error| format!("failed to join cache restore task: {error}"))?
-}
-
-pub async fn store(key: &CompiledPackageCacheKey, package_dir: &Path) -> Result<(), String> {
-    let target = package_cache_path(key);
-    let package_dir = package_dir.to_path_buf();
-
-    tokio::task::spawn_blocking(move || copy_package_dir(&package_dir, &target))
-        .await
-        .map_err(|error| format!("failed to join cache store task: {error}"))?
-}
-
-fn host_platform_key() -> String {
-    format!("{}-{}", std::env::consts::OS, std::env::consts::ARCH)
-}
-
-fn package_cache_path(key: &CompiledPackageCacheKey) -> PathBuf {
+pub(crate) fn compiled_package_cache_path(key: &CompiledPackageCacheKey) -> PathBuf {
     cache_dir_path()
         .join("builds")
-        .join(key.cache_dir_name())
+        .join(COMPILED_PACKAGE_CACHE_VERSION)
+        .join(&key.package)
+        .join(cache_key_digest(key))
         .join("package")
-}
-
-fn copy_package_dir(source: &Path, destination: &Path) -> Result<(), String> {
-    if !source.exists() {
-        return Err(format!(
-            "cached package directory is missing: {}",
-            source.display()
-        ));
-    }
-
-    if destination.exists() {
-        fs::remove_dir_all(destination)
-            .map_err(|error| format!("failed to replace package directory: {error}"))?;
-    }
-    fs::create_dir_all(destination)
-        .map_err(|error| format!("failed to create package directory: {error}"))?;
-
-    for entry in fs::read_dir(source)
-        .map_err(|error| format!("failed to read package directory: {error}"))?
-    {
-        let entry = entry.map_err(|error| format!("failed to read package entry: {error}"))?;
-        let source_path = entry.path();
-        let destination_path = destination.join(entry.file_name());
-        let file_type = entry
-            .file_type()
-            .map_err(|error| format!("failed to inspect package entry: {error}"))?;
-
-        if file_type.is_dir() {
-            copy_package_dir(&source_path, &destination_path)?;
-        } else {
-            fs::copy(&source_path, &destination_path)
-                .map_err(|error| format!("failed to copy package file: {error}"))?;
-        }
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::{
+        fs,
+        path::Path,
+        sync::atomic::{AtomicU64, Ordering},
+    };
 
     static UNIQUE: AtomicU64 = AtomicU64::new(0);
 
@@ -177,27 +172,154 @@ mod tests {
     }
 
     #[test]
-    fn artifact_cache_path_has_exact_layout_and_creates_only_parent() {
+    fn source_artifact_cache_path_is_versioned_and_has_no_side_effects() {
         let package = unique("artifact");
-        let root = cache_dir_path().join("artifacts").join(&package);
+        let root = cache_dir_path()
+            .join("artifacts")
+            .join("source")
+            .join(SOURCE_ARTIFACT_CACHE_VERSION)
+            .join(&package);
         remove_dir_if_present(&root);
-        let path = artifact_cache_path(&package, "1.2.3", "package.tar.gz");
-        assert_eq!(path, root.join("1.2.3").join("package.tar.gz"));
-        assert!(path.parent().expect("artifact should have parent").is_dir());
+        let key = SourceArtifactCacheKey::new(
+            SourceArtifactIdentity::Registry(RegistryIdentity::Cran(
+                "https://example.test/cran".parse().unwrap(),
+            )),
+            &package,
+            "1.2.3".parse().unwrap(),
+        );
+        let path = source_artifact_cache_path(&key);
+        assert_eq!(
+            path.parent()
+                .and_then(Path::parent)
+                .expect("artifact should be nested below its package"),
+            root
+        );
+        assert_eq!(
+            path.file_name().and_then(|name| name.to_str()),
+            Some("artifact.tar.gz")
+        );
+        assert!(!root.exists());
         assert!(!path.exists());
-        remove_dir_if_present(&root);
     }
 
     #[test]
-    fn build_temp_library_path_has_exact_layout_and_creates_directory() {
-        let package = unique("build");
-        let root = cache_dir_path()
-            .join("build-temp")
-            .join(format!("{package}-unique"));
-        remove_dir_if_present(&root);
-        let path = build_temp_library_path(&package, "unique");
-        assert_eq!(path, root.join("library"));
-        assert!(path.is_dir());
-        remove_dir_if_present(&root);
+    fn source_artifact_key_uses_version_equivalence() {
+        let key = |version: &str| {
+            SourceArtifactCacheKey::new(
+                SourceArtifactIdentity::Registry(RegistryIdentity::Cran(
+                    "https://example.test/cran".parse().unwrap(),
+                )),
+                "package",
+                version.parse().unwrap(),
+            )
+        };
+        let hyphen = key("2.5-1");
+        let trailing_zeroes = key("2.5.1.0");
+
+        assert_eq!(hyphen, trailing_zeroes);
+        assert_eq!(
+            source_artifact_cache_path(&hyphen),
+            source_artifact_cache_path(&trailing_zeroes)
+        );
+    }
+
+    #[test]
+    fn artifact_stores_use_distinct_compatibility_keys() {
+        let repository = || RegistryIdentity::Cran("https://example.test/cran".parse().unwrap());
+        let source = source_artifact_cache_path(&SourceArtifactCacheKey::new(
+            SourceArtifactIdentity::Registry(repository()),
+            "package",
+            "1.2.3".parse().unwrap(),
+        ));
+        let other_repository = source_artifact_cache_path(&SourceArtifactCacheKey::new(
+            SourceArtifactIdentity::Registry(RegistryIdentity::Cran(
+                "https://mirror.example.test/cran".parse().unwrap(),
+            )),
+            "package",
+            "1.2.3".parse().unwrap(),
+        ));
+        let windows_430 = binary_artifact_cache_path(&BinaryArtifactCacheKey::new(
+            repository(),
+            "package",
+            "1.2.3".parse().unwrap(),
+            "x86_64-pc-windows-msvc".parse().unwrap(),
+            "4.3.0".parse().unwrap(),
+        ));
+        let windows_431 = binary_artifact_cache_path(&BinaryArtifactCacheKey::new(
+            repository(),
+            "package",
+            "1.2.3".parse().unwrap(),
+            "x86_64-pc-windows-msvc".parse().unwrap(),
+            "4.3.1".parse().unwrap(),
+        ));
+        let windows_arm = binary_artifact_cache_path(&BinaryArtifactCacheKey::new(
+            repository(),
+            "package",
+            "1.2.3".parse().unwrap(),
+            "aarch64-pc-windows-msvc".parse().unwrap(),
+            "4.3.0".parse().unwrap(),
+        ));
+
+        assert_ne!(source, other_repository);
+        assert_ne!(source, windows_430);
+        assert_ne!(windows_430, windows_431);
+        assert_ne!(windows_430, windows_arm);
+    }
+
+    #[test]
+    fn compiled_package_cache_uses_binary_compatibility_identity() {
+        let repository = || RegistryIdentity::Cran("https://example.test/cran".parse().unwrap());
+        let key = |repository, version: &str, target: &str, r_version: &str| {
+            CompiledPackageCacheKey::new(
+                repository,
+                "package",
+                version.parse().unwrap(),
+                target.parse().unwrap(),
+                r_version.parse().unwrap(),
+            )
+        };
+        let base = compiled_package_cache_path(&key(
+            repository(),
+            "1.2.3",
+            "x86_64-pc-windows-msvc",
+            "4.3.0",
+        ));
+
+        assert_ne!(
+            base,
+            compiled_package_cache_path(&key(
+                RegistryIdentity::Cran("https://mirror.example.test/cran".parse().unwrap()),
+                "1.2.3",
+                "x86_64-pc-windows-msvc",
+                "4.3.0",
+            ))
+        );
+        assert_ne!(
+            base,
+            compiled_package_cache_path(&key(
+                repository(),
+                "1.2.3",
+                "aarch64-pc-windows-msvc",
+                "4.3.0",
+            ))
+        );
+        assert_ne!(
+            base,
+            compiled_package_cache_path(&key(
+                repository(),
+                "1.2.3",
+                "x86_64-pc-windows-msvc",
+                "4.3.1",
+            ))
+        );
+        assert_eq!(
+            base,
+            compiled_package_cache_path(&key(
+                repository(),
+                "1.2.3.0",
+                "x86_64-pc-windows-msvc",
+                "4.3.0",
+            ))
+        );
     }
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -352,6 +352,10 @@ pub(crate) async fn checkout(
     .map_err(GitError::Join)?
 }
 
+pub(crate) fn checkout_path(remote: &GitUrl, commit: Oid) -> PathBuf {
+    GitCachePaths::new(remote, commit).checkout
+}
+
 fn checkout_blocking(
     remote: &GitUrl,
     reference: Option<&str>,

--- a/src/http.rs
+++ b/src/http.rs
@@ -14,6 +14,7 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use std::io::IsTerminal;
 use std::str::FromStr;
 use std::sync::{Arc, LazyLock};
+use target_lexicon::{Aarch64Architecture, Architecture, OperatingSystem, Triple};
 use thiserror::Error;
 use tracing::Span;
 use tracing_indicatif::span_ext::IndicatifSpanExt;
@@ -754,52 +755,61 @@ pub async fn rrepo_source_artifact(
     client().get(url).send().await
 }
 
-pub async fn rrepo_windows_binary(
-    base_url: &reqwest::Url,
-    package: &str,
-    version: &str,
-    r_version: &semver::Version,
-) -> Result<reqwest::Response, reqwest_middleware::Error> {
-    let mut url = base_url.clone();
-    url.path_segments_mut()
-        .expect("repository base URL should support path segments")
-        .pop_if_empty()
-        .extend([
-            "packages",
-            package,
-            "versions",
-            version,
-            "binaries",
-            "windows",
-            format!("{}.{}", r_version.major, r_version.minor).as_str(),
-        ]);
-
-    client().get(url).send().await
+#[derive(Debug, Error)]
+pub enum BinaryArtifactRequestError {
+    #[error("binary artifacts are not supported for target {target}")]
+    UnsupportedTarget { target: Triple },
+    #[error(transparent)]
+    Request(#[from] reqwest_middleware::Error),
 }
 
-pub async fn rrepo_macos_binary(
+pub(crate) fn r_macos_binary_target(
+    target: &Triple,
+) -> Result<&'static str, BinaryArtifactRequestError> {
+    match (target.operating_system, target.architecture) {
+        (
+            OperatingSystem::Darwin(_) | OperatingSystem::MacOSX(_),
+            Architecture::Aarch64(Aarch64Architecture::Aarch64),
+        ) => Ok("big-sur-arm64"),
+        (OperatingSystem::Darwin(_) | OperatingSystem::MacOSX(_), Architecture::X86_64) => {
+            Ok("big-sur-x86_64")
+        }
+        _ => Err(BinaryArtifactRequestError::UnsupportedTarget {
+            target: target.clone(),
+        }),
+    }
+}
+
+pub async fn rrepo_binary(
     base_url: &reqwest::Url,
     package: &str,
     version: &str,
-    target: &str,
+    target: &Triple,
     r_version: &semver::Version,
-) -> Result<reqwest::Response, reqwest_middleware::Error> {
+) -> Result<reqwest::Response, BinaryArtifactRequestError> {
     let mut url = base_url.clone();
-    url.path_segments_mut()
-        .expect("repository base URL should support path segments")
+    let r_version = format!("{}.{}", r_version.major, r_version.minor);
+    let target_path = match target.operating_system {
+        OperatingSystem::Windows => vec!["windows", r_version.as_str()],
+        OperatingSystem::Darwin(_) | OperatingSystem::MacOSX(_) => {
+            vec!["macos", r_macos_binary_target(target)?, r_version.as_str()]
+        }
+        _ => {
+            return Err(BinaryArtifactRequestError::UnsupportedTarget {
+                target: target.clone(),
+            });
+        }
+    };
+    let mut segments = url
+        .path_segments_mut()
+        .expect("repository base URL should support path segments");
+    segments
         .pop_if_empty()
-        .extend([
-            "packages",
-            package,
-            "versions",
-            version,
-            "binaries",
-            "macos",
-            target,
-            format!("{}.{}", r_version.major, r_version.minor).as_str(),
-        ]);
+        .extend(["packages", package, "versions", version, "binaries"]);
+    segments.extend(target_path);
+    drop(segments);
 
-    client().get(url).send().await
+    Ok(client().get(url).send().await?)
 }
 
 pub async fn cran_packages(
@@ -883,56 +893,52 @@ pub async fn cran_latest_package_description(
     client().get(url).send().await
 }
 
-pub async fn cran_windows_binary(
+pub async fn cran_binary(
     base_url: &reqwest::Url,
-    r_version: &semver::Version,
     package: &str,
     version: &str,
-) -> Result<reqwest::Response, reqwest_middleware::Error> {
-    let file_name = format!("{package}_{version}.zip");
-    let mut url = base_url.clone();
-    url.path_segments_mut()
-        .expect("repository base URL should support path segments")
-        .pop_if_empty()
-        .extend([
-            "bin",
-            "windows",
-            "contrib",
-            format!("{}.{}", r_version.major, r_version.minor).as_str(),
-            &file_name,
-        ]);
-
-    client().get(url).send().await
-}
-
-pub async fn cran_macos_binary(
-    base_url: &reqwest::Url,
-    target: &str,
+    target: &Triple,
     r_version: &semver::Version,
-    package: &str,
-    version: &str,
-) -> Result<reqwest::Response, reqwest_middleware::Error> {
-    let file_name = format!("{package}_{version}.tgz");
+) -> Result<reqwest::Response, BinaryArtifactRequestError> {
+    let r_version = format!("{}.{}", r_version.major, r_version.minor);
+    let file_name;
+    let target_path = match target.operating_system {
+        OperatingSystem::Windows => {
+            file_name = format!("{package}_{version}.zip");
+            vec!["windows", "contrib", r_version.as_str(), file_name.as_str()]
+        }
+        OperatingSystem::Darwin(_) | OperatingSystem::MacOSX(_) => {
+            file_name = format!("{package}_{version}.tgz");
+            vec![
+                "macosx",
+                r_macos_binary_target(target)?,
+                "contrib",
+                r_version.as_str(),
+                file_name.as_str(),
+            ]
+        }
+        _ => {
+            return Err(BinaryArtifactRequestError::UnsupportedTarget {
+                target: target.clone(),
+            });
+        }
+    };
     let mut url = base_url.clone();
-    url.path_segments_mut()
-        .expect("repository base URL should support path segments")
-        .pop_if_empty()
-        .extend([
-            "bin",
-            "macosx",
-            target,
-            "contrib",
-            format!("{}.{}", r_version.major, r_version.minor).as_str(),
-            &file_name,
-        ]);
+    let mut segments = url
+        .path_segments_mut()
+        .expect("repository base URL should support path segments");
+    segments.pop_if_empty().extend(["bin"]);
+    segments.extend(target_path);
+    drop(segments);
 
-    client().get(url).send().await
+    Ok(client().get(url).send().await?)
 }
 
 #[cfg(test)]
 mod tests {
     use super::{
-        CranPackagesIndex, CranPackagesParseError, CranPackagesParseIssue, display_safe_url,
+        BinaryArtifactRequestError, CranPackagesIndex, CranPackagesParseError,
+        CranPackagesParseIssue, display_safe_url, r_macos_binary_target,
     };
 
     fn parse_packages_index(input: &str) -> Result<CranPackagesIndex, CranPackagesParseError> {
@@ -950,6 +956,20 @@ mod tests {
             display_safe_url(&url).as_str(),
             "https://example.test/repository/src/contrib/PACKAGES"
         );
+    }
+
+    #[test]
+    fn derives_r_macos_binary_targets_from_target_lexicon() {
+        let arm = "aarch64-apple-darwin".parse().unwrap();
+        let x86 = "x86_64-apple-darwin".parse().unwrap();
+        let linux = "x86_64-unknown-linux-gnu".parse().unwrap();
+
+        assert_eq!(r_macos_binary_target(&arm).unwrap(), "big-sur-arm64");
+        assert_eq!(r_macos_binary_target(&x86).unwrap(), "big-sur-x86_64");
+        assert!(matches!(
+            r_macos_binary_target(&linux),
+            Err(BinaryArtifactRequestError::UnsupportedTarget { .. })
+        ));
     }
 
     #[test]

--- a/src/r.rs
+++ b/src/r.rs
@@ -3,6 +3,7 @@ use std::{
     fs,
     path::{Path, PathBuf},
     process::Output,
+    sync::atomic::{AtomicU64, Ordering},
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -40,25 +41,40 @@ pub enum PackageInstallError {
     #[diagnostic(code(rpx::install::invalid_path))]
     InvalidPath { path: PathBuf },
 
-    #[error("failed to install {target}: {source}")]
+    #[error("failed to {action} {target}: {source}")]
     #[diagnostic(code(rpx::install::command_failed))]
     Command {
+        action: &'static str,
         target: String,
         #[source]
-        source: RSubprocessError,
+        source: Box<RSubprocessError>,
     },
 
     #[error(
-        "failed to install {target}: {source} (log: {})",
+        "failed to {action} {target}: {source} (log: {})",
         log_path.display()
     )]
     #[diagnostic(code(rpx::install::command_failed))]
     Failed {
+        action: &'static str,
         target: String,
         log_path: PathBuf,
         #[source]
-        source: RSubprocessError,
+        source: Box<RSubprocessError>,
     },
+
+    #[error("failed to {operation} temporary package build directory at {}: {source}", path.display())]
+    #[diagnostic(code(rpx::install::temporary_build_directory_failed))]
+    TemporaryBuildDirectory {
+        operation: &'static str,
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("R CMD build did not create the expected source archive at {}", path.display())]
+    #[diagnostic(code(rpx::install::build_archive_missing))]
+    BuildArchiveMissing { path: PathBuf },
 
     #[error("failed to write installation log at {}: {source}", path.display())]
     #[diagnostic(code(rpx::install::log_write_failed))]
@@ -204,42 +220,142 @@ pub async fn install_local_package(
     command.arg("-e").arg(expression);
     let output = run_subprocess(command, "Rscript").await;
 
-    install_command_result(output, format!("{package}@{version}"))
+    package_command_result(output, "install", format!("{package}@{version}"))
 }
 
 pub async fn install_package_directory(
     package_root: &Path,
     target_library: &Path,
+    package: &str,
+    version: &str,
     target: &str,
 ) -> Result<(), PackageInstallError> {
-    let mut command = Command::with_venv("R", target_library);
-    command
-        .arg("CMD")
-        .arg("INSTALL")
-        .arg(format!("--library={}", target_library.display()))
-        .arg(package_root);
-    let output = run_subprocess(command, "R").await;
+    let build_directory = TemporaryBuildDirectory::create()?;
+    let archive_path = build_directory
+        .path()
+        .join(format!("{package}_{version}.tar.gz"));
 
-    install_command_result(output, target.to_string())
+    let result = async {
+        let mut build = Command::with_venv("R", target_library);
+        build
+            .arg("CMD")
+            .arg("build")
+            .arg("--no-build-vignettes")
+            .arg("--no-manual")
+            .arg("--no-resave-data")
+            .arg(package_root)
+            .current_dir(build_directory.path());
+        build.kill_on_drop(true);
+        let output = run_subprocess(build, "R").await;
+        package_command_result(output, "build", target.to_string())?;
+
+        match tokio::fs::metadata(&archive_path).await {
+            Ok(metadata) if metadata.is_file() => {}
+            Ok(_) => {
+                return Err(PackageInstallError::BuildArchiveMissing {
+                    path: archive_path.clone(),
+                });
+            }
+            Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+                return Err(PackageInstallError::BuildArchiveMissing {
+                    path: archive_path.clone(),
+                });
+            }
+            Err(source) => {
+                return Err(PackageInstallError::TemporaryBuildDirectory {
+                    operation: "inspect",
+                    path: archive_path.clone(),
+                    source,
+                });
+            }
+        }
+
+        let mut install = Command::with_venv("R", target_library);
+        install
+            .arg("CMD")
+            .arg("INSTALL")
+            .arg(format!("--library={}", target_library.display()))
+            .arg(&archive_path);
+        install.kill_on_drop(true);
+        let output = run_subprocess(install, "R").await;
+
+        package_command_result(output, "install", target.to_string())
+    }
+    .await;
+
+    if let Err(source) = build_directory.remove().await {
+        if result.is_ok() {
+            return Err(PackageInstallError::TemporaryBuildDirectory {
+                operation: "remove",
+                path: build_directory.path().to_path_buf(),
+                source,
+            });
+        }
+        tracing::warn!(
+            path = %build_directory.path().display(),
+            error = %source,
+            "failed to remove temporary package build directory"
+        );
+    }
+
+    result
 }
 
-fn install_command_result(
+fn package_command_result(
     result: Result<Output, RSubprocessError>,
+    action: &'static str,
     target: String,
 ) -> Result<(), PackageInstallError> {
     let Err(source) = result else {
         return Ok(());
     };
     match &source {
-        RSubprocessError::Start { .. } => Err(PackageInstallError::Command { target, source }),
+        RSubprocessError::Start { .. } => Err(PackageInstallError::Command {
+            action,
+            target,
+            source: Box::new(source),
+        }),
         RSubprocessError::Failed { stdout, stderr, .. } => {
             let log_path = install_log_path();
             write_install_log(&log_path, stdout, stderr)?;
             Err(PackageInstallError::Failed {
+                action,
                 target,
                 log_path,
-                source,
+                source: Box::new(source),
             })
+        }
+    }
+}
+
+struct TemporaryBuildDirectory {
+    path: PathBuf,
+}
+
+impl TemporaryBuildDirectory {
+    fn create() -> Result<Self, PackageInstallError> {
+        let path = temporary_build_directory_path();
+        fs::create_dir(&path).map_err(|source| PackageInstallError::TemporaryBuildDirectory {
+            operation: "create",
+            path: path.clone(),
+            source,
+        })?;
+        Ok(Self { path })
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+
+    async fn remove(&self) -> Result<(), std::io::Error> {
+        tokio::fs::remove_dir_all(&self.path).await
+    }
+}
+
+impl Drop for TemporaryBuildDirectory {
+    fn drop(&mut self) {
+        if self.path.exists() {
+            let _ = fs::remove_dir_all(&self.path);
         }
     }
 }
@@ -526,6 +642,20 @@ fn install_log_path() -> PathBuf {
         .expect("system time should be after unix epoch")
         .as_nanos();
     std::env::temp_dir().join(format!("rpx-install-{}-{unique}.log", std::process::id()))
+}
+
+fn temporary_build_directory_path() -> PathBuf {
+    static NEXT_DIRECTORY: AtomicU64 = AtomicU64::new(0);
+
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time should be after unix epoch")
+        .as_nanos();
+    let sequence = NEXT_DIRECTORY.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!(
+        "rpx-build-{}-{unique}-{sequence}",
+        std::process::id()
+    ))
 }
 
 #[cfg(test)]

--- a/src/r.rs
+++ b/src/r.rs
@@ -4,7 +4,6 @@ use std::{
     fs,
     path::{Path, PathBuf},
     process::Output,
-    sync::atomic::{AtomicU64, Ordering},
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -223,7 +222,8 @@ pub async fn install_package_directory(
     version: &str,
     target: &str,
 ) -> Result<(), PackageInstallError> {
-    let build_directory = TemporaryBuildDirectory::create()?;
+    let build_directory = temporary_build_directory()?;
+    let build_directory_path = build_directory.path().to_path_buf();
     let archive_path = build_directory
         .path()
         .join(format!("{package}_{version}.tar.gz"));
@@ -277,16 +277,16 @@ pub async fn install_package_directory(
     }
     .await;
 
-    if let Err(source) = build_directory.remove().await {
+    if let Err(source) = close_temporary_build_directory(build_directory).await {
         if result.is_ok() {
             return Err(PackageInstallError::TemporaryBuildDirectory {
                 operation: "remove",
-                path: build_directory.path().to_path_buf(),
+                path: build_directory_path,
                 source,
             });
         }
         tracing::warn!(
-            path = %build_directory.path().display(),
+            path = %build_directory_path.display(),
             error = %source,
             "failed to remove temporary package build directory"
         );
@@ -322,36 +322,23 @@ fn package_command_result(
     }
 }
 
-struct TemporaryBuildDirectory {
-    path: PathBuf,
-}
-
-impl TemporaryBuildDirectory {
-    fn create() -> Result<Self, PackageInstallError> {
-        let path = temporary_build_directory_path();
-        fs::create_dir(&path).map_err(|source| PackageInstallError::TemporaryBuildDirectory {
+fn temporary_build_directory() -> Result<tempfile::TempDir, PackageInstallError> {
+    tempfile::Builder::new()
+        .prefix("rpx-build-")
+        .tempdir()
+        .map_err(|source| PackageInstallError::TemporaryBuildDirectory {
             operation: "create",
-            path: path.clone(),
+            path: std::env::temp_dir(),
             source,
-        })?;
-        Ok(Self { path })
-    }
-
-    fn path(&self) -> &Path {
-        &self.path
-    }
-
-    async fn remove(&self) -> Result<(), std::io::Error> {
-        tokio::fs::remove_dir_all(&self.path).await
-    }
+        })
 }
 
-impl Drop for TemporaryBuildDirectory {
-    fn drop(&mut self) {
-        if self.path.exists() {
-            let _ = fs::remove_dir_all(&self.path);
-        }
-    }
+async fn close_temporary_build_directory(
+    directory: tempfile::TempDir,
+) -> Result<(), std::io::Error> {
+    tokio::task::spawn_blocking(move || directory.close())
+        .await
+        .map_err(std::io::Error::other)?
 }
 
 pub async fn base_packages() -> Result<BTreeSet<String>, BasePackagesError> {
@@ -639,20 +626,6 @@ fn install_log_path() -> PathBuf {
     std::env::temp_dir().join(format!("rpx-install-{}-{unique}.log", std::process::id()))
 }
 
-fn temporary_build_directory_path() -> PathBuf {
-    static NEXT_DIRECTORY: AtomicU64 = AtomicU64::new(0);
-
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("system time should be after unix epoch")
-        .as_nanos();
-    let sequence = NEXT_DIRECTORY.fetch_add(1, Ordering::Relaxed);
-    std::env::temp_dir().join(format!(
-        "rpx-build-{}-{unique}-{sequence}",
-        std::process::id()
-    ))
-}
-
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
@@ -678,6 +651,50 @@ mod tests {
             InstalledPackagesError::InvalidVersion { package, version, .. }
                 if package == "digest" && version == "not-a-version"
         ));
+    }
+
+    #[test]
+    fn temporary_build_directories_are_unique_and_removed_on_drop() {
+        let first = temporary_build_directory().expect("first temporary directory should exist");
+        let second = temporary_build_directory().expect("second temporary directory should exist");
+        let first_path = first.path().to_path_buf();
+        let second_path = second.path().to_path_buf();
+
+        assert_ne!(first_path, second_path);
+        assert!(first_path.is_dir());
+        assert!(second_path.is_dir());
+
+        drop(first);
+        drop(second);
+        assert!(!first_path.exists());
+        assert!(!second_path.exists());
+    }
+
+    #[tokio::test]
+    async fn aborting_task_removes_owned_temporary_build_directory() {
+        let directory = temporary_build_directory().expect("temporary directory should exist");
+        let path = directory.path().to_path_buf();
+        let task = tokio::spawn(async move {
+            let _directory = directory;
+            std::future::pending::<()>().await;
+        });
+
+        task.abort();
+        let _ = task.await;
+
+        assert!(!path.exists());
+    }
+
+    #[tokio::test]
+    async fn explicitly_closes_temporary_build_directory() {
+        let directory = temporary_build_directory().expect("temporary directory should exist");
+        let path = directory.path().to_path_buf();
+
+        close_temporary_build_directory(directory)
+            .await
+            .expect("temporary directory should close");
+
+        assert!(!path.exists());
     }
 
     #[tokio::test]

--- a/src/r.rs
+++ b/src/r.rs
@@ -1,10 +1,8 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     ffi::OsStr,
-    fs,
     path::{Path, PathBuf},
     process::Output,
-    time::{SystemTime, UNIX_EPOCH},
 };
 
 use miette::Diagnostic;
@@ -19,19 +17,76 @@ pub enum RSubprocessError {
     #[error("failed to start {program}: {source}")]
     #[diagnostic(code(rpx::r::start_failed))]
     Start {
-        program: &'static str,
+        program: String,
         #[source]
         source: std::io::Error,
     },
 
-    #[error("{program} exited unsuccessfully with code {exit_code:?}: {summary}")]
+    #[error(
+        "{program} exited unsuccessfully with code {exit_code:?}: {summary}\n\nstdout:\n{stdout}\n\nstderr:\n{stderr}"
+    )]
     #[diagnostic(code(rpx::r::command_failed))]
     Failed {
-        program: &'static str,
+        program: String,
         exit_code: Option<i32>,
         stdout: String,
         stderr: String,
         summary: String,
+    },
+}
+
+#[derive(Debug, Error, Diagnostic)]
+pub enum PackageBuildError {
+    #[error("failed to prepare package artifact directory at {}: {source}", path.display())]
+    #[diagnostic(code(rpx::build::artifact_directory_failed))]
+    ArtifactDirectory {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("failed to create temporary package build directory in {}: {source}", path.display())]
+    #[diagnostic(code(rpx::build::temporary_directory_failed))]
+    TemporaryDirectory {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("failed to build package at {}: {source}", path.display())]
+    #[diagnostic(code(rpx::build::command_failed))]
+    Command {
+        path: PathBuf,
+        #[source]
+        source: Box<RSubprocessError>,
+    },
+
+    #[error("R CMD build did not create the expected source archive at {}", path.display())]
+    #[diagnostic(code(rpx::build::archive_missing))]
+    ArchiveMissing { path: PathBuf },
+
+    #[error("failed to inspect source archive at {}: {source}", path.display())]
+    #[diagnostic(code(rpx::build::archive_inspection_failed))]
+    InspectArchive {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("failed to publish source archive at {}: {source}", path.display())]
+    #[diagnostic(code(rpx::build::archive_publication_failed))]
+    PublishArchive {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("failed to clean temporary package build directory at {}: {source}", path.display())]
+    #[diagnostic(code(rpx::build::temporary_directory_cleanup_failed))]
+    Cleanup {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
     },
 }
 
@@ -44,40 +99,6 @@ pub enum PackageInstallError {
         target: String,
         #[source]
         source: Box<RSubprocessError>,
-    },
-
-    #[error(
-        "failed to {action} {target}: {source} (log: {})",
-        log_path.display()
-    )]
-    #[diagnostic(code(rpx::install::command_failed))]
-    Failed {
-        action: &'static str,
-        target: String,
-        log_path: PathBuf,
-        #[source]
-        source: Box<RSubprocessError>,
-    },
-
-    #[error("failed to {operation} temporary package build directory at {}: {source}", path.display())]
-    #[diagnostic(code(rpx::install::temporary_build_directory_failed))]
-    TemporaryBuildDirectory {
-        operation: &'static str,
-        path: PathBuf,
-        #[source]
-        source: std::io::Error,
-    },
-
-    #[error("R CMD build did not create the expected source archive at {}", path.display())]
-    #[diagnostic(code(rpx::install::build_archive_missing))]
-    BuildArchiveMissing { path: PathBuf },
-
-    #[error("failed to write installation log at {}: {source}", path.display())]
-    #[diagnostic(code(rpx::install::log_write_failed))]
-    LogWrite {
-        path: PathBuf,
-        #[source]
-        source: std::io::Error,
     },
 }
 
@@ -179,7 +200,7 @@ fn rscript_query() -> Command {
 static BASE_PACKAGES: OnceCell<BTreeSet<String>> = OnceCell::const_new();
 static R_VERSION: OnceCell<semver::Version> = OnceCell::const_new();
 
-pub async fn install_local_package(
+pub async fn install_package_artifact(
     project_library: &Path,
     artifact_path: &Path,
     package: &str,
@@ -210,26 +231,44 @@ pub async fn install_local_package(
         .arg(target_library)
         .arg(package)
         .arg(version);
-    let output = run_subprocess(command, "Rscript").await;
-
-    package_command_result(output, "install", format!("{package}@{version}"))
+    command.kill_on_drop(true);
+    run_subprocess(command)
+        .await
+        .map(|_| ())
+        .map_err(|source| PackageInstallError::Command {
+            action: "install",
+            target: format!("{package}@{version}"),
+            source: Box::new(source),
+        })
 }
 
-pub async fn install_package_directory(
+pub async fn build_package_archive(
     package_root: &Path,
-    target_library: &Path,
     package: &str,
     version: &str,
-    target: &str,
-) -> Result<(), PackageInstallError> {
-    let build_directory = temporary_build_directory()?;
-    let build_directory_path = build_directory.path().to_path_buf();
-    let archive_path = build_directory
-        .path()
-        .join(format!("{package}_{version}.tar.gz"));
+    archive: &Path,
+) -> Result<(), PackageBuildError> {
+    let artifact_directory = archive
+        .parent()
+        .expect("source artifact path should have a parent");
+    tokio::fs::create_dir_all(artifact_directory)
+        .await
+        .map_err(|source| PackageBuildError::ArtifactDirectory {
+            path: artifact_directory.to_path_buf(),
+            source,
+        })?;
+    let workspace = tempfile::Builder::new()
+        .prefix(".rpx-build-")
+        .tempdir_in(artifact_directory)
+        .map_err(|source| PackageBuildError::TemporaryDirectory {
+            path: artifact_directory.to_path_buf(),
+            source,
+        })?;
+    let workspace_path = workspace.path().to_path_buf();
+    let staged_archive = workspace.path().join(format!("{package}_{version}.tar.gz"));
 
     let result = async {
-        let mut build = project_r_command("R", target_library);
+        let mut build = Command::new("R");
         build
             .arg("CMD")
             .arg("build")
@@ -237,108 +276,60 @@ pub async fn install_package_directory(
             .arg("--no-manual")
             .arg("--no-resave-data")
             .arg(package_root)
-            .current_dir(build_directory.path());
+            .current_dir(&workspace_path);
         build.kill_on_drop(true);
-        let output = run_subprocess(build, "R").await;
-        package_command_result(output, "build", target.to_string())?;
+        run_subprocess(build)
+            .await
+            .map_err(|source| PackageBuildError::Command {
+                path: package_root.to_path_buf(),
+                source: Box::new(source),
+            })?;
 
-        match tokio::fs::metadata(&archive_path).await {
+        match tokio::fs::metadata(&staged_archive).await {
             Ok(metadata) if metadata.is_file() => {}
             Ok(_) => {
-                return Err(PackageInstallError::BuildArchiveMissing {
-                    path: archive_path.clone(),
+                return Err(PackageBuildError::ArchiveMissing {
+                    path: staged_archive.clone(),
                 });
             }
             Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
-                return Err(PackageInstallError::BuildArchiveMissing {
-                    path: archive_path.clone(),
+                return Err(PackageBuildError::ArchiveMissing {
+                    path: staged_archive.clone(),
                 });
             }
             Err(source) => {
-                return Err(PackageInstallError::TemporaryBuildDirectory {
-                    operation: "inspect",
-                    path: archive_path.clone(),
+                return Err(PackageBuildError::InspectArchive {
+                    path: staged_archive.clone(),
                     source,
                 });
             }
         }
 
-        let mut install = project_r_command("R", target_library);
-        install
-            .arg("CMD")
-            .arg("INSTALL")
-            .arg("-l")
-            .arg(target_library)
-            .arg(&archive_path);
-        install.kill_on_drop(true);
-        let output = run_subprocess(install, "R").await;
+        tempfile::TempPath::try_from_path(staged_archive.clone())
+            .and_then(|temporary| temporary.persist(archive).map_err(|error| error.error))
+            .map_err(|source| PackageBuildError::PublishArchive {
+                path: archive.to_path_buf(),
+                source,
+            })?;
 
-        package_command_result(output, "install", target.to_string())
+        Ok(())
     }
     .await;
 
-    if let Err(source) = close_temporary_build_directory(build_directory).await {
-        if result.is_ok() {
-            return Err(PackageInstallError::TemporaryBuildDirectory {
-                operation: "remove",
-                path: build_directory_path,
-                source,
-            });
-        }
-        tracing::warn!(
-            path = %build_directory_path.display(),
-            error = %source,
-            "failed to remove temporary package build directory"
-        );
-    }
-
-    result
-}
-
-fn package_command_result(
-    result: Result<Output, RSubprocessError>,
-    action: &'static str,
-    target: String,
-) -> Result<(), PackageInstallError> {
-    let Err(source) = result else {
-        return Ok(());
-    };
-    match &source {
-        RSubprocessError::Start { .. } => Err(PackageInstallError::Command {
-            action,
-            target,
-            source: Box::new(source),
-        }),
-        RSubprocessError::Failed { stdout, stderr, .. } => {
-            let log_path = install_log_path();
-            write_install_log(&log_path, stdout, stderr)?;
-            Err(PackageInstallError::Failed {
-                action,
-                target,
-                log_path,
-                source: Box::new(source),
-            })
-        }
-    }
-}
-
-fn temporary_build_directory() -> Result<tempfile::TempDir, PackageInstallError> {
-    tempfile::Builder::new()
-        .prefix("rpx-build-")
-        .tempdir()
-        .map_err(|source| PackageInstallError::TemporaryBuildDirectory {
-            operation: "create",
-            path: std::env::temp_dir(),
-            source,
-        })
-}
-
-async fn close_temporary_build_directory(
-    directory: tempfile::TempDir,
-) -> Result<(), std::io::Error> {
-    tokio::task::spawn_blocking(move || directory.close())
+    let cleanup = tokio::task::spawn_blocking(move || workspace.close())
         .await
-        .map_err(std::io::Error::other)?
+        .map_err(std::io::Error::other)
+        .and_then(|result| result);
+    if let Err(error) = &cleanup
+        && result.is_err()
+    {
+        tracing::warn!(%error, path = %workspace_path.display(), "failed to clean temporary package build directory");
+    }
+    result?;
+    cleanup.map_err(|source| PackageBuildError::Cleanup {
+        path: workspace_path,
+        source,
+    })
 }
 
 pub async fn base_packages() -> Result<BTreeSet<String>, BasePackagesError> {
@@ -405,7 +396,7 @@ pub async fn installed_packages(
 
     let mut command = rscript_query();
     command.arg("-e").arg(expression).arg(project_library);
-    let output = run_subprocess(command, "Rscript")
+    let output = run_subprocess(command)
         .await
         .map_err(|source| InstalledPackagesError::Command { source })?;
     let stdout = String::from_utf8(output.stdout)
@@ -511,7 +502,7 @@ pub async fn r_version_async() -> Result<semver::Version, RVersionError> {
 async fn fetch_r_version() -> Result<semver::Version, RVersionError> {
     let mut command = Command::new("Rscript");
     command.arg("--version");
-    let output = run_subprocess(command, "Rscript")
+    let output = run_subprocess(command)
         .await
         .map_err(|source| RVersionError::Command { source })?;
 
@@ -531,14 +522,19 @@ async fn fetch_r_version() -> Result<semver::Version, RVersionError> {
         })
 }
 
-async fn run_subprocess(
-    mut command: Command,
-    program: &'static str,
-) -> Result<Output, RSubprocessError> {
+async fn run_subprocess(mut command: Command) -> Result<Output, RSubprocessError> {
+    let program = command
+        .as_std()
+        .get_program()
+        .to_string_lossy()
+        .into_owned();
     let output = command
         .output()
         .await
-        .map_err(|source| RSubprocessError::Start { program, source })?;
+        .map_err(|source| RSubprocessError::Start {
+            program: program.clone(),
+            source,
+        })?;
     if output.status.success() {
         return Ok(output);
     }
@@ -552,32 +548,12 @@ async fn run_subprocess(
     })
 }
 
-fn write_install_log(
-    log_path: &Path,
-    stdout: &str,
-    stderr: &str,
-) -> Result<(), PackageInstallError> {
-    let mut contents = String::new();
-    contents.push_str("# stdout\n");
-    contents.push_str(stdout);
-    if !contents.ends_with('\n') {
-        contents.push('\n');
-    }
-    contents.push_str("# stderr\n");
-    contents.push_str(stderr);
-
-    fs::write(log_path, contents).map_err(|source| PackageInstallError::LogWrite {
-        path: log_path.to_path_buf(),
-        source,
-    })
-}
-
 async fn fetch_base_packages() -> Result<BTreeSet<String>, BasePackagesError> {
     let mut command = rscript_query();
     command
         .arg("-e")
         .arg("writeLines(rownames(utils::installed.packages(priority = 'base')))");
-    let output = run_subprocess(command, "Rscript")
+    let output = run_subprocess(command)
         .await
         .map_err(|source| BasePackagesError::Command { source })?;
     let stdout = String::from_utf8(output.stdout)
@@ -618,17 +594,9 @@ fn summarize_subprocess_output(stdout: &[u8], stderr: &[u8]) -> String {
         .to_string()
 }
 
-fn install_log_path() -> PathBuf {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("system time should be after unix epoch")
-        .as_nanos();
-    std::env::temp_dir().join(format!("rpx-install-{}-{unique}.log", std::process::id()))
-}
-
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{fs, sync::Arc};
 
     use super::*;
 
@@ -653,53 +621,10 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn temporary_build_directories_are_unique_and_removed_on_drop() {
-        let first = temporary_build_directory().expect("first temporary directory should exist");
-        let second = temporary_build_directory().expect("second temporary directory should exist");
-        let first_path = first.path().to_path_buf();
-        let second_path = second.path().to_path_buf();
-
-        assert_ne!(first_path, second_path);
-        assert!(first_path.is_dir());
-        assert!(second_path.is_dir());
-
-        drop(first);
-        drop(second);
-        assert!(!first_path.exists());
-        assert!(!second_path.exists());
-    }
-
-    #[tokio::test]
-    async fn aborting_task_removes_owned_temporary_build_directory() {
-        let directory = temporary_build_directory().expect("temporary directory should exist");
-        let path = directory.path().to_path_buf();
-        let task = tokio::spawn(async move {
-            let _directory = directory;
-            std::future::pending::<()>().await;
-        });
-
-        task.abort();
-        let _ = task.await;
-
-        assert!(!path.exists());
-    }
-
-    #[tokio::test]
-    async fn explicitly_closes_temporary_build_directory() {
-        let directory = temporary_build_directory().expect("temporary directory should exist");
-        let path = directory.path().to_path_buf();
-
-        close_temporary_build_directory(directory)
-            .await
-            .expect("temporary directory should close");
-
-        assert!(!path.exists());
-    }
-
     #[tokio::test]
     async fn missing_project_library_has_no_installed_packages() {
-        let path = install_log_path();
+        let directory = tempfile::tempdir().expect("temporary directory should exist");
+        let path = directory.path().join("missing-library");
 
         let packages = installed_packages(&path)
             .await
@@ -710,7 +635,8 @@ mod tests {
 
     #[tokio::test]
     async fn project_library_must_be_a_directory() {
-        let path = install_log_path();
+        let directory = tempfile::tempdir().expect("temporary directory should exist");
+        let path = directory.path().join("library");
         fs::write(&path, "not a directory").expect("test file should be written");
 
         let error = installed_packages(&path)
@@ -721,6 +647,5 @@ mod tests {
             error,
             InstalledPackagesError::LibraryNotDirectory { path: actual } if actual == path
         ));
-        fs::remove_file(path).expect("test file should be removed");
     }
 }

--- a/src/repository/git.rs
+++ b/src/repository/git.rs
@@ -76,6 +76,11 @@ impl GitRepository {
             .map_err(|source| self.git_error(source))
     }
 
+    pub async fn checkout_path(&self) -> Result<PathBuf, RepositoryError> {
+        let commit = self.commit().await?;
+        Ok(git::checkout_path(&self.remote, commit))
+    }
+
     pub fn remote(&self) -> &GitUrl {
         &self.remote
     }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -19,7 +19,10 @@ use r_description::RDescription;
 use std::{
     collections::{BTreeMap, BTreeSet},
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     time::{SystemTime, UNIX_EPOCH},
 };
 use thiserror::Error;
@@ -259,6 +262,7 @@ async fn install_required_packages(
             .collect::<BTreeSet<_>>(),
     );
     let installed_packages = Arc::new(Mutex::new(retained));
+    let install_failed = Arc::new(AtomicBool::new(false));
     let shared_pool = Arc::new(Semaphore::new(SYNC_SHARED_WORKERS));
     let install_pool = Arc::new(Semaphore::new(SYNC_INSTALL_WORKERS));
     let (installed_tx, installed_rx) = watch::channel(());
@@ -277,6 +281,7 @@ async fn install_required_packages(
             let project_path = repository.path().to_path_buf();
             let install_required_names = Arc::clone(&required_names);
             let install_installed_packages = Arc::clone(&installed_packages);
+            let install_install_failed = Arc::clone(&install_failed);
             let install_installed_rx = installed_rx.clone();
             let install_installed_tx = installed_tx.clone();
             let install_shared_pool = Arc::clone(&shared_pool);
@@ -289,6 +294,7 @@ async fn install_required_packages(
                         &dependencies,
                         install_required_names,
                         Arc::clone(&install_installed_packages),
+                        install_install_failed,
                         install_installed_rx,
                     )
                     .await
@@ -339,6 +345,7 @@ async fn install_required_packages(
             let repository = repository.clone();
             let install_required_names = Arc::clone(&required_names);
             let install_installed_packages = Arc::clone(&installed_packages);
+            let install_install_failed = Arc::clone(&install_failed);
             let install_installed_rx = installed_rx.clone();
             let install_installed_tx = installed_tx.clone();
             let install_shared_pool = Arc::clone(&shared_pool);
@@ -351,6 +358,7 @@ async fn install_required_packages(
                         &dependencies,
                         install_required_names,
                         Arc::clone(&install_installed_packages),
+                        install_install_failed,
                         install_installed_rx,
                     )
                     .await
@@ -437,6 +445,7 @@ async fn install_required_packages(
 
         let install_required_names = Arc::clone(&required_names);
         let install_installed_packages = Arc::clone(&installed_packages);
+        let install_install_failed = Arc::clone(&install_failed);
         let install_installed_rx = installed_rx.clone();
         let install_installed_tx = installed_tx.clone();
         let install_shared_pool = Arc::clone(&shared_pool);
@@ -459,6 +468,7 @@ async fn install_required_packages(
                     &dependencies,
                     install_required_names,
                     Arc::clone(&install_installed_packages),
+                    install_install_failed,
                     install_installed_rx,
                 )
                 .await
@@ -498,11 +508,27 @@ async fn install_required_packages(
 
     sync_span.record("running", install_tasks.len() as u64);
 
+    let mut first_error = None;
     while let Some(result) = install_tasks.join_next().await {
-        result.map_err(|error| SyncError::DownloadArtifactsFailed {
-            details: format!("install task failed to join: {error}"),
-        })??;
-        completed += 1;
+        let result = result
+            .map_err(|error| SyncError::DownloadArtifactsFailed {
+                details: format!("install task failed to join: {error}"),
+            })
+            .and_then(|result| result);
+
+        match result {
+            Ok(_) => completed += 1,
+            Err(error) if first_error.is_none() => {
+                first_error = Some(error);
+                install_failed.store(true, Ordering::Relaxed);
+                install_pool.close();
+                shared_pool.close();
+                prepare_tasks.abort_all();
+                let _ = installed_tx.send(());
+            }
+            Err(_) => {}
+        }
+
         sync_span.record("completed", completed);
         sync_span.record("running", install_tasks.len() as u64);
         sync_span.record("pending", total_packages.saturating_sub(completed));
@@ -514,7 +540,7 @@ async fn install_required_packages(
 
     sync_span.record("stage", "done");
     sync_span.pb_set_finish_message(&format!("sync packages {completed}/{total_packages}"));
-    Ok(())
+    first_error.map_or(Ok(()), Err)
 }
 
 async fn wait_for_package_dependencies(
@@ -522,9 +548,16 @@ async fn wait_for_package_dependencies(
     dependencies: &BTreeSet<String>,
     required_names: Arc<BTreeSet<String>>,
     installed_packages: Arc<Mutex<BTreeSet<String>>>,
+    install_failed: Arc<AtomicBool>,
     mut installed_rx: watch::Receiver<()>,
 ) -> Result<(), String> {
     loop {
+        if install_failed.load(Ordering::Relaxed) {
+            return Err(format!(
+                "stopped waiting for {package} dependencies after an installation failed"
+            ));
+        }
+
         {
             let installed_packages = installed_packages.lock().await;
             if dependencies
@@ -1029,6 +1062,34 @@ mod tests {
     use super::*;
     use crate::repository::{PackageRepository, built_in_repository};
     use r_description::Remote;
+
+    #[tokio::test]
+    async fn dependency_wait_stops_after_install_failure() {
+        let install_failed = Arc::new(AtomicBool::new(false));
+        let (installed_tx, installed_rx) = watch::channel(());
+        let wait_install_failed = Arc::clone(&install_failed);
+        let waiter = tokio::spawn(async move {
+            wait_for_package_dependencies(
+                "dependent",
+                &BTreeSet::from(["dependency".to_string()]),
+                Arc::new(BTreeSet::from(["dependency".to_string()])),
+                Arc::new(Mutex::new(BTreeSet::new())),
+                wait_install_failed,
+                installed_rx,
+            )
+            .await
+        });
+
+        tokio::task::yield_now().await;
+        install_failed.store(true, Ordering::Relaxed);
+        let _ = installed_tx.send(());
+
+        let error = waiter
+            .await
+            .expect("dependency waiter should join")
+            .expect_err("dependency waiter should stop");
+        assert!(error.contains("after an installation failed"));
+    }
 
     #[test]
     fn package_dependency_names_uses_only_hard_dependencies() {

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,35 +1,36 @@
 use crate::{
-    cache::{self, CompiledPackageCacheKey, artifact_cache_path, build_temp_library_path},
-    description::{DescriptionParseError, root_package},
+    cache::{
+        BinaryArtifactCacheKey, CompiledPackageCacheKey, RegistryIdentity, SourceArtifactCacheKey,
+        SourceArtifactIdentity, binary_artifact_cache_path, compiled_package_cache_path,
+        source_artifact_cache_path,
+    },
+    description::{DescriptionParseError, required_dependencies, root_package},
     http,
     project::{
-        Project, ProjectLibraryError, ProjectResolution, RequiredPackages, ensure_project_library,
+        Project, ProjectLibraryError, ProjectResolution, RequiredPackages, cache_dir_path,
+        ensure_project_library,
     },
     r::{
-        self, BasePackagesError, base_packages, install_local_package, install_package_directory,
+        self, BasePackagesError, base_packages, build_package_archive, install_package_artifact,
         installed_packages, remove_packages_from_venv,
     },
-    repository::{CranRepository, GitRepository, LocalRepository, RrepoRepository},
+    repository::{
+        CranRepository, GitRepository, LocalRepository, RepositoryError, RrepoRepository,
+    },
     resolver::PackageVersion,
     ui::{progress_bar_style, progress_spinner_style},
 };
 use futures_util::StreamExt;
 use miette::Diagnostic;
-use r_description::RDescription;
 use std::{
     collections::{BTreeMap, BTreeSet},
+    fs,
     path::{Path, PathBuf},
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    },
-    time::{SystemTime, UNIX_EPOCH},
+    sync::Arc,
 };
+use target_lexicon::{HOST, OperatingSystem};
 use thiserror::Error;
-use tokio::{
-    io::AsyncWriteExt,
-    sync::{Mutex, Semaphore, oneshot, watch},
-};
+use tokio::io::AsyncWriteExt;
 use tracing::Instrument;
 use tracing_indicatif::span_ext::IndicatifSpanExt;
 
@@ -53,21 +54,30 @@ pub(crate) enum SyncError {
     #[error("failed to prepare source artifacts: {details}")]
     #[diagnostic(code(rpx::sync::download_failed))]
     DownloadArtifactsFailed { details: String },
+    #[error("failed to download artifact for {package} {version}: {source}")]
+    #[diagnostic(code(rpx::sync::package_artifact_download_failed))]
+    DownloadPackageArtifact {
+        package: String,
+        version: String,
+        #[source]
+        source: DownloadPackageArtifactError,
+    },
     #[error(transparent)]
     #[diagnostic(transparent)]
     PackageGraph(#[from] PackageGraphError),
-    #[error("failed to install project package: {source}")]
-    #[diagnostic(code(rpx::sync::project_install_failed))]
-    ProjectPackageInstall {
+    #[error("failed to build package {package}: {source}")]
+    #[diagnostic(code(rpx::sync::package_build_failed))]
+    PackageBuild {
+        package: String,
         #[source]
-        source: Box<r::PackageInstallError>,
+        source: Box<r::PackageBuildError>,
     },
     #[error("failed to install package {package}: {source}")]
     #[diagnostic(code(rpx::sync::package_install_failed))]
     PackageInstall {
         package: String,
         #[source]
-        source: Box<r::PackageInstallError>,
+        source: Box<InstallPackageError>,
     },
 }
 
@@ -129,15 +139,6 @@ pub(crate) async fn sync_resolved_project(
         })
         .map(|(name, _)| name.clone())
         .collect::<BTreeSet<_>>();
-    let retained = installed
-        .iter()
-        .filter(|(name, installed_version)| {
-            required.get(*name).is_some_and(|(required_version, _)| {
-                !package_requires_install(required_version, Some(installed_version))
-            })
-        })
-        .map(|(name, _)| name.clone())
-        .collect::<BTreeSet<_>>();
     let packages_to_install = required
         .into_iter()
         .filter(|(name, (required_version, _))| {
@@ -145,13 +146,7 @@ pub(crate) async fn sync_resolved_project(
         })
         .collect::<RequiredPackages>();
     remove_packages_from_venv(&project_library, &removed)?;
-    install_required_packages(
-        &project_library,
-        packages_to_install,
-        retained,
-        &resolution.r_version,
-    )
-    .await?;
+    install_required_packages(&project_library, packages_to_install, &resolution.r_version).await?;
 
     Ok(SyncReport { installed_before })
 }
@@ -165,23 +160,213 @@ fn package_requires_install(required: &PackageVersion, installed: Option<&Packag
         || installed != Some(required)
 }
 
-fn package_dependency_names(description: &RDescription) -> Result<BTreeSet<String>, String> {
-    let depends = description.depends().map_err(|error| error.to_string())?;
-    let imports = description.imports().map_err(|error| error.to_string())?;
-    let linking_to = description
-        .linking_to()
-        .map_err(|error| error.to_string())?;
+const SYNC_SHARED_WORKERS: usize = 50;
+const SYNC_CHECKOUT_WORKERS: usize = 1;
+const SYNC_R_WORKERS: usize = 8;
 
-    Ok(depends
-        .chain(imports)
-        .chain(linking_to)
-        .map(|relation| relation.package().to_string())
-        .filter(|package| package != "R")
+#[derive(Clone)]
+struct SyncTaskContext {
+    project_library: PathBuf,
+    r_version: Arc<semver::Version>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum TaskKind {
+    Download,
+    Checkout,
+    Build,
+    Install,
+}
+
+type TaskId = (String, TaskKind);
+
+#[derive(Clone)]
+struct TaskRow {
+    blockers: usize,
+    task: TaskId,
+    version: PackageVersion,
+    dependents: BTreeSet<TaskId>,
+}
+
+impl Ord for TaskRow {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        (&self.blockers, &self.task).cmp(&(&other.blockers, &other.task))
+    }
+}
+
+impl PartialOrd for TaskRow {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for TaskRow {
+    fn eq(&self, other: &Self) -> bool {
+        self.blockers == other.blockers && self.task == other.task
+    }
+}
+
+impl Eq for TaskRow {}
+
+struct ResourcePool {
+    shared: usize,
+    checkout: usize,
+    r: usize,
+}
+
+impl ResourcePool {
+    fn new() -> Self {
+        Self {
+            shared: 0,
+            checkout: 0,
+            r: 0,
+        }
+    }
+
+    fn can_reserve(&self, kind: TaskKind) -> bool {
+        self.shared < SYNC_SHARED_WORKERS
+            && (kind != TaskKind::Checkout || self.checkout < SYNC_CHECKOUT_WORKERS)
+            && (!matches!(kind, TaskKind::Build | TaskKind::Install) || self.r < SYNC_R_WORKERS)
+    }
+
+    fn reserve(&mut self, kind: TaskKind) {
+        debug_assert!(self.can_reserve(kind));
+        self.shared += 1;
+        if kind == TaskKind::Checkout {
+            self.checkout += 1;
+        }
+        if matches!(kind, TaskKind::Build | TaskKind::Install) {
+            self.r += 1;
+        }
+    }
+
+    fn release(&mut self, kind: TaskKind) {
+        self.shared -= 1;
+        if kind == TaskKind::Checkout {
+            self.checkout -= 1;
+        }
+        if matches!(kind, TaskKind::Build | TaskKind::Install) {
+            self.r -= 1;
+        }
+    }
+}
+
+fn install_tasks(packages: RequiredPackages) -> Result<BTreeSet<TaskRow>, SyncError> {
+    let package_names = packages.keys().cloned().collect::<BTreeSet<_>>();
+    let packages = packages
+        .into_iter()
+        .map(|(package, (version, description))| {
+            let dependencies =
+                required_dependencies(format!("{package} {}", version.version()), &description)?
+                    .into_iter()
+                    .map(|relation| relation.package().to_string())
+                    .collect::<BTreeSet<_>>();
+            Ok((package, version, dependencies))
+        })
+        .collect::<Result<Vec<_>, SyncError>>()?;
+    Ok(packages
+        .iter()
+        .flat_map(|(package, package_version, dependencies)| {
+            let install = (package.clone(), TaskKind::Install);
+            let install_blockers = 1 + dependencies
+                .iter()
+                .filter(|dependency| package_names.contains(*dependency))
+                .count();
+            let install_dependents = packages
+                .iter()
+                .filter(|(_, _, dependencies)| dependencies.contains(package))
+                .map(|(dependent, _, _)| (dependent.clone(), TaskKind::Install))
+                .collect::<BTreeSet<_>>();
+            let repository = package_version.repository();
+
+            match (
+                repository.as_ref().downcast_ref::<LocalRepository>(),
+                repository.as_ref().downcast_ref::<GitRepository>(),
+            ) {
+                (Some(_), _) => vec![
+                    TaskRow {
+                        blockers: 0,
+                        task: (package.clone(), TaskKind::Build),
+                        version: package_version.clone(),
+                        dependents: BTreeSet::from([install.clone()]),
+                    },
+                    TaskRow {
+                        blockers: install_blockers,
+                        task: install,
+                        version: package_version.clone(),
+                        dependents: install_dependents,
+                    },
+                ],
+                (_, Some(_)) => {
+                    let build = (package.clone(), TaskKind::Build);
+                    vec![
+                        TaskRow {
+                            blockers: 0,
+                            task: (package.clone(), TaskKind::Checkout),
+                            version: package_version.clone(),
+                            dependents: BTreeSet::from([build.clone()]),
+                        },
+                        TaskRow {
+                            blockers: 1,
+                            task: build,
+                            version: package_version.clone(),
+                            dependents: BTreeSet::from([install.clone()]),
+                        },
+                        TaskRow {
+                            blockers: install_blockers,
+                            task: install,
+                            version: package_version.clone(),
+                            dependents: install_dependents,
+                        },
+                    ]
+                }
+                (None, None) => vec![
+                    TaskRow {
+                        blockers: 0,
+                        task: (package.clone(), TaskKind::Download),
+                        version: package_version.clone(),
+                        dependents: BTreeSet::from([install.clone()]),
+                    },
+                    TaskRow {
+                        blockers: install_blockers,
+                        task: install,
+                        version: package_version.clone(),
+                        dependents: install_dependents,
+                    },
+                ],
+            }
+        })
         .collect())
 }
 
-const SYNC_SHARED_WORKERS: usize = 50;
-const SYNC_INSTALL_WORKERS: usize = 8;
+fn pop_startable(tasks: &mut BTreeSet<TaskRow>, resources: &ResourcePool) -> Option<TaskRow> {
+    let task = tasks
+        .iter()
+        .take_while(|row| row.blockers == 0)
+        .find(|row| resources.can_reserve(row.task.1))?
+        .clone();
+    tasks.take(&task)
+}
+
+fn complete_task(tasks: &mut BTreeSet<TaskRow>, completed: TaskRow) {
+    for dependent in completed.dependents {
+        let mut row = tasks
+            .iter()
+            .find(|row| row.task == dependent)
+            .cloned()
+            .expect("dependent task should exist");
+        tasks.take(&row);
+        row.blockers -= 1;
+        tasks.insert(row);
+    }
+}
+
+fn pending_package_count(tasks: &BTreeSet<TaskRow>) -> usize {
+    tasks
+        .iter()
+        .filter(|row| row.task.1 == TaskKind::Install)
+        .count()
+}
 
 #[derive(Debug, Error, Diagnostic)]
 pub(crate) enum PackageGraphError {
@@ -228,7 +413,6 @@ pub(crate) struct CycleBlockedPackage {
 async fn install_required_packages(
     project_library: &Path,
     packages: RequiredPackages,
-    retained: BTreeSet<String>,
     r_version: &semver::Version,
 ) -> Result<(), SyncError> {
     let total_packages = packages.len() as u64;
@@ -252,341 +436,260 @@ async fn install_required_packages(
         return Ok(());
     }
 
-    let project_library = project_library.to_path_buf();
-    let r_version = Arc::new(r_version.clone());
-    let required_names = Arc::new(
-        retained
-            .iter()
-            .cloned()
-            .chain(packages.keys().cloned())
-            .collect::<BTreeSet<_>>(),
-    );
-    let installed_packages = Arc::new(Mutex::new(retained));
-    let install_failed = Arc::new(AtomicBool::new(false));
-    let shared_pool = Arc::new(Semaphore::new(SYNC_SHARED_WORKERS));
-    let install_pool = Arc::new(Semaphore::new(SYNC_INSTALL_WORKERS));
-    let (installed_tx, installed_rx) = watch::channel(());
-    let mut prepare_tasks = tokio::task::JoinSet::new();
-    let mut install_tasks = tokio::task::JoinSet::new();
+    let context = SyncTaskContext {
+        project_library: project_library.to_path_buf(),
+        r_version: Arc::new(r_version.clone()),
+    };
+    let mut tasks = install_tasks(packages)?;
+    let mut resources = ResourcePool::new();
+    let mut running = tokio::task::JoinSet::<(TaskRow, Result<(), SyncError>)>::new();
     let mut completed = 0_u64;
 
-    for (package_name, (package_version, description)) in packages {
-        let dependencies = package_dependency_names(&description)
-            .map_err(|details| SyncError::DownloadArtifactsFailed { details })?;
-        if let Some(repository) = package_version
-            .repository()
-            .as_ref()
-            .downcast_ref::<LocalRepository>()
-        {
-            let project_path = repository.path().to_path_buf();
-            let install_required_names = Arc::clone(&required_names);
-            let install_installed_packages = Arc::clone(&installed_packages);
-            let install_install_failed = Arc::clone(&install_failed);
-            let install_installed_rx = installed_rx.clone();
-            let install_installed_tx = installed_tx.clone();
-            let install_shared_pool = Arc::clone(&shared_pool);
-            let install_pool = Arc::clone(&install_pool);
-            let install_project_library = project_library.clone();
-            install_tasks.spawn(
+    let result = loop {
+        while let Some(row) = pop_startable(&mut tasks, &resources) {
+            resources.reserve(row.task.1);
+            let task = row.task.clone();
+            let version = row.version.clone();
+            let context = context.clone();
+            running.spawn(
                 async move {
-                    wait_for_package_dependencies(
-                        &package_name,
-                        &dependencies,
-                        install_required_names,
-                        Arc::clone(&install_installed_packages),
-                        install_install_failed,
-                        install_installed_rx,
-                    )
-                    .await
-                    .map_err(|details| SyncError::DownloadArtifactsFailed { details })?;
-
-                    let _install_permit = install_pool.acquire_owned().await.map_err(|_| {
-                        SyncError::DownloadArtifactsFailed {
-                            details: "install pool closed before project installation".to_string(),
-                        }
-                    })?;
-                    let _shared_permit =
-                        install_shared_pool.acquire_owned().await.map_err(|_| {
-                            SyncError::DownloadArtifactsFailed {
-                                details: "sync work pool closed before project installation"
-                                    .to_string(),
-                            }
-                        })?;
-
-                    install_package_directory(
-                        &project_path,
-                        &install_project_library,
-                        &package_name,
-                        package_version.version().as_ref(),
-                        "project package",
-                    )
-                    .await
-                    .map_err(|source| SyncError::ProjectPackageInstall {
-                        source: Box::new(source),
-                    })?;
-                    {
-                        let mut installed_packages = install_installed_packages.lock().await;
-                        installed_packages.insert(package_name.clone());
-                    }
-                    let _ = install_installed_tx.send(());
-
-                    Ok::<_, SyncError>(package_name)
+                    let result = run_sync_task(task, version, context).await;
+                    (row, result)
                 }
                 .instrument(sync_span.clone()),
             );
-            continue;
         }
 
-        if let Some(repository) = package_version
-            .repository()
-            .as_ref()
-            .downcast_ref::<GitRepository>()
+        sync_span.record("running", running.len() as u64);
+        sync_span.record("pending", pending_package_count(&tasks) as u64);
+
+        if running.is_empty() && tasks.is_empty() {
+            break Ok(());
+        }
+        if running.is_empty() {
+            break Err(SyncError::DownloadArtifactsFailed {
+                details: "package task graph stalled with no runnable tasks".to_string(),
+            });
+        }
+
+        match running
+            .join_next()
+            .await
+            .expect("running task set should not be empty")
         {
-            let repository = repository.clone();
-            let install_required_names = Arc::clone(&required_names);
-            let install_installed_packages = Arc::clone(&installed_packages);
-            let install_install_failed = Arc::clone(&install_failed);
-            let install_installed_rx = installed_rx.clone();
-            let install_installed_tx = installed_tx.clone();
-            let install_shared_pool = Arc::clone(&shared_pool);
-            let install_pool = Arc::clone(&install_pool);
-            let install_project_library = project_library.clone();
-            install_tasks.spawn(
-                async move {
-                    wait_for_package_dependencies(
-                        &package_name,
-                        &dependencies,
-                        install_required_names,
-                        Arc::clone(&install_installed_packages),
-                        install_install_failed,
-                        install_installed_rx,
+            Ok((row, Ok(()))) => {
+                resources.release(row.task.1);
+                if row.task.1 == TaskKind::Install {
+                    completed += 1;
+                }
+                complete_task(&mut tasks, row);
+            }
+            Ok((row, Err(error))) => {
+                resources.release(row.task.1);
+                break Err(error);
+            }
+            Err(error) => {
+                break Err(SyncError::DownloadArtifactsFailed {
+                    details: format!("sync task failed to join: {error}"),
+                });
+            }
+        }
+
+        sync_span.record("completed", completed);
+        sync_span.record("running", running.len() as u64);
+        sync_span.record("pending", pending_package_count(&tasks) as u64);
+        sync_span.pb_set_position(completed);
+        sync_span.pb_set_message(&format!("sync packages {completed}/{total_packages}"));
+    };
+
+    if result.is_err() {
+        while running.join_next().await.is_some() {}
+    }
+
+    sync_span.record("completed", completed);
+    sync_span.record("running", 0_u64);
+    sync_span.record("pending", 0_u64);
+    sync_span.record("stage", "done");
+    sync_span.pb_set_finish_message(&format!("sync packages {completed}/{total_packages}"));
+    result
+}
+
+async fn run_sync_task(
+    (package, kind): TaskId,
+    package_version: PackageVersion,
+    context: SyncTaskContext,
+) -> Result<(), SyncError> {
+    match kind {
+        TaskKind::Download => {
+            let version = package_version.version().to_string();
+            download_package_artifact(package.clone(), package_version, context.r_version)
+                .await
+                .map_err(|source| SyncError::DownloadPackageArtifact {
+                    package,
+                    version,
+                    source,
+                })
+        }
+        TaskKind::Checkout => {
+            let repository = package_version
+                .repository()
+                .as_ref()
+                .downcast_ref::<GitRepository>()
+                .expect("checkout task should use a Git repository")
+                .clone();
+            repository
+                .checkout()
+                .await
+                .map_err(|error| SyncError::DownloadArtifactsFailed {
+                    details: format!("failed to checkout {package}: {error}"),
+                })?;
+            Ok(())
+        }
+        TaskKind::Build => {
+            let repository = package_version.repository().as_ref();
+            let (package_root, source) =
+                if let Some(repository) = repository.downcast_ref::<LocalRepository>() {
+                    (
+                        repository.path().to_path_buf(),
+                        SourceArtifactIdentity::Local(repository.path().to_path_buf()),
                     )
-                    .await
-                    .map_err(|details| SyncError::DownloadArtifactsFailed { details })?;
-
-                    let _install_permit = install_pool.acquire_owned().await.map_err(|_| {
+                } else {
+                    let repository = repository
+                        .downcast_ref::<GitRepository>()
+                        .expect("build task should use a local or Git repository");
+                    let checkout = repository.checkout_path().await.map_err(|error| {
                         SyncError::DownloadArtifactsFailed {
-                            details: "install pool closed before Git package installation"
-                                .to_string(),
-                        }
-                    })?;
-                    let _shared_permit =
-                        install_shared_pool.acquire_owned().await.map_err(|_| {
-                            SyncError::DownloadArtifactsFailed {
-                                details: "sync work pool closed before Git package installation"
-                                    .to_string(),
-                            }
-                        })?;
-
-                    let checkout = repository.checkout().await.map_err(|error| {
-                        SyncError::DownloadArtifactsFailed {
-                            details: format!("failed to checkout {package_name}: {error}"),
+                            details: format!("failed to locate checkout for {package}: {error}"),
                         }
                     })?;
                     let package_root = repository
                         .subdirectory()
                         .map_or(checkout.clone(), |subdirectory| checkout.join(subdirectory));
-                    install_package_directory(
-                        &package_root,
-                        &install_project_library,
-                        &package_name,
-                        package_version.version().as_ref(),
-                        &format!("{package_name} from Git"),
-                    )
-                    .await
-                    .map_err(|source| SyncError::PackageInstall {
-                        package: package_name.clone(),
-                        source: Box::new(source),
+                    let commit = repository.commit().await.map_err(|error| {
+                        SyncError::DownloadArtifactsFailed {
+                            details: format!("failed to resolve Git commit for {package}: {error}"),
+                        }
                     })?;
-                    {
-                        let mut installed_packages = install_installed_packages.lock().await;
-                        installed_packages.insert(package_name.clone());
-                    }
-                    let _ = install_installed_tx.send(());
-
-                    Ok::<_, SyncError>(package_name)
-                }
-                .instrument(sync_span.clone()),
-            );
-            continue;
-        }
-
-        let cache_key = CompiledPackageCacheKey::new(
-            &package_name,
-            package_version.version().as_ref(),
-            r_version.as_ref(),
-        );
-        let (prepared_tx, prepared_rx) = oneshot::channel();
-
-        let prepare_package_name = package_name.clone();
-        let prepare_package_version = package_version.clone();
-        let prepare_cache_key = cache_key.clone();
-        let prepare_r_version = Arc::clone(&r_version);
-        let prepare_shared_pool = Arc::clone(&shared_pool);
-        prepare_tasks.spawn(
-            async move {
-                let prepared = match prepare_shared_pool.acquire_owned().await {
-                    Ok(_permit) => {
-                        prepare_locked_package_artifact(
-                            prepare_package_name,
-                            prepare_package_version,
-                            prepare_cache_key,
-                            prepare_r_version,
-                        )
-                        .await
-                    }
-                    Err(_) => Err("sync work pool closed before artifact preparation".to_string()),
+                    (
+                        package_root,
+                        SourceArtifactIdentity::Git {
+                            remote: repository.remote().clone(),
+                            commit,
+                            subdirectory: repository.subdirectory().map(Path::to_path_buf),
+                        },
+                    )
                 };
-
-                let _ = prepared_tx.send(prepared);
-            }
-            .instrument(sync_span.clone()),
-        );
-
-        let install_required_names = Arc::clone(&required_names);
-        let install_installed_packages = Arc::clone(&installed_packages);
-        let install_install_failed = Arc::clone(&install_failed);
-        let install_installed_rx = installed_rx.clone();
-        let install_installed_tx = installed_tx.clone();
-        let install_shared_pool = Arc::clone(&shared_pool);
-        let install_pool = Arc::clone(&install_pool);
-        let install_project_library = project_library.clone();
-        install_tasks.spawn(
-            async move {
-                let prepared_artifact = prepared_rx
-                    .await
-                    .map_err(|_| SyncError::DownloadArtifactsFailed {
-                        details: format!(
-                            "{package_name} artifact preparation task ended without a result"
-                        ),
-                    })?
-                    .map_err(|details| SyncError::DownloadArtifactsFailed { details })?;
-
-                // Keep package spans out of the progress UI while blocked on dependency installs.
-                wait_for_package_dependencies(
-                    &package_name,
-                    &dependencies,
-                    install_required_names,
-                    Arc::clone(&install_installed_packages),
-                    install_install_failed,
-                    install_installed_rx,
-                )
-                .await
-                .map_err(|details| SyncError::DownloadArtifactsFailed { details })?;
-
-                let _install_permit = install_pool.acquire_owned().await.map_err(|_| {
-                    SyncError::DownloadArtifactsFailed {
-                        details: "install pool closed before package installation".to_string(),
-                    }
-                })?;
-                let _shared_permit = install_shared_pool.acquire_owned().await.map_err(|_| {
-                    SyncError::DownloadArtifactsFailed {
-                        details: "sync work pool closed before package installation".to_string(),
-                    }
-                })?;
-
-                let installed = install_prepared_package(
-                    install_project_library,
-                    package_name,
-                    package_version,
-                    cache_key,
-                    prepared_artifact,
-                )
-                .await
-                .map_err(|details| SyncError::DownloadArtifactsFailed { details })?;
-                {
-                    let mut installed_packages = install_installed_packages.lock().await;
-                    installed_packages.insert(installed.clone());
-                }
-                let _ = install_installed_tx.send(());
-
-                Ok::<_, SyncError>(installed)
-            }
-            .instrument(sync_span.clone()),
-        );
-    }
-
-    sync_span.record("running", install_tasks.len() as u64);
-
-    let mut first_error = None;
-    while let Some(result) = install_tasks.join_next().await {
-        let result = result
-            .map_err(|error| SyncError::DownloadArtifactsFailed {
-                details: format!("install task failed to join: {error}"),
-            })
-            .and_then(|result| result);
-
-        match result {
-            Ok(_) => completed += 1,
-            Err(error) if first_error.is_none() => {
-                first_error = Some(error);
-                install_failed.store(true, Ordering::Relaxed);
-                install_pool.close();
-                shared_pool.close();
-                prepare_tasks.abort_all();
-                let _ = installed_tx.send(());
-            }
-            Err(_) => {}
-        }
-
-        sync_span.record("completed", completed);
-        sync_span.record("running", install_tasks.len() as u64);
-        sync_span.record("pending", total_packages.saturating_sub(completed));
-        sync_span.pb_set_position(completed);
-        sync_span.pb_set_message(&format!("sync packages {completed}/{total_packages}"));
-    }
-
-    drop(prepare_tasks);
-
-    sync_span.record("stage", "done");
-    sync_span.pb_set_finish_message(&format!("sync packages {completed}/{total_packages}"));
-    first_error.map_or(Ok(()), Err)
-}
-
-async fn wait_for_package_dependencies(
-    package: &str,
-    dependencies: &BTreeSet<String>,
-    required_names: Arc<BTreeSet<String>>,
-    installed_packages: Arc<Mutex<BTreeSet<String>>>,
-    install_failed: Arc<AtomicBool>,
-    mut installed_rx: watch::Receiver<()>,
-) -> Result<(), String> {
-    loop {
-        if install_failed.load(Ordering::Relaxed) {
-            return Err(format!(
-                "stopped waiting for {package} dependencies after an installation failed"
+            let archive = source_artifact_cache_path(&SourceArtifactCacheKey::new(
+                source,
+                &package,
+                package_version.version().clone(),
             ));
-        }
-
-        {
-            let installed_packages = installed_packages.lock().await;
-            if dependencies
-                .iter()
-                .filter(|dependency| required_names.contains(*dependency))
-                .all(|dependency| installed_packages.contains(dependency))
-            {
-                return Ok(());
-            }
-        }
-
-        installed_rx.changed().await.map_err(|_| {
-            format!(
-                "dependency notifier closed before {} dependencies were installed",
-                package
+            build_package_archive(
+                &package_root,
+                &package,
+                package_version.version().as_ref(),
+                &archive,
             )
-        })?;
+            .await
+            .map_err(|source| SyncError::PackageBuild {
+                package,
+                source: Box::new(source),
+            })
+        }
+        TaskKind::Install => install_package(
+            &context.project_library,
+            &package,
+            &package_version,
+            context.r_version.as_ref(),
+        )
+        .await
+        .map_err(|source| SyncError::PackageInstall {
+            package,
+            source: Box::new(source),
+        }),
     }
 }
 
-async fn prepare_locked_package_artifact(
+#[derive(Debug, Error)]
+pub(crate) enum DownloadPackageArtifactError {
+    #[error("unsupported remote package repository")]
+    UnsupportedRepository,
+    #[error("failed to request binary artifact: {source}")]
+    BinaryRequest {
+        #[source]
+        source: http::BinaryArtifactRequestError,
+    },
+    #[error("failed to request {artifact} artifact: {source}")]
+    Request {
+        artifact: &'static str,
+        #[source]
+        source: reqwest_middleware::Error,
+    },
+    #[error("{artifact} artifact response failed: {source}")]
+    Response {
+        artifact: &'static str,
+        #[source]
+        source: reqwest::Error,
+    },
+    #[error("failed to create artifact cache directory {}: {source}", path.display())]
+    CreateCacheDirectory {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to create temporary artifact in {}: {source}", path.display())]
+    CreateTemporaryArtifact {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to open temporary artifact {}: {source}", path.display())]
+    OpenTemporaryArtifact {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to read artifact response: {source}")]
+    ReadResponse {
+        #[source]
+        source: reqwest::Error,
+    },
+    #[error("failed to write temporary artifact {}: {source}", path.display())]
+    WriteArtifact {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("artifact response was incomplete: expected {expected} bytes, received {actual}")]
+    ContentLengthMismatch { expected: u64, actual: u64 },
+    #[error("failed to flush temporary artifact {}: {source}", path.display())]
+    FlushArtifact {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to sync temporary artifact {}: {source}", path.display())]
+    SyncArtifact {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to publish artifact {}: {source}", path.display())]
+    PublishArtifact {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+async fn download_package_artifact(
     package: String,
     package_version: PackageVersion,
-    cache_key: CompiledPackageCacheKey,
     r_version: Arc<semver::Version>,
-) -> Result<Option<(PathBuf, String)>, String> {
+) -> Result<(), DownloadPackageArtifactError> {
     let version = package_version.version().to_string();
     let span = tracing::info_span!(
-        "prepare_package",
+        "download_package_artifact",
         package = %package,
         version = %version,
         repository = tracing::field::Empty,
@@ -597,152 +700,290 @@ async fn prepare_locked_package_artifact(
         indicatif.pb_show = true,
     );
     span.pb_set_style(&progress_spinner_style());
-    span.pb_set_message(&package_stage_message(&package, &version, "preparing"));
+    span.pb_set_message(&format!("{package} {version} preparing"));
     span.pb_start();
 
-    prepare_locked_package_artifact_inner(
-        package,
-        package_version,
-        &cache_key,
-        r_version.as_ref(),
-        span.clone(),
-    )
-    .instrument(span)
+    async {
+        let repository = package_version.repository();
+        let repository =
+            if let Some(repository) = repository.as_ref().downcast_ref::<RrepoRepository>() {
+                RegistryIdentity::Rrepo(repository.url().clone())
+            } else if let Some(repository) = repository.as_ref().downcast_ref::<CranRepository>() {
+                RegistryIdentity::Cran(repository.url().clone())
+            } else {
+                return Err(DownloadPackageArtifactError::UnsupportedRepository);
+            };
+        span.record(
+            "repository",
+            match &repository {
+                RegistryIdentity::Cran(url) | RegistryIdentity::Rrepo(url) => url.as_str(),
+            },
+        );
+        let compiled = compiled_package_cache_path(&CompiledPackageCacheKey::new(
+            repository.clone(),
+            &package,
+            package_version.version().clone(),
+            HOST.clone(),
+            r_version.as_ref().clone(),
+        ));
+        if compiled.is_dir() {
+            span.record("artifact_kind", "compiled-cache");
+            span.record("stage", "prepared");
+            span.pb_set_message(&format!("{package} {version} prepared"));
+            span.pb_tick();
+            return Ok(());
+        }
+
+        span.record("stage", "downloading binary");
+        span.pb_set_message(&format!("{package} {version} downloading binary"));
+        span.pb_tick();
+        let binary = async {
+            let key = BinaryArtifactCacheKey::new(
+                repository.clone(),
+                &package,
+                package_version.version().clone(),
+                HOST.clone(),
+                r_version.as_ref().clone(),
+            );
+            let path = binary_artifact_cache_path(&key);
+            if path.exists() {
+                return Ok(());
+            }
+
+            let response = match &repository {
+                RegistryIdentity::Rrepo(url) => http::rrepo_binary(
+                    url,
+                    &package,
+                    &version,
+                    &HOST,
+                    r_version.as_ref(),
+                )
+                .await,
+                RegistryIdentity::Cran(url) => http::cran_binary(
+                    url,
+                    &package,
+                    &version,
+                    &HOST,
+                    r_version.as_ref(),
+                )
+                .await,
+            }
+            .map_err(|source| DownloadPackageArtifactError::BinaryRequest { source })?
+            .error_for_status()
+            .map_err(|source| DownloadPackageArtifactError::Response {
+                artifact: "binary",
+                source,
+            })?;
+            span.record("artifact_kind", "binary");
+            publish_artifact_response(path, response, &span).await
+        }
+        .await;
+
+        let binary_error = match binary {
+            Ok(()) => {
+                span.record("stage", "prepared");
+                span.pb_set_message(&format!("{package} {version} prepared"));
+                span.pb_tick();
+                return Ok(());
+            }
+            Err(error) => error,
+        };
+        tracing::debug!(
+            package = %package,
+            version = %version,
+            error = %binary_error,
+            "binary artifact unavailable; falling back to source"
+        );
+
+        span.pb_set_style(&progress_spinner_style());
+        span.record("stage", "falling back to source");
+        span.pb_set_message(&format!("{package} {version} falling back to source"));
+        span.pb_tick();
+        span.record("stage", "downloading source");
+        span.pb_set_message(&format!("{package} {version} downloading source"));
+        span.pb_tick();
+        let key = SourceArtifactCacheKey::new(
+            SourceArtifactIdentity::Registry(repository.clone()),
+            &package,
+            package_version.version().clone(),
+        );
+        let path = source_artifact_cache_path(&key);
+        if path.exists() {
+            span.record("stage", "prepared");
+            span.pb_set_message(&format!("{package} {version} prepared"));
+            span.pb_tick();
+            return Ok(());
+        }
+
+        let response = match &repository {
+            RegistryIdentity::Rrepo(url) => http::rrepo_source_artifact(url, &package, &version)
+                .await
+                .map_err(|source| DownloadPackageArtifactError::Request {
+                    artifact: "source",
+                    source,
+                })?
+                .error_for_status()
+                .map_err(|source| DownloadPackageArtifactError::Response {
+                    artifact: "source",
+                    source,
+                })?,
+            RegistryIdentity::Cran(url) => {
+                let current = http::cran_current_source_tarball(url, &package, &version)
+                    .await
+                    .map_err(|source| DownloadPackageArtifactError::Request {
+                        artifact: "current source",
+                        source,
+                    })
+                    .and_then(|response| {
+                        response.error_for_status().map_err(|source| {
+                            DownloadPackageArtifactError::Response {
+                                artifact: "current source",
+                                source,
+                            }
+                        })
+                    });
+                match current {
+                    Ok(response) => response,
+                    Err(error) => {
+                        tracing::debug!(%error, "current source artifact unavailable; trying archive");
+                        http::cran_archive_source_tarball(url, &package, &version)
+                            .await
+                            .map_err(|source| DownloadPackageArtifactError::Request {
+                                artifact: "archived source",
+                                source,
+                            })?
+                            .error_for_status()
+                            .map_err(|source| DownloadPackageArtifactError::Response {
+                                artifact: "archived source",
+                                source,
+                            })?
+                    }
+                }
+            }
+        };
+        span.record("artifact_kind", "source");
+        publish_artifact_response(path, response, &span).await?;
+        span.record("stage", "prepared");
+        span.pb_set_message(&format!("{package} {version} prepared"));
+        span.pb_tick();
+        Ok(())
+    }
+    .instrument(span.clone())
     .await
 }
 
-async fn prepare_locked_package_artifact_inner(
-    package: String,
-    package_version: PackageVersion,
-    cache_key: &CompiledPackageCacheKey,
-    r_version: &semver::Version,
-    span: tracing::Span,
-) -> Result<Option<(PathBuf, String)>, String> {
-    fn response_for_status(response: reqwest::Response) -> Result<reqwest::Response, String> {
-        response
-            .error_for_status()
-            .map_err(|error| error.to_string())
-    }
-
-    let version = package_version.version().to_string();
-    record_package_stage(&span, &package, &version, "checking cache");
-    if cache::exists(cache_key).await {
-        record_package_stage(&span, &package, &version, "cached");
-        return Ok(None);
-    }
-
-    let repository = package_version.repository();
-    let (base_url, is_rrepo) =
-        if let Some(repository) = repository.as_ref().downcast_ref::<RrepoRepository>() {
-            (repository.url(), true)
-        } else if let Some(repository) = repository.as_ref().downcast_ref::<CranRepository>() {
-            (repository.url(), false)
-        } else {
-            return Err(format!(
-                "package {package} uses an unsupported remote repository"
-            ));
-        };
-    span.record("repository", base_url.as_str());
-
-    record_package_stage(&span, &package, &version, "downloading binary");
-
-    let binary = match (std::env::consts::OS, is_rrepo) {
-        ("windows", true) => http::rrepo_windows_binary(base_url, &package, &version, r_version)
-            .await
-            .map_err(|error| error.to_string())
-            .and_then(response_for_status)
-            .map(|response| (response, "zip", "win.binary".to_string())),
-
-        ("windows", false) => http::cran_windows_binary(base_url, r_version, &package, &version)
-            .await
-            .map_err(|error| error.to_string())
-            .and_then(response_for_status)
-            .map(|response| (response, "zip", "win.binary".to_string())),
-
-        ("macos", true) => {
-            let target = macos_binary_target()?;
-
-            http::rrepo_macos_binary(base_url, &package, &version, &target, r_version)
-                .await
-                .map_err(|error| error.to_string())
-                .and_then(response_for_status)
-                .map(|response| (response, "tgz", format!("mac.binary.{target}")))
-        }
-
-        ("macos", false) => {
-            let target = macos_binary_target()?;
-
-            http::cran_macos_binary(base_url, &target, r_version, &package, &version)
-                .await
-                .map_err(|error| error.to_string())
-                .and_then(response_for_status)
-                .map(|response| (response, "tgz", format!("mac.binary.{target}")))
-        }
-
-        _ => Err(format!(
-            "binary artifacts are not supported on {}-{}",
-            std::env::consts::OS,
-            std::env::consts::ARCH
-        )),
-    };
-
-    let (response, extension, install_type) = match binary {
-        Ok(binary) => {
-            span.record("artifact_kind", binary.2.as_str());
-            binary
-        }
-
-        Err(error) => {
-            tracing::debug!(
-                package = %package,
-                version = %version,
-                error = %error,
-                "binary artifact unavailable; falling back to source"
-            );
-
-            record_package_stage(&span, &package, &version, "falling back to source");
-            record_package_stage(&span, &package, &version, "downloading source");
-
-            let response = if is_rrepo {
-                http::rrepo_source_artifact(base_url, &package, &version)
-                    .await
-                    .map_err(|error| error.to_string())
-                    .and_then(response_for_status)?
-            } else {
-                let current = http::cran_current_source_tarball(base_url, &package, &version)
-                    .await
-                    .map_err(|error| error.to_string())
-                    .and_then(response_for_status);
-                match current {
-                    Ok(response) => response,
-                    Err(_) => http::cran_archive_source_tarball(base_url, &package, &version)
-                        .await
-                        .map_err(|error| error.to_string())
-                        .and_then(response_for_status)?,
-                }
-            };
-
-            span.record("artifact_kind", "source");
-
-            (response, "tar.gz", "source".to_string())
-        }
-    };
-
-    let artifact_path =
-        write_artifact_response(&package, &version, extension, response, &span).await?;
-
-    record_package_stage(&span, &package, &version, "prepared");
-
-    Ok(Some((artifact_path, install_type)))
+#[derive(Debug, Error)]
+pub(crate) enum InstallPackageError {
+    #[error("unsupported package repository")]
+    UnsupportedRepository,
+    #[error("failed to resolve Git commit for {package}: {source}")]
+    GitCommit {
+        package: String,
+        #[source]
+        source: RepositoryError,
+    },
+    #[error("failed to determine the macOS binary package type: {source}")]
+    MacBinaryType {
+        #[source]
+        source: http::BinaryArtifactRequestError,
+    },
+    #[error("no installable artifact exists for {package} {version}")]
+    MissingArtifact { package: String, version: String },
+    #[error("failed to prepare package install workspace root at {}: {source}", path.display())]
+    WorkspaceRoot {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to create package install workspace in {}: {source}", path.display())]
+    Workspace {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to create temporary package library at {}: {source}", path.display())]
+    TemporaryLibrary {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error(transparent)]
+    Command(#[from] r::PackageInstallError),
+    #[error("installed package directory is missing at {}", path.display())]
+    InstalledPackageMissing { path: PathBuf },
+    #[error("failed to inspect installed package directory at {}: {source}", path.display())]
+    InspectInstalledPackage {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to prepare compiled package cache directory at {}: {source}", path.display())]
+    CompiledCacheDirectory {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("compiled package cache path is not a directory: {}", path.display())]
+    InvalidCompiledCache { path: PathBuf },
+    #[error("failed to publish compiled package at {}: {source}", path.display())]
+    PublishCompiledPackage {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error(transparent)]
+    PublishProject(#[from] PublishInstalledPackageError),
+    #[error("failed to clean package install workspace at {}: {source}", path.display())]
+    Cleanup {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
 }
 
-async fn install_prepared_package(
-    project_library: PathBuf,
-    package: String,
-    package_version: PackageVersion,
-    cache_key: CompiledPackageCacheKey,
-    prepared_artifact: Option<(PathBuf, String)>,
-) -> Result<String, String> {
+#[derive(Debug, Error)]
+pub(crate) enum PublishInstalledPackageError {
+    #[error("failed to publish package because the destination already exists: {}", path.display())]
+    DestinationExists { path: PathBuf },
+    #[error("failed to create package staging directory in {}: {source}", path.display())]
+    CreateStagingDirectory {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to stage installed package from {}: {source}", path.display())]
+    StagePackage {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("staged package metadata is missing at {}", path.display())]
+    MissingMetadata { path: PathBuf },
+    #[error("failed to publish installed package at {}: {source}", path.display())]
+    Publish {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to clean package staging directory at {}: {source}", path.display())]
+    Cleanup {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("failed to join package publication task: {source}")]
+    Join {
+        #[source]
+        source: tokio::task::JoinError,
+    },
+}
+
+async fn install_package(
+    project_library: &Path,
+    package: &str,
+    package_version: &PackageVersion,
+    r_version: &semver::Version,
+) -> Result<(), InstallPackageError> {
     let version = package_version.version().to_string();
     let span = tracing::info_span!(
         "install_package",
@@ -753,137 +994,313 @@ async fn install_prepared_package(
         indicatif.pb_show = true,
     );
     span.pb_set_style(&progress_spinner_style());
-    span.pb_set_message(&package_stage_message(&package, &version, "installing"));
+    span.pb_set_message(&format!("{package} {version} installing"));
     span.pb_start();
 
-    install_prepared_package_inner(
-        project_library,
-        package,
-        version,
-        cache_key,
-        prepared_artifact,
-        span.clone(),
-    )
-    .instrument(span)
-    .await
-}
-
-async fn install_prepared_package_inner(
-    project_library: PathBuf,
-    package: String,
-    version: String,
-    cache_key: CompiledPackageCacheKey,
-    prepared_artifact: Option<(PathBuf, String)>,
-    span: tracing::Span,
-) -> Result<String, String> {
-    match prepared_artifact {
-        None => {
-            span.record("artifact_kind", "compiled-cache");
-            record_package_stage(&span, &package, &version, "restoring from cache");
-            cache::restore(&cache_key, &project_library).await?;
-            record_package_stage(&span, &package, &version, "restored from cache");
-            Ok(package)
-        }
-
-        Some((artifact_path, install_type)) => {
-            span.record("artifact_kind", install_type.as_str());
-            install_downloaded_package(
+    async {
+        let repository = package_version.repository();
+        let repository = repository.as_ref();
+        let registry = if let Some(repository) = repository.downcast_ref::<RrepoRepository>() {
+            Some(RegistryIdentity::Rrepo(repository.url().clone()))
+        } else {
+            repository
+                .downcast_ref::<CranRepository>()
+                .map(|repository| RegistryIdentity::Cran(repository.url().clone()))
+        };
+        let compiled = registry.as_ref().map(|registry| {
+            compiled_package_cache_path(&CompiledPackageCacheKey::new(
+                registry.clone(),
                 package,
-                version,
-                cache_key,
-                artifact_path,
-                install_type,
-                project_library,
-                span,
+                package_version.version().clone(),
+                HOST.clone(),
+                r_version.clone(),
+            ))
+        });
+
+        if let Some(compiled) = &compiled
+            && compiled.is_dir()
+        {
+            span.record("artifact_kind", "compiled-cache");
+            span.record("stage", "restoring project library");
+            span.pb_set_message(&format!("{package} {version} restoring project library"));
+            span.pb_tick();
+            publish_installed_package(compiled, project_library, package).await?;
+            span.record("stage", "done");
+            span.pb_set_message(&format!("{package} {version} done"));
+            span.pb_tick();
+            return Ok(());
+        }
+
+        let (artifact, install_type) = if let Some(registry) = &registry {
+            let binary = match HOST.operating_system {
+                OperatingSystem::Windows => Some("win.binary".to_string()),
+                OperatingSystem::Darwin(_) | OperatingSystem::MacOSX(_) => Some(format!(
+                    "mac.binary.{}",
+                    http::r_macos_binary_target(&HOST)
+                        .map_err(|source| InstallPackageError::MacBinaryType { source })?
+                )),
+                _ => None,
+            }
+            .map(|install_type| {
+                let path = binary_artifact_cache_path(&BinaryArtifactCacheKey::new(
+                    registry.clone(),
+                    package,
+                    package_version.version().clone(),
+                    HOST.clone(),
+                    r_version.clone(),
+                ));
+                (path, install_type)
+            });
+            if let Some((path, install_type)) = binary
+                && path.is_file()
+            {
+                (path, install_type)
+            } else {
+                (
+                    source_artifact_cache_path(&SourceArtifactCacheKey::new(
+                        SourceArtifactIdentity::Registry(registry.clone()),
+                        package,
+                        package_version.version().clone(),
+                    )),
+                    "source".to_string(),
+                )
+            }
+        } else if let Some(repository) = repository.downcast_ref::<LocalRepository>() {
+            (
+                source_artifact_cache_path(&SourceArtifactCacheKey::new(
+                    SourceArtifactIdentity::Local(repository.path().to_path_buf()),
+                    package,
+                    package_version.version().clone(),
+                )),
+                "source".to_string(),
             )
+        } else if let Some(repository) = repository.downcast_ref::<GitRepository>() {
+            let commit = repository.commit().await.map_err(|source| {
+                InstallPackageError::GitCommit {
+                    package: package.to_string(),
+                    source,
+                }
+            })?;
+            (
+                source_artifact_cache_path(&SourceArtifactCacheKey::new(
+                    SourceArtifactIdentity::Git {
+                        remote: repository.remote().clone(),
+                        commit,
+                        subdirectory: repository.subdirectory().map(Path::to_path_buf),
+                    },
+                    package,
+                    package_version.version().clone(),
+                )),
+                "source".to_string(),
+            )
+        } else {
+            return Err(InstallPackageError::UnsupportedRepository);
+        };
+        if !artifact.is_file() {
+            return Err(InstallPackageError::MissingArtifact {
+                package: package.to_string(),
+                version,
+            });
+        }
+        span.record("artifact_kind", install_type.as_str());
+
+        let workspace_parent = cache_dir_path().join("build-temp");
+        tokio::fs::create_dir_all(&workspace_parent)
             .await
+            .map_err(|source| InstallPackageError::WorkspaceRoot {
+                path: workspace_parent.clone(),
+                source,
+            })?;
+        let workspace = tempfile::Builder::new()
+            .prefix("rpx-install-")
+            .tempdir_in(&workspace_parent)
+            .map_err(|source| InstallPackageError::Workspace {
+                path: workspace_parent,
+                source,
+            })?;
+        let workspace_path = workspace.path().to_path_buf();
+        let temporary_library = workspace.path().join("library");
+        tokio::fs::create_dir(&temporary_library)
+            .await
+            .map_err(|source| InstallPackageError::TemporaryLibrary {
+                path: temporary_library.clone(),
+                source,
+            })?;
+
+        let result = async {
+            span.record("stage", "installing");
+            span.pb_set_message(&format!("{package} {version} installing"));
+            span.pb_tick();
+            install_package_artifact(
+                project_library,
+                &artifact,
+                package,
+                &version,
+                &install_type,
+                &temporary_library,
+            )
+            .await?;
+
+            let installed = temporary_library.join(package);
+            match tokio::fs::metadata(&installed).await {
+                Ok(metadata) if metadata.is_dir() => {}
+                Ok(_) => {
+                    return Err(InstallPackageError::InstalledPackageMissing { path: installed });
+                }
+                Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
+                    return Err(InstallPackageError::InstalledPackageMissing { path: installed });
+                }
+                Err(source) => {
+                    return Err(InstallPackageError::InspectInstalledPackage {
+                        path: installed,
+                        source,
+                    });
+                }
+            }
+
+            let installed = if let Some(compiled) = &compiled {
+                span.record("stage", "storing cache");
+                span.pb_set_message(&format!("{package} {version} storing cache"));
+                span.pb_tick();
+                let parent = compiled
+                    .parent()
+                    .expect("compiled package cache path should have a parent");
+                tokio::fs::create_dir_all(parent).await.map_err(|source| {
+                    InstallPackageError::CompiledCacheDirectory {
+                        path: parent.to_path_buf(),
+                        source,
+                    }
+                })?;
+                if compiled.exists() {
+                    if !compiled.is_dir() {
+                        return Err(InstallPackageError::InvalidCompiledCache {
+                            path: compiled.clone(),
+                        });
+                    }
+                } else {
+                    tokio::fs::rename(&installed, compiled).await.map_err(|source| {
+                        InstallPackageError::PublishCompiledPackage {
+                            path: compiled.clone(),
+                            source,
+                        }
+                    })?;
+                }
+                compiled.clone()
+            } else {
+                installed
+            };
+
+            span.record("stage", "restoring project library");
+            span.pb_set_message(&format!("{package} {version} restoring project library"));
+            span.pb_tick();
+            publish_installed_package(&installed, project_library, package).await?;
+            Ok(())
+        }
+        .await;
+
+        span.record("stage", "cleaning up");
+        span.pb_set_message(&format!("{package} {version} cleaning up"));
+        span.pb_tick();
+        let cleanup = tokio::task::spawn_blocking(move || workspace.close())
+            .await
+            .map_err(std::io::Error::other)
+            .and_then(|result| result);
+        if let Err(error) = &cleanup
+            && result.is_err()
+        {
+            tracing::warn!(%error, path = %workspace_path.display(), "failed to clean package install workspace");
+        }
+        result?;
+        cleanup.map_err(|source| InstallPackageError::Cleanup {
+            path: workspace_path,
+            source,
+        })?;
+
+        span.record("stage", "done");
+        span.pb_set_message(&format!("{package} {version} done"));
+        span.pb_tick();
+        Ok(())
+    }
+    .instrument(span.clone())
+    .await
+}
+
+async fn publish_installed_package(
+    source: &Path,
+    project_library: &Path,
+    package: &str,
+) -> Result<(), PublishInstalledPackageError> {
+    let source = source.to_path_buf();
+    let project_library = project_library.to_path_buf();
+    let package = package.to_string();
+    tokio::task::spawn_blocking(move || {
+        let destination = project_library.join(&package);
+        if destination.exists() {
+            return Err(PublishInstalledPackageError::DestinationExists { path: destination });
+        }
+        let staging = tempfile::Builder::new()
+            .prefix(".rpx-install-")
+            .tempdir_in(&project_library)
+            .map_err(
+                |source| PublishInstalledPackageError::CreateStagingDirectory {
+                    path: project_library.clone(),
+                    source,
+                },
+            )?;
+        let staging_path = staging.path().to_path_buf();
+        let staged_package = staging.path().join(&package);
+        copy_directory(&source, &staged_package).map_err(|error| {
+            PublishInstalledPackageError::StagePackage {
+                path: source,
+                source: error,
+            }
+        })?;
+        let metadata = staged_package.join("DESCRIPTION");
+        if !metadata.is_file() {
+            return Err(PublishInstalledPackageError::MissingMetadata { path: metadata });
+        }
+        if destination.exists() {
+            return Err(PublishInstalledPackageError::DestinationExists { path: destination });
+        }
+        fs::rename(&staged_package, &destination).map_err(|source| {
+            PublishInstalledPackageError::Publish {
+                path: destination,
+                source,
+            }
+        })?;
+        staging
+            .close()
+            .map_err(|source| PublishInstalledPackageError::Cleanup {
+                path: staging_path,
+                source,
+            })
+    })
+    .await
+    .map_err(|source| PublishInstalledPackageError::Join { source })?
+}
+
+fn copy_directory(source: &Path, destination: &Path) -> Result<(), std::io::Error> {
+    fs::create_dir(destination)?;
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let source = entry.path();
+        let destination = destination.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_directory(&source, &destination)?;
+        } else {
+            fs::copy(source, destination)?;
         }
     }
+    Ok(())
 }
 
-async fn install_downloaded_package(
-    package: String,
-    version: String,
-    key: CompiledPackageCacheKey,
-    artifact_path: PathBuf,
-    install_type: String,
-    project_library: PathBuf,
-    span: tracing::Span,
-) -> Result<String, String> {
-    record_package_stage(&span, &package, &version, "installing");
-
-    let temp_library = build_temp_library_path(&package, &unique_build_token());
-
-    install_local_package(
-        &project_library,
-        &artifact_path,
-        &package,
-        &version,
-        &install_type,
-        &temp_library,
-    )
-    .await
-    .map_err(|failure| failure.to_string())?;
-
-    let built_package_path = temp_library.join(&package);
-
-    record_package_stage(&span, &package, &version, "storing cache");
-    cache::store(&key, &built_package_path).await?;
-
-    record_package_stage(&span, &package, &version, "restoring project library");
-    cache::restore(&key, &project_library).await?;
-
-    record_package_stage(&span, &package, &version, "cleaning up");
-    if let Some(temp_root) = temp_library.parent() {
-        tokio::fs::remove_dir_all(temp_root)
-            .await
-            .map_err(|error| format!("failed to clean temporary build directory: {error}"))?;
-    }
-
-    record_package_stage(&span, &package, &version, "done");
-
-    Ok(package)
-}
-
-fn record_package_stage(span: &tracing::Span, package: &str, version: &str, stage: &'static str) {
-    span.record("stage", stage);
-    span.pb_set_style(&progress_spinner_style());
-    span.pb_set_message(&package_stage_message(package, version, stage));
-    span.pb_tick();
-}
-
-fn package_stage_message(package: &str, version: &str, stage: &str) -> String {
-    format!("{package} {version} {stage}")
-}
-
-async fn write_artifact_response(
-    package: &str,
-    version: &str,
-    extension: &str,
+async fn publish_artifact_response(
+    path: PathBuf,
     response: reqwest::Response,
     span: &tracing::Span,
-) -> Result<PathBuf, String> {
-    let file_name = format!("{package}_{version}.{extension}");
-    let path = artifact_cache_path(package, version, &file_name);
-
-    if path.exists() {
-        if let Ok(metadata) = path.metadata() {
-            span.record("bytes", metadata.len());
-            span.record("total_bytes", metadata.len());
-            span.pb_set_style(&progress_bar_style());
-            span.pb_set_length(metadata.len());
-            span.pb_set_position(metadata.len());
-            span.pb_set_message(&package_stage_message(
-                package,
-                version,
-                "using cached artifact",
-            ));
-        }
-
-        return Ok(path);
-    }
-
+) -> Result<(), DownloadPackageArtifactError> {
     let content_length = response.content_length();
+    let mut stream = response.bytes_stream();
 
     if let Some(total) = content_length {
         span.record("total_bytes", total);
@@ -892,28 +1309,52 @@ async fn write_artifact_response(
         span.pb_set_position(0);
     }
 
-    if let Some(parent) = path.parent() {
-        tokio::fs::create_dir_all(parent).await.map_err(|error| {
-            format!(
-                "failed to create artifact cache directory {}: {error}",
-                parent.display()
-            )
+    let parent = path
+        .parent()
+        .ok_or_else(|| DownloadPackageArtifactError::PublishArtifact {
+            path: path.clone(),
+            source: std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "artifact cache path has no parent",
+            ),
         })?;
-    }
-
-    let mut file = tokio::fs::File::create(&path)
+    tokio::fs::create_dir_all(parent).await.map_err(|source| {
+        DownloadPackageArtifactError::CreateCacheDirectory {
+            path: parent.to_path_buf(),
+            source,
+        }
+    })?;
+    let temporary_path = tempfile::Builder::new()
+        .prefix(".rpx-artifact-")
+        .tempfile_in(parent)
+        .map_err(
+            |source| DownloadPackageArtifactError::CreateTemporaryArtifact {
+                path: parent.to_path_buf(),
+                source,
+            },
+        )?
+        .into_temp_path();
+    let mut file = tokio::fs::File::create(&temporary_path)
         .await
-        .map_err(|error| format!("failed to create artifact file {}: {error}", path.display()))?;
+        .map_err(
+            |source| DownloadPackageArtifactError::OpenTemporaryArtifact {
+                path: temporary_path.to_path_buf(),
+                source,
+            },
+        )?;
 
-    let mut stream = response.bytes_stream();
     let mut written = 0_u64;
 
     while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|error| format!("failed to read artifact response: {error}"))?;
+        let chunk =
+            chunk.map_err(|source| DownloadPackageArtifactError::ReadResponse { source })?;
         let chunk_len = chunk.len() as u64;
 
-        file.write_all(&chunk).await.map_err(|error| {
-            format!("failed to write artifact file {}: {error}", path.display())
+        file.write_all(&chunk).await.map_err(|source| {
+            DownloadPackageArtifactError::WriteArtifact {
+                path: temporary_path.to_path_buf(),
+                source,
+            }
         })?;
 
         written += chunk_len;
@@ -927,29 +1368,36 @@ async fn write_artifact_response(
         }
     }
 
+    if let Some(expected) = content_length
+        && written != expected
+    {
+        return Err(DownloadPackageArtifactError::ContentLengthMismatch {
+            expected,
+            actual: written,
+        });
+    }
+
     file.flush()
         .await
-        .map_err(|error| format!("failed to flush artifact file {}: {error}", path.display()))?;
+        .map_err(|source| DownloadPackageArtifactError::FlushArtifact {
+            path: temporary_path.to_path_buf(),
+            source,
+        })?;
+    file.sync_all()
+        .await
+        .map_err(|source| DownloadPackageArtifactError::SyncArtifact {
+            path: temporary_path.to_path_buf(),
+            source,
+        })?;
+    drop(file);
+    tokio::fs::rename(&temporary_path, &path)
+        .await
+        .map_err(|source| DownloadPackageArtifactError::PublishArtifact {
+            path: path.clone(),
+            source,
+        })?;
 
-    Ok(path)
-}
-
-fn macos_binary_target() -> Result<String, String> {
-    match std::env::consts::ARCH {
-        "aarch64" => Ok("big-sur-arm64".to_string()),
-        "x86_64" => Ok("big-sur-x86_64".to_string()),
-        arch => Err(format!(
-            "unsupported macOS architecture for binary packages: {arch}"
-        )),
-    }
-}
-
-fn unique_build_token() -> String {
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("system time should be after unix epoch")
-        .as_nanos();
-    format!("{}-{unique}", std::process::id())
+    Ok(())
 }
 
 async fn validate_package_graph(packages: &RequiredPackages) -> Result<(), SyncError> {
@@ -966,17 +1414,17 @@ async fn validate_package_graph(packages: &RequiredPackages) -> Result<(), SyncE
 
     let dependencies = packages
         .iter()
-        .map(|(package, (_, description))| {
-            package_dependency_names(description)
+        .map(|(package, (version, description))| {
+            required_dependencies(format!("{package} {}", version.version()), description)
                 .map(|dependencies| {
                     dependencies
                         .into_iter()
-                        .map(|dependency| (package.clone(), dependency))
-                        .collect::<Vec<_>>()
+                        .map(|dependency| (package.clone(), dependency.package().to_string()))
+                        .collect::<BTreeSet<_>>()
                 })
-                .map_err(|details| PackageGraphError::InvalidDependencies {
+                .map_err(|error| PackageGraphError::InvalidDependencies {
                     package: package.clone(),
-                    details,
+                    details: error.to_string(),
                 })
         })
         .collect::<Result<Vec<_>, _>>()?
@@ -1061,57 +1509,7 @@ async fn validate_package_graph(packages: &RequiredPackages) -> Result<(), SyncE
 mod tests {
     use super::*;
     use crate::repository::{PackageRepository, built_in_repository};
-    use r_description::Remote;
-
-    #[tokio::test]
-    async fn dependency_wait_stops_after_install_failure() {
-        let install_failed = Arc::new(AtomicBool::new(false));
-        let (installed_tx, installed_rx) = watch::channel(());
-        let wait_install_failed = Arc::clone(&install_failed);
-        let waiter = tokio::spawn(async move {
-            wait_for_package_dependencies(
-                "dependent",
-                &BTreeSet::from(["dependency".to_string()]),
-                Arc::new(BTreeSet::from(["dependency".to_string()])),
-                Arc::new(Mutex::new(BTreeSet::new())),
-                wait_install_failed,
-                installed_rx,
-            )
-            .await
-        });
-
-        tokio::task::yield_now().await;
-        install_failed.store(true, Ordering::Relaxed);
-        let _ = installed_tx.send(());
-
-        let error = waiter
-            .await
-            .expect("dependency waiter should join")
-            .expect_err("dependency waiter should stop");
-        assert!(error.contains("after an installation failed"));
-    }
-
-    #[test]
-    fn package_dependency_names_uses_only_hard_dependencies() {
-        let description = RDescription::parse(
-            "Package: selected\nVersion: 1.0.0\nDepends: R, depends, duplicate\nImports: imports, duplicate\nLinkingTo: linking\nSuggests: suggested\n",
-        );
-        assert_eq!(
-            package_dependency_names(&description).unwrap(),
-            BTreeSet::from([
-                "depends".into(),
-                "duplicate".into(),
-                "imports".into(),
-                "linking".into()
-            ])
-        );
-        for field in ["Depends", "Imports", "LinkingTo"] {
-            let description = RDescription::parse(&format!(
-                "Package: selected\nVersion: 1.0.0\n{field}: broken (>= invalid)\n"
-            ));
-            assert!(package_dependency_names(&description).is_err());
-        }
-    }
+    use r_description::{RDescription, Remote};
 
     #[test]
     fn package_requires_install_respects_source_and_version() {
@@ -1157,12 +1555,134 @@ mod tests {
             .collect()
     }
 
+    #[test]
+    fn install_tasks_release_by_kind_and_package_dependency() {
+        let packages =
+            required_packages(&[("dependency", ""), ("dependent", "Imports: dependency\n")]);
+        let mut tasks = install_tasks(packages).unwrap();
+        let resources = ResourcePool::new();
+
+        let dependency_download = pop_startable(&mut tasks, &resources).unwrap();
+        assert_eq!(dependency_download.task.0, "dependency");
+        assert_eq!(dependency_download.task.1, TaskKind::Download);
+        complete_task(&mut tasks, dependency_download);
+
+        let dependency_install = pop_startable(&mut tasks, &resources).unwrap();
+        assert_eq!(dependency_install.task.0, "dependency");
+        assert_eq!(dependency_install.task.1, TaskKind::Install);
+        complete_task(&mut tasks, dependency_install);
+
+        let dependent_download = pop_startable(&mut tasks, &resources).unwrap();
+        assert_eq!(dependent_download.task.0, "dependent");
+        assert_eq!(dependent_download.task.1, TaskKind::Download);
+        complete_task(&mut tasks, dependent_download);
+
+        let dependent_install = pop_startable(&mut tasks, &resources).unwrap();
+        assert_eq!(dependent_install.task.0, "dependent");
+        assert_eq!(dependent_install.task.1, TaskKind::Install);
+    }
+
+    #[test]
+    fn resource_pool_enforces_shared_and_subset_limits() {
+        let mut resources = ResourcePool::new();
+        resources.reserve(TaskKind::Checkout);
+        assert!(!resources.can_reserve(TaskKind::Checkout));
+        assert!(resources.can_reserve(TaskKind::Build));
+
+        resources.release(TaskKind::Checkout);
+        for _ in 0..SYNC_R_WORKERS {
+            resources.reserve(TaskKind::Build);
+        }
+        assert!(!resources.can_reserve(TaskKind::Install));
+        assert!(resources.can_reserve(TaskKind::Download));
+
+        for _ in SYNC_R_WORKERS..SYNC_SHARED_WORKERS {
+            resources.reserve(TaskKind::Download);
+        }
+        assert!(!resources.can_reserve(TaskKind::Download));
+    }
+
+    #[tokio::test]
+    async fn publishes_complete_installed_package() {
+        let source_root = tempfile::tempdir().unwrap();
+        let source = source_root.path().join("package");
+        fs::create_dir(&source).unwrap();
+        fs::write(
+            source.join("DESCRIPTION"),
+            "Package: package\nVersion: 1.0.0\n",
+        )
+        .unwrap();
+        fs::write(source.join("contents"), "complete").unwrap();
+        let project_library = tempfile::tempdir().unwrap();
+
+        publish_installed_package(&source, project_library.path(), "package")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            fs::read_to_string(project_library.path().join("package/contents")).unwrap(),
+            "complete"
+        );
+        assert!(fs::read_dir(project_library.path()).unwrap().all(|entry| {
+            !entry
+                .unwrap()
+                .file_name()
+                .to_string_lossy()
+                .starts_with(".rpx-install-")
+        }));
+    }
+
+    #[tokio::test]
+    async fn package_publication_does_not_replace_existing_destination() {
+        let source_root = tempfile::tempdir().unwrap();
+        let source = source_root.path().join("package");
+        fs::create_dir(&source).unwrap();
+        fs::write(
+            source.join("DESCRIPTION"),
+            "Package: package\nVersion: 2.0.0\n",
+        )
+        .unwrap();
+        let project_library = tempfile::tempdir().unwrap();
+        let existing = project_library.path().join("package");
+        fs::create_dir(&existing).unwrap();
+        fs::write(
+            existing.join("DESCRIPTION"),
+            "Package: package\nVersion: 1.0.0\n",
+        )
+        .unwrap();
+
+        let error = publish_installed_package(&source, project_library.path(), "package")
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            PublishInstalledPackageError::DestinationExists { path } if path == existing
+        ));
+        assert_eq!(
+            fs::read_to_string(existing.join("DESCRIPTION")).unwrap(),
+            "Package: package\nVersion: 1.0.0\n"
+        );
+    }
+
     #[tokio::test]
     async fn package_graph_validation_accepts_complete_acyclic_graph() {
         let packages = required_packages(&[
             ("dependent", "Imports: dependency, testBasePackage\n"),
             ("dependency", ""),
             ("unrelated", ""),
+        ]);
+        validate_package_graph(&packages).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn package_graph_validation_deduplicates_dependency_constraints() {
+        let packages = required_packages(&[
+            (
+                "dependent",
+                "Imports: dependency (>= 1.0.0), dependency (< 2.0.0)\n",
+            ),
+            ("dependency", ""),
         ]);
         validate_package_graph(&packages).await.unwrap();
     }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -310,6 +310,8 @@ async fn install_required_packages(
                     install_package_directory(
                         &project_path,
                         &install_project_library,
+                        &package_name,
+                        package_version.version().as_ref(),
                         "project package",
                     )
                     .await
@@ -379,6 +381,8 @@ async fn install_required_packages(
                     install_package_directory(
                         &package_root,
                         &install_project_library,
+                        &package_name,
+                        package_version.version().as_ref(),
                         &format!("{package_name} from Git"),
                     )
                     .await

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -102,7 +102,7 @@ EOF
 cat > {wrapper_path}/Rscript <<'EOF'
 #!/bin/sh
 case "$*" in
-    *install.packages*digest_*)
+    *install.packages*digest*)
         if [ "${{RPX_TEST_FAIL_DIGEST:-}}" = 1 ]; then
             attempts=0
             while [ ! -f "$RPX_TEST_STATE/root-active" ] && [ "$attempts" -lt 100 ]; do
@@ -217,7 +217,7 @@ fn sync_installs_project_without_mutating_its_sources() {
     assert_package_state(&container, project_path, "testpkg", "TRUE");
 
     let assert_clean = format!(
-        "cd {project_path} && test ! -e configured-during-install && test ! -e src/native.o && test ! -e src/testpkg.so && set -- {temp_path}/rpx-build-* && test ! -e \"$1\""
+        "cd {project_path} && test ! -e configured-during-install && test ! -e src/native.o && test ! -e src/testpkg.so && set -- \"$HOME/.cache/rpx/artifacts/source/v1/testpkg\"/*/artifact.tar.gz && test -f \"$1\" && set -- \"$HOME/.cache/rpx/artifacts/source/v1\"/*/*/.rpx-build-* && test ! -e \"$1\" && set -- \"$HOME/.cache/rpx/build-temp\"/rpx-install-* && test ! -e \"$1\""
     );
     let (exit_code, stdout, stderr) = run_shell_command(&container, &assert_clean);
     assert_eq!(
@@ -277,7 +277,7 @@ Suggests: digest",
     );
 
     let completed_root_command = format!(
-        "test -f {state_path}/root-cleaned && test ! -e {state_path}/root-active && set -- {temp_path}/rpx-build-* && test ! -e \"$1\""
+        "test -f {state_path}/root-cleaned && test ! -e {state_path}/root-active && set -- \"$HOME/.cache/rpx/artifacts/source/v1/testpkg\"/*/artifact.tar.gz && test -f \"$1\" && set -- \"$HOME/.cache/rpx/artifacts/source/v1\"/*/*/.rpx-build-* && test ! -e \"$1\" && set -- \"$HOME/.cache/rpx/build-temp\"/rpx-install-* && test ! -e \"$1\""
     );
     let (exit_code, stdout, stderr) = run_shell_command(&container, &completed_root_command);
     assert_eq!(
@@ -291,6 +291,11 @@ Suggests: digest",
     assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
     assert_package_state(&container, project_path, "digest", "TRUE");
     assert_package_state(&container, project_path, "testpkg", "TRUE");
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &completed_root_command);
+    assert_eq!(
+        exit_code, 0,
+        "retry left a temporary build workspace\nstdout was: {stdout}\nstderr was: {stderr}"
+    );
 }
 
 #[test]

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -124,6 +124,50 @@ fn runs_rpx_sync_from_lockfile_without_mutating_it() {
 }
 
 #[test]
+fn sync_installs_project_without_mutating_its_sources() {
+    let container = start_container();
+    let project_path = "/tmp/rpx-project-sync-clean-sources";
+    create_package_project(&container, project_path);
+    let add_build_sources = format!(
+        "cd {project_path} && mkdir src && cat > configure <<'EOF'\n#!/bin/sh\ntouch configured-during-install\nEOF\nchmod +x configure && cat > src/native.c <<'EOF'\nvoid native(void) {{}}\nEOF"
+    );
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &add_build_sources);
+    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
+
+    let lock_command = format!("cd {project_path} && rpx lock");
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &lock_command);
+    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
+
+    let sync_command = format!("cd {project_path} && rpx sync");
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &sync_command);
+    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
+    assert_package_state(&container, project_path, "testpkg", "TRUE");
+
+    let assert_clean = format!(
+        "cd {project_path} && test ! -e configured-during-install && test ! -e src/native.o && test ! -e src/testpkg.so && set -- /tmp/rpx-build-* && test ! -e \"$1\""
+    );
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &assert_clean);
+    assert_eq!(
+        exit_code, 0,
+        "project sources or temporary build files were left behind\nstdout was: {stdout}\nstderr was: {stderr}"
+    );
+
+    let fail_configure = format!(
+        "cd {project_path} && cat > configure <<'EOF'\n#!/bin/sh\ntouch configured-during-install\nexit 1\nEOF\nchmod +x configure"
+    );
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &fail_configure);
+    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
+
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &sync_command);
+    assert_eq!(exit_code, 1, "stdout was: {stdout}\nstderr was: {stderr}");
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &assert_clean);
+    assert_eq!(
+        exit_code, 0,
+        "failed installation left project sources or temporary build files behind\nstdout was: {stdout}\nstderr was: {stderr}"
+    );
+}
+
+#[test]
 fn sync_without_project_installs_dependencies_and_removes_project() {
     let container = start_container();
     let project_path = "/tmp/rpx-project-sync-without-project";

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -66,6 +66,71 @@ fn assert_package_version(
     );
 }
 
+fn install_sync_failure_wrappers(
+    container: &testcontainers::core::Container<testcontainers::GenericImage>,
+    project_path: &str,
+    wrapper_path: &str,
+    state_path: &str,
+) -> String {
+    let command = format!(
+        r#"mkdir -p {wrapper_path}/real {state_path}
+ln -s "$(command -v R)" {wrapper_path}/real/R
+ln -s "$(command -v Rscript)" {wrapper_path}/real/Rscript
+cat > {wrapper_path}/R <<'EOF'
+#!/bin/sh
+case "$*" in
+    *CMD*build*"$RPX_TEST_PROJECT"*)
+        if [ "${{RPX_TEST_ROOT_DELAY:-}}" = 1 ] && [ "${{RPX_TEST_FAIL_DIGEST:-}}" = 1 ]; then
+            rm -f "$RPX_TEST_STATE/root-cleaned" "$RPX_TEST_STATE/digest-failed"
+            touch "$RPX_TEST_STATE/root-active"
+            attempts=0
+            while [ ! -f "$RPX_TEST_STATE/digest-failed" ] && [ "$attempts" -lt 1200 ]; do
+                sleep 0.05
+                attempts=$((attempts + 1))
+            done
+            sleep 1
+            {wrapper_path}/real/R "$@"
+            status=$?
+            rm -f "$RPX_TEST_STATE/root-active"
+            touch "$RPX_TEST_STATE/root-cleaned"
+            exit "$status"
+        fi
+        ;;
+esac
+exec {wrapper_path}/real/R "$@"
+EOF
+cat > {wrapper_path}/Rscript <<'EOF'
+#!/bin/sh
+case "$*" in
+    *install.packages*digest_*)
+        if [ "${{RPX_TEST_FAIL_DIGEST:-}}" = 1 ]; then
+            attempts=0
+            while [ ! -f "$RPX_TEST_STATE/root-active" ] && [ "$attempts" -lt 100 ]; do
+                sleep 0.05
+                attempts=$((attempts + 1))
+            done
+            if [ ! -f "$RPX_TEST_STATE/root-active" ]; then
+                echo "digest install did not overlap the root build" >&2
+                exit 98
+            fi
+            touch "$RPX_TEST_STATE/digest-failed"
+            echo "injected digest install failure" >&2
+            exit 97
+        fi
+        ;;
+esac
+exec {wrapper_path}/real/Rscript "$@"
+EOF
+chmod +x {wrapper_path}/R {wrapper_path}/Rscript"#
+    );
+    let (exit_code, stdout, stderr) = run_shell_command(container, &command);
+    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
+
+    format!(
+        "PATH={wrapper_path}:$PATH RPX_TEST_PROJECT={project_path} RPX_TEST_STATE={state_path} RPX_TEST_ROOT_DELAY=1"
+    )
+}
+
 #[test]
 fn runs_rpx_lock_from_current_library() {
     let container = start_container();
@@ -134,9 +199,10 @@ fn runs_rpx_sync_from_lockfile_without_mutating_it() {
 fn sync_installs_project_without_mutating_its_sources() {
     let container = start_container();
     let project_path = "/tmp/rpx-project-sync-clean-sources";
+    let temp_path = "/tmp/rpx-project-sync-clean-sources-tmp";
     create_package_project(&container, project_path);
     let add_build_sources = format!(
-        "cd {project_path} && mkdir src && cat > configure <<'EOF'\n#!/bin/sh\ntouch configured-during-install\nEOF\nchmod +x configure && cat > src/native.c <<'EOF'\nvoid native(void) {{}}\nEOF"
+        "mkdir -p {temp_path} && cd {project_path} && mkdir src && cat > configure <<'EOF'\n#!/bin/sh\ntouch configured-during-install\nEOF\nchmod +x configure && cat > src/native.c <<'EOF'\nvoid native(void) {{}}\nEOF"
     );
     let (exit_code, stdout, stderr) = run_shell_command(&container, &add_build_sources);
     assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
@@ -145,13 +211,13 @@ fn sync_installs_project_without_mutating_its_sources() {
     let (exit_code, stdout, stderr) = run_shell_command(&container, &lock_command);
     assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
 
-    let sync_command = format!("cd {project_path} && rpx sync");
+    let sync_command = format!("cd {project_path} && TMPDIR={temp_path} rpx sync");
     let (exit_code, stdout, stderr) = run_shell_command(&container, &sync_command);
     assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
     assert_package_state(&container, project_path, "testpkg", "TRUE");
 
     let assert_clean = format!(
-        "cd {project_path} && test ! -e configured-during-install && test ! -e src/native.o && test ! -e src/testpkg.so && set -- /tmp/rpx-build-* && test ! -e \"$1\""
+        "cd {project_path} && test ! -e configured-during-install && test ! -e src/native.o && test ! -e src/testpkg.so && set -- {temp_path}/rpx-build-* && test ! -e \"$1\""
     );
     let (exit_code, stdout, stderr) = run_shell_command(&container, &assert_clean);
     assert_eq!(
@@ -172,6 +238,59 @@ fn sync_installs_project_without_mutating_its_sources() {
         exit_code, 0,
         "failed installation left project sources or temporary build files behind\nstdout was: {stdout}\nstderr was: {stderr}"
     );
+}
+
+#[test]
+fn failed_sync_drains_active_source_builds() {
+    let container = start_container();
+    let project_path = "/tmp/rpx-project-sync-drain-installs";
+    let wrapper_path = "/tmp/rpx-sync-drain-wrappers";
+    let state_path = "/tmp/rpx-sync-drain-state";
+    let temp_path = "/tmp/rpx-sync-drain-temp";
+    write_description(
+        &container,
+        project_path,
+        "Package: testpkg
+Version: 0.1.0
+Title: Test Package
+Description: Test package for rpx integration tests.
+License: MIT
+Author: Test Author
+Maintainer: Test Author <test@example.com>
+Suggests: digest",
+    );
+
+    let lock_command = format!("cd {project_path} && rpx lock");
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &lock_command);
+    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
+
+    let wrapped_environment =
+        install_sync_failure_wrappers(&container, project_path, wrapper_path, state_path);
+    let sync_command = format!(
+        "mkdir -p {temp_path} && cd {project_path} && {wrapped_environment} TMPDIR={temp_path} RPX_TEST_FAIL_DIGEST=1 rpx sync"
+    );
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &sync_command);
+    assert_eq!(exit_code, 1, "stdout was: {stdout}\nstderr was: {stderr}");
+    assert!(
+        stderr.contains("code Some(97)") && stderr.contains("injected digest"),
+        "stdout was: {stdout}\nstderr was: {stderr}"
+    );
+
+    let completed_root_command = format!(
+        "test -f {state_path}/root-cleaned && test ! -e {state_path}/root-active && set -- {temp_path}/rpx-build-* && test ! -e \"$1\""
+    );
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &completed_root_command);
+    assert_eq!(
+        exit_code, 0,
+        "sync returned before the root build cleaned up\nstdout was: {stdout}\nstderr was: {stderr}"
+    );
+
+    let retry_command =
+        format!("cd {project_path} && {wrapped_environment} TMPDIR={temp_path} rpx sync");
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &retry_command);
+    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
+    assert_package_state(&container, project_path, "digest", "TRUE");
+    assert_package_state(&container, project_path, "testpkg", "TRUE");
 }
 
 #[test]

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -131,6 +131,76 @@ chmod +x {wrapper_path}/R {wrapper_path}/Rscript"#
     )
 }
 
+fn install_lock_failure_wrapper(
+    container: &testcontainers::core::Container<testcontainers::GenericImage>,
+    wrapper_path: &str,
+    state_path: &str,
+) -> String {
+    let command = format!(
+        r#"mkdir -p {wrapper_path}/real {state_path}
+ln -s "$(command -v Rscript)" {wrapper_path}/real/Rscript
+cat > {wrapper_path}/Rscript <<'EOF'
+#!/bin/sh
+case "$*" in
+    *install.packages*)
+        last=
+        second_last=
+        third_last=
+        for argument in "$@"; do
+            third_last=$second_last
+            second_last=$last
+            last=$argument
+        done
+        package=$second_last
+        library=$third_last
+        case "$package" in
+            testpkg)
+                if [ "${{RPX_TEST_ROOT_DELAY:-}}" = 1 ] && [ "${{RPX_TEST_FAIL_DIGEST:-}}" = 1 ]; then
+                    rm -f "$RPX_TEST_STATE/root-cleaned" "$RPX_TEST_STATE/digest-failed"
+                    printf '%s\n' "$library" > "$RPX_TEST_STATE/root-library"
+                    printf '%s\n' "$R_LIBS_USER" > "$RPX_TEST_STATE/project-library"
+                    mkdir -p "$library/00LOCK-testpkg"
+                    touch "$RPX_TEST_STATE/root-active"
+                    attempts=0
+                    while [ ! -f "$RPX_TEST_STATE/digest-failed" ] && [ "$attempts" -lt 1200 ]; do
+                        sleep 0.05
+                        attempts=$((attempts + 1))
+                    done
+                    sleep 1
+                    rm -rf "$library/00LOCK-testpkg"
+                    rm -f "$RPX_TEST_STATE/root-active"
+                    touch "$RPX_TEST_STATE/root-cleaned"
+                fi
+                ;;
+            digest)
+                if [ "${{RPX_TEST_FAIL_DIGEST:-}}" = 1 ]; then
+                    attempts=0
+                    while [ ! -f "$RPX_TEST_STATE/root-active" ] && [ "$attempts" -lt 1200 ]; do
+                        sleep 0.05
+                        attempts=$((attempts + 1))
+                    done
+                    if [ ! -f "$RPX_TEST_STATE/root-active" ]; then
+                        echo "digest install did not overlap the root install" >&2
+                        exit 98
+                    fi
+                    touch "$RPX_TEST_STATE/digest-failed"
+                    echo "injected digest install failure" >&2
+                    exit 97
+                fi
+                ;;
+        esac
+        ;;
+esac
+exec {wrapper_path}/real/Rscript "$@"
+EOF
+chmod +x {wrapper_path}/Rscript"#
+    );
+    let (exit_code, stdout, stderr) = run_shell_command(container, &command);
+    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
+
+    format!("PATH={wrapper_path}:$PATH RPX_TEST_STATE={state_path} RPX_TEST_ROOT_DELAY=1")
+}
+
 #[test]
 fn runs_rpx_lock_from_current_library() {
     let container = start_container();
@@ -295,6 +365,60 @@ Suggests: digest",
     assert_eq!(
         exit_code, 0,
         "retry left a temporary build workspace\nstdout was: {stdout}\nstderr was: {stderr}"
+    );
+}
+
+#[test]
+fn failed_sync_releases_install_locks_and_retries_without_clean() {
+    let container = start_container();
+    let project_path = "/tmp/rpx-project-sync-failed-install";
+    let wrapper_path = "/tmp/rpx-sync-install-wrappers";
+    let state_path = "/tmp/rpx-sync-install-state";
+    write_description(
+        &container,
+        project_path,
+        "Package: testpkg
+Version: 0.1.0
+Title: Test Package
+Description: Test package for rpx integration tests.
+License: MIT
+Author: Test Author
+Maintainer: Test Author <test@example.com>
+Suggests: digest",
+    );
+
+    let lock_command = format!("cd {project_path} && rpx lock");
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &lock_command);
+    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
+
+    let wrapped_environment = install_lock_failure_wrapper(&container, wrapper_path, state_path);
+    let sync_command =
+        format!("cd {project_path} && {wrapped_environment} RPX_TEST_FAIL_DIGEST=1 rpx sync");
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &sync_command);
+    assert_eq!(exit_code, 1, "stdout was: {stdout}\nstderr was: {stderr}");
+    assert!(
+        stderr.contains("code Some(97)") && stderr.contains("injected digest install"),
+        "stdout was: {stdout}\nstderr was: {stderr}"
+    );
+
+    let completed_root_command = format!(
+        "test -f {state_path}/root-cleaned && test ! -e {state_path}/root-active && root_library=$(cat {state_path}/root-library) && project_library=$(cat {state_path}/project-library) && test ! -e \"$root_library\" && set -- \"$project_library\"/00LOCK* && test ! -e \"$1\" && set -- \"$HOME/.cache/rpx/build-temp\"/rpx-install-* && test ! -e \"$1\""
+    );
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &completed_root_command);
+    assert_eq!(
+        exit_code, 0,
+        "sync returned before the root install cleaned its lock or workspace\nstdout was: {stdout}\nstderr was: {stderr}"
+    );
+
+    let retry_command = format!("cd {project_path} && {wrapped_environment} rpx sync");
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &retry_command);
+    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
+    assert_package_state(&container, project_path, "digest", "TRUE");
+    assert_package_state(&container, project_path, "testpkg", "TRUE");
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &completed_root_command);
+    assert_eq!(
+        exit_code, 0,
+        "retry left an install lock or workspace\nstdout was: {stdout}\nstderr was: {stderr}"
     );
 }
 


### PR DESCRIPTION
## Summary
- build local and Git source packages into temporary source archives before installation
- keep configure scripts and native compilation away from project roots and cached Git checkouts
- clean temporary build directories after successful and failed installs, with cancellation-safe subprocess termination
- publish downloaded artifacts, compiled packages, and project packages transactionally
- isolate R package installation locks in owned temporary libraries and drain active work after failures
- report build, installation, and temporary-directory failures through structured diagnostics

## Testing
- `cargo test`
- `cargo fmt --check`
- Docker regression covering successful and failed project installation with configure side effects and native compilation
- Docker regression covering failed parallel installation, lock cleanup, and retry without `rpx clean`

Closes #95
Closes #91
Linear: SCA-80