### PR TITLE
fix: purge project libraries and preserve binary package filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ shell syntax such as pipes, redirects, or variable expansion:
 rpx run sh -c 'Rscript scripts/check.R | tee check.log'
 ```
 
-If local package state becomes confusing, remove the project library and caches:
+If local package state becomes confusing, remove all project libraries and caches:
 
 ```bash
 rpx clean

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -97,9 +97,11 @@ pub(crate) fn source_artifact_cache_path(key: &SourceArtifactCacheKey) -> PathBu
 
 pub(crate) fn binary_artifact_cache_path(key: &BinaryArtifactCacheKey) -> PathBuf {
     let file_name = match key.target.operating_system {
-        OperatingSystem::Windows => "artifact.zip",
-        OperatingSystem::Darwin(_) | OperatingSystem::MacOSX(_) => "artifact.tgz",
-        _ => "artifact.bin",
+        OperatingSystem::Windows => format!("{}_{}.zip", key.package, key.version),
+        OperatingSystem::Darwin(_) | OperatingSystem::MacOSX(_) => {
+            format!("{}_{}.tgz", key.package, key.version)
+        }
+        _ => "artifact.bin".to_string(),
     };
     cache_dir_path()
         .join("artifacts")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -60,8 +60,8 @@ pub enum Commands {
     Sync(SyncArgs),
 
     #[command(
-        about = "Remove project library and caches",
-        long_about = "Remove this project's isolated library and wipe rpx cache directories so the next sync or add starts from a clean local state."
+        about = "Remove all project libraries and caches",
+        long_about = "Remove all isolated project libraries and wipe rpx cache directories so the next sync or add starts from a clean local state."
     )]
     Clean,
 

--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -1,8 +1,6 @@
 use crate::{
     output::status,
-    project::{
-        ProjectDiscoveryError, cache_dir_path, find_project_root, project_library_root_path,
-    },
+    project::{cache_dir_path, libraries_dir_path},
 };
 use miette::Diagnostic;
 use std::{fs, path::Path};
@@ -10,10 +8,6 @@ use thiserror::Error;
 
 #[derive(Debug, Error, Diagnostic)]
 pub(crate) enum Error {
-    #[error(transparent)]
-    #[diagnostic(transparent)]
-    ProjectDiscovery(#[from] ProjectDiscoveryError),
-
     #[error("failed to remove {label} at {path}")]
     #[diagnostic(code(rpx::clean::remove_failed))]
     RemoveFailed {
@@ -25,17 +19,15 @@ pub(crate) enum Error {
 }
 
 pub(crate) fn run() -> Result<(), Error> {
-    let current_dir = find_project_root()?;
     let mut removed_any = false;
 
-    removed_any |=
-        remove_dir_if_exists(&project_library_root_path(&current_dir), "project library")?;
+    removed_any |= remove_dir_if_exists(&libraries_dir_path(), "project libraries")?;
     removed_any |= remove_dir_if_exists(&cache_dir_path(), "cache directory")?;
 
     if removed_any {
-        status("Removed project library and cache directories");
+        status("Removed all project libraries and cache directories");
     } else {
-        status("Project library and cache directories are already clean");
+        status("Project libraries and cache directories are already clean");
     }
     Ok(())
 }

--- a/src/project.rs
+++ b/src/project.rs
@@ -1102,10 +1102,11 @@ pub(crate) fn ensure_project_library(path: &Path) -> Result<PathBuf, ProjectLibr
 
 pub fn project_library_root_path(path: &Path) -> PathBuf {
     let project_key = hash_path(path);
-    project_dirs()
-        .data_dir()
-        .join("libraries")
-        .join(project_key)
+    libraries_dir_path().join(project_key)
+}
+
+pub fn libraries_dir_path() -> PathBuf {
+    project_dirs().data_dir().join("libraries")
 }
 
 pub fn cache_dir_path() -> PathBuf {
@@ -1747,7 +1748,7 @@ mod tests {
         let first = project_library_root_path(&first_path);
         assert_eq!(first, project_library_root_path(&first_path));
         assert_ne!(first, project_library_root_path(&second_path));
-        let libraries = project_dirs().data_dir().join("libraries");
+        let libraries = libraries_dir_path();
         assert_eq!(first.parent(), Some(libraries.as_path()));
         let key = first
             .file_name()

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -431,38 +431,25 @@ fn init_creates_project_that_can_add_dependencies() {
 }
 
 #[test]
-fn clean_removes_project_library_and_cache_directories() {
+fn clean_removes_all_project_libraries_and_cache_directories_without_a_project() {
     let container = start_container();
-    let project_path = "/tmp/rpx-clean";
-    let setup_command =
-        format!("mkdir -p {project_path} && cd {project_path} && rpx init && rpx add digest");
-    let (exit_code, stdout, stderr) = run_shell_command(&container, &setup_command);
-
-    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
-
-    let library_path_command =
-        format!("cd {project_path} && rpx run Rscript -e \"cat(.libPaths()[1])\"");
-    let (exit_code, library_path, stderr) = run_shell_command(&container, &library_path_command);
-    assert_eq!(
-        exit_code, 0,
-        "stdout was: {library_path}\nstderr was: {stderr}"
+    let working_path = "/tmp/rpx-clean";
+    let libraries_path = "/root/.local/share/rpx/libraries";
+    let setup_command = format!(
+        "mkdir -p {working_path} {libraries_path}/current/library {libraries_path}/orphaned/library /root/.cache/rpx/artifacts"
     );
-
-    let library_path = library_path.trim();
-    let check_before_command = format!("test -d '{library_path}' && test -d /root/.cache/rpx");
-    let (exit_code, stdout, stderr) = run_shell_command(&container, &check_before_command);
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &setup_command);
     assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
 
-    let working_path = "/tmp/rpx-clean/nested";
-    let clean_command = format!("mkdir -p {working_path} && cd {working_path} && rpx clean");
+    let clean_command = format!("cd {working_path} && rpx clean");
     let (exit_code, stdout, stderr) = run_shell_command(&container, &clean_command);
     assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
     assert!(
-        stdout.contains("Removed project library and cache directories"),
+        stdout.contains("Removed all project libraries and cache directories"),
         "stdout was: {stdout}\nstderr was: {stderr}"
     );
 
-    let check_after_command = format!("test ! -d '{library_path}' && test ! -d /root/.cache/rpx");
+    let check_after_command = format!("test ! -d {libraries_path} && test ! -d /root/.cache/rpx");
     let (exit_code, stdout, stderr) = run_shell_command(&container, &check_after_command);
     assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
 }


### PR DESCRIPTION
This pull request updates the behavior of the `rpx clean` command to remove all project libraries and caches, not just the current project's, and updates documentation, code, and tests accordingly. It also makes artifact cache file naming more descriptive and refactors related path logic for clarity and reuse.

**Command and Documentation Updates:**

* The `rpx clean` command now removes all project libraries and caches, not just those for the current project, and both the CLI help text and documentation in `README.md` are updated to reflect this broader scope. [[1]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccL63-R64) [[2]](diffhunk://#diff-5823d648e1ec5df5af30a4e574ec575919cc879f8c89a97928499d8a29b42765L28-R30) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L192-R192)

**Code Refactoring and Path Handling:**

* Introduced a new `libraries_dir_path` function in `src/project.rs` for consistent access to the global libraries directory, and refactored code to use this helper instead of duplicating path logic. [[1]](diffhunk://#diff-f36a5c348f86854b0177520d601d75ed1dc2ac736aebe2e6b928389485b75021L1105-R1109) [[2]](diffhunk://#diff-f36a5c348f86854b0177520d601d75ed1dc2ac736aebe2e6b928389485b75021L1750-R1751) [[3]](diffhunk://#diff-5823d648e1ec5df5af30a4e574ec575919cc879f8c89a97928499d8a29b42765L3-L16)

**Testing Updates:**

* Updated and expanded the clean command test in `tests/cli.rs` to ensure it removes all project libraries and cache directories, even when not in a project directory, and to check the correct output message.

**Artifact Cache Improvements:**

* Artifact cache files are now named with the package and version for Windows and macOS, making them easier to identify and manage.