### PR TITLE
fix: avoid stale install locks after failed sync

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -19,7 +19,10 @@ use r_description::RDescription;
 use std::{
     collections::{BTreeMap, BTreeSet},
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     time::{SystemTime, UNIX_EPOCH},
 };
 use thiserror::Error;
@@ -259,6 +262,7 @@ async fn install_required_packages(
             .collect::<BTreeSet<_>>(),
     );
     let installed_packages = Arc::new(Mutex::new(retained));
+    let install_failed = Arc::new(AtomicBool::new(false));
     let shared_pool = Arc::new(Semaphore::new(SYNC_SHARED_WORKERS));
     let install_pool = Arc::new(Semaphore::new(SYNC_INSTALL_WORKERS));
     let (installed_tx, installed_rx) = watch::channel(());
@@ -277,6 +281,7 @@ async fn install_required_packages(
             let project_path = repository.path().to_path_buf();
             let install_required_names = Arc::clone(&required_names);
             let install_installed_packages = Arc::clone(&installed_packages);
+            let install_install_failed = Arc::clone(&install_failed);
             let install_installed_rx = installed_rx.clone();
             let install_installed_tx = installed_tx.clone();
             let install_shared_pool = Arc::clone(&shared_pool);
@@ -289,6 +294,7 @@ async fn install_required_packages(
                         &dependencies,
                         install_required_names,
                         Arc::clone(&install_installed_packages),
+                        install_install_failed,
                         install_installed_rx,
                     )
                     .await
@@ -337,6 +343,7 @@ async fn install_required_packages(
             let repository = repository.clone();
             let install_required_names = Arc::clone(&required_names);
             let install_installed_packages = Arc::clone(&installed_packages);
+            let install_install_failed = Arc::clone(&install_failed);
             let install_installed_rx = installed_rx.clone();
             let install_installed_tx = installed_tx.clone();
             let install_shared_pool = Arc::clone(&shared_pool);
@@ -349,6 +356,7 @@ async fn install_required_packages(
                         &dependencies,
                         install_required_names,
                         Arc::clone(&install_installed_packages),
+                        install_install_failed,
                         install_installed_rx,
                     )
                     .await
@@ -433,6 +441,7 @@ async fn install_required_packages(
 
         let install_required_names = Arc::clone(&required_names);
         let install_installed_packages = Arc::clone(&installed_packages);
+        let install_install_failed = Arc::clone(&install_failed);
         let install_installed_rx = installed_rx.clone();
         let install_installed_tx = installed_tx.clone();
         let install_shared_pool = Arc::clone(&shared_pool);
@@ -455,6 +464,7 @@ async fn install_required_packages(
                     &dependencies,
                     install_required_names,
                     Arc::clone(&install_installed_packages),
+                    install_install_failed,
                     install_installed_rx,
                 )
                 .await
@@ -494,11 +504,27 @@ async fn install_required_packages(
 
     sync_span.record("running", install_tasks.len() as u64);
 
+    let mut first_error = None;
     while let Some(result) = install_tasks.join_next().await {
-        result.map_err(|error| SyncError::DownloadArtifactsFailed {
-            details: format!("install task failed to join: {error}"),
-        })??;
-        completed += 1;
+        let result = result
+            .map_err(|error| SyncError::DownloadArtifactsFailed {
+                details: format!("install task failed to join: {error}"),
+            })
+            .and_then(|result| result);
+
+        match result {
+            Ok(_) => completed += 1,
+            Err(error) if first_error.is_none() => {
+                first_error = Some(error);
+                install_failed.store(true, Ordering::Relaxed);
+                install_pool.close();
+                shared_pool.close();
+                prepare_tasks.abort_all();
+                let _ = installed_tx.send(());
+            }
+            Err(_) => {}
+        }
+
         sync_span.record("completed", completed);
         sync_span.record("running", install_tasks.len() as u64);
         sync_span.record("pending", total_packages.saturating_sub(completed));
@@ -510,7 +536,7 @@ async fn install_required_packages(
 
     sync_span.record("stage", "done");
     sync_span.pb_set_finish_message(&format!("sync packages {completed}/{total_packages}"));
-    Ok(())
+    first_error.map_or(Ok(()), Err)
 }
 
 async fn wait_for_package_dependencies(
@@ -518,9 +544,16 @@ async fn wait_for_package_dependencies(
     dependencies: &BTreeSet<String>,
     required_names: Arc<BTreeSet<String>>,
     installed_packages: Arc<Mutex<BTreeSet<String>>>,
+    install_failed: Arc<AtomicBool>,
     mut installed_rx: watch::Receiver<()>,
 ) -> Result<(), String> {
     loop {
+        if install_failed.load(Ordering::Relaxed) {
+            return Err(format!(
+                "stopped waiting for {package} dependencies after an installation failed"
+            ));
+        }
+
         {
             let installed_packages = installed_packages.lock().await;
             if dependencies
@@ -776,32 +809,42 @@ async fn install_downloaded_package(
     record_package_stage(&span, &package, &version, "installing");
 
     let temp_library = build_temp_library_path(&package, &unique_build_token());
+    let temp_root = temp_library
+        .parent()
+        .expect("temporary library should have a build root")
+        .to_path_buf();
 
-    install_local_package(
-        &project_library,
-        &artifact_path,
-        &package,
-        &version,
-        &install_type,
-        &temp_library,
-    )
-    .await
-    .map_err(|failure| failure.to_string())?;
+    let result = async {
+        install_local_package(
+            &project_library,
+            &artifact_path,
+            &package,
+            &version,
+            &install_type,
+            &temp_library,
+        )
+        .await
+        .map_err(|failure| failure.to_string())?;
 
-    let built_package_path = temp_library.join(&package);
+        let built_package_path = temp_library.join(&package);
 
-    record_package_stage(&span, &package, &version, "storing cache");
-    cache::store(&key, &built_package_path).await?;
+        record_package_stage(&span, &package, &version, "storing cache");
+        cache::store(&key, &built_package_path).await?;
 
-    record_package_stage(&span, &package, &version, "restoring project library");
-    cache::restore(&key, &project_library).await?;
+        record_package_stage(&span, &package, &version, "restoring project library");
+        cache::restore(&key, &project_library).await?;
+
+        Ok::<_, String>(())
+    }
+    .await;
 
     record_package_stage(&span, &package, &version, "cleaning up");
-    if let Some(temp_root) = temp_library.parent() {
-        tokio::fs::remove_dir_all(temp_root)
-            .await
-            .map_err(|error| format!("failed to clean temporary build directory: {error}"))?;
-    }
+    let cleanup = tokio::fs::remove_dir_all(temp_root)
+        .await
+        .map_err(|error| format!("failed to clean temporary build directory: {error}"));
+
+    result?;
+    cleanup?;
 
     record_package_stage(&span, &package, &version, "done");
 
@@ -1070,6 +1113,35 @@ mod tests {
             &PackageVersion::new(version("1.0.0"), git),
             Some(&same)
         ));
+    }
+
+    #[tokio::test]
+    async fn dependency_wait_stops_after_install_failure() {
+        let install_failed = Arc::new(AtomicBool::new(false));
+        let (installed_tx, installed_rx) = watch::channel(());
+        let wait_install_failed = Arc::clone(&install_failed);
+        let waiter = tokio::spawn(async move {
+            wait_for_package_dependencies(
+                "dependent",
+                &BTreeSet::from(["dependency".to_string()]),
+                Arc::new(BTreeSet::from(["dependency".to_string()])),
+                Arc::new(Mutex::new(BTreeSet::new())),
+                wait_install_failed,
+                installed_rx,
+            )
+            .await
+        });
+
+        tokio::task::yield_now().await;
+        install_failed.store(true, Ordering::Relaxed);
+        let _ = installed_tx.send(());
+        drop(installed_tx);
+
+        let error = waiter
+            .await
+            .expect("dependency waiter should join")
+            .expect_err("dependency waiter should stop");
+        assert!(error.contains("after an installation failed"));
     }
 
     fn required_packages(packages: &[(&str, &str)]) -> RequiredPackages {

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -66,6 +66,74 @@ fn assert_package_version(
     );
 }
 
+fn install_sync_failure_wrappers(
+    container: &testcontainers::core::Container<testcontainers::GenericImage>,
+    project_path: &str,
+    wrapper_path: &str,
+    state_path: &str,
+) -> String {
+    let command = format!(
+        r#"mkdir -p {wrapper_path}/real {state_path}
+ln -s "$(command -v R)" {wrapper_path}/real/R
+ln -s "$(command -v Rscript)" {wrapper_path}/real/Rscript
+cat > {wrapper_path}/R <<'EOF'
+#!/bin/sh
+project_install=false
+library=
+for argument in "$@"; do
+    case "$argument" in
+        --library=*) library=${{argument#--library=}} ;;
+        "$RPX_TEST_PROJECT") project_install=true ;;
+    esac
+done
+if [ "${{RPX_TEST_ROOT_DELAY:-}}" = 1 ] && [ "${{RPX_TEST_FAIL_DIGEST:-}}" = 1 ] && [ "$project_install" = true ]; then
+    rm -f "$RPX_TEST_STATE/root-cleaned" "$RPX_TEST_STATE/digest-failed"
+    mkdir -p "$library/00LOCK-testpkg"
+    touch "$RPX_TEST_STATE/root-active"
+    attempts=0
+    while [ ! -f "$RPX_TEST_STATE/digest-failed" ] && [ "$attempts" -lt 1200 ]; do
+        sleep 0.05
+        attempts=$((attempts + 1))
+    done
+    sleep 1
+    rm -rf "$library/00LOCK-testpkg"
+    rm -f "$RPX_TEST_STATE/root-active"
+    touch "$RPX_TEST_STATE/root-cleaned"
+fi
+exec {wrapper_path}/real/R "$@"
+EOF
+cat > {wrapper_path}/Rscript <<'EOF'
+#!/bin/sh
+case "$*" in
+    *install.packages*digest_*)
+        if [ "${{RPX_TEST_FAIL_DIGEST:-}}" = 1 ]; then
+            attempts=0
+            while [ ! -f "$RPX_TEST_STATE/root-active" ] && [ "$attempts" -lt 100 ]; do
+                sleep 0.05
+                attempts=$((attempts + 1))
+            done
+            if [ ! -f "$RPX_TEST_STATE/root-active" ]; then
+                echo "digest install did not overlap the root install" >&2
+                exit 98
+            fi
+            touch "$RPX_TEST_STATE/digest-failed"
+            echo "injected digest install failure" >&2
+            exit 97
+        fi
+        ;;
+esac
+exec {wrapper_path}/real/Rscript "$@"
+EOF
+chmod +x {wrapper_path}/R {wrapper_path}/Rscript"#
+    );
+    let (exit_code, stdout, stderr) = run_shell_command(container, &command);
+    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
+
+    format!(
+        "PATH={wrapper_path}:$PATH RPX_TEST_PROJECT={project_path} RPX_TEST_STATE={state_path} RPX_TEST_ROOT_DELAY=1"
+    )
+}
+
 #[test]
 fn runs_rpx_lock_from_current_library() {
     let container = start_container();
@@ -120,6 +188,65 @@ fn runs_rpx_sync_from_lockfile_without_mutating_it() {
     assert_eq!(
         after, before,
         "lockfile changed during sync\nbefore:\n{before}\nafter:\n{after}"
+    );
+}
+
+#[test]
+fn failed_sync_waits_for_root_install_and_can_retry_without_clean() {
+    let container = start_container();
+    let project_path = "/tmp/rpx-project-sync-failed-install";
+    let wrapper_path = "/tmp/rpx-sync-wrappers";
+    let state_path = "/tmp/rpx-sync-state";
+    write_description(
+        &container,
+        project_path,
+        "Package: testpkg
+Version: 0.1.0
+Title: Test Package
+Description: Test package for rpx integration tests.
+License: MIT
+Author: Test Author
+Maintainer: Test Author <test@example.com>
+Suggests: digest",
+    );
+
+    let lock_command = format!("cd {project_path} && rpx lock");
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &lock_command);
+    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
+
+    let wrapped_environment =
+        install_sync_failure_wrappers(&container, project_path, wrapper_path, state_path);
+    let sync_command =
+        format!("cd {project_path} && {wrapped_environment} RPX_TEST_FAIL_DIGEST=1 rpx sync");
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &sync_command);
+    assert_eq!(exit_code, 1, "stdout was: {stdout}\nstderr was: {stderr}");
+    assert!(
+        stderr.contains("code Some(97)") && stderr.contains("injected digest install"),
+        "stdout was: {stdout}\nstderr was: {stderr}"
+    );
+
+    let completed_root_command = format!(
+        "test -f {state_path}/root-cleaned && test ! -e {state_path}/root-active && library=$(cd {project_path} && rpx run Rscript -e 'cat(.libPaths()[1])') && test ! -e \"$library/00LOCK-testpkg\""
+    );
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &completed_root_command);
+    assert_eq!(
+        exit_code, 0,
+        "sync returned before the root install cleaned its lock\nstdout was: {stdout}\nstderr was: {stderr}"
+    );
+
+    let retry_command = format!("cd {project_path} && {wrapped_environment} rpx sync");
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &retry_command);
+    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
+    assert_package_state(&container, project_path, "digest", "TRUE");
+    assert_package_state(&container, project_path, "testpkg", "TRUE");
+
+    let clean_paths_command = format!(
+        "library=$(cd {project_path} && rpx run Rscript -e 'cat(.libPaths()[1])') && locks=$(find \"$library\" -maxdepth 1 -name '00LOCK*' -print) && stale_builds=$(find \"$HOME/.cache/rpx/build-temp\" -mindepth 1 -maxdepth 1 -name 'digest-*' -print 2>/dev/null) && test -z \"$locks\" && test -z \"$stale_builds\""
+    );
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &clean_paths_command);
+    assert_eq!(
+        exit_code, 0,
+        "sync left an install lock or build-temp directory\nstdout was: {stdout}\nstderr was: {stderr}"
     );
 }
 


### PR DESCRIPTION
## Summary
- stop queued synchronization work after the first package failure while allowing active R installers to finish and release their locks
- wake dependency waiters and preserve the original synchronization error after all install tasks are drained
- remove temporary package build directories on both successful and failed installs
- add deterministic coverage for a failed parallel sync followed by an immediate retry without `rpx clean`

## Testing
- `cargo test`
- `cargo clippy --all-targets --all-features` (passes with existing repository warnings)

Fixes #91