### PR TITLE
refactor: remove duplicated cycle detection in sync

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -23,7 +23,7 @@ use crate::{
 use futures_util::StreamExt;
 use miette::Diagnostic;
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::BTreeSet,
     fs,
     path::{Path, PathBuf},
     sync::Arc,
@@ -125,7 +125,7 @@ pub(crate) async fn sync_resolved_project(
         );
     }
 
-    validate_package_graph(&required).await?;
+    validate_package_dependencies(&required).await?;
 
     let project_library = ensure_project_library(&project.root)?;
     let installed = installed_packages(&project_library).await?;
@@ -467,9 +467,16 @@ async fn install_required_packages(
             break Ok(());
         }
         if running.is_empty() {
-            break Err(SyncError::DownloadArtifactsFailed {
-                details: "package task graph stalled with no runnable tasks".to_string(),
-            });
+            break Err(PackageGraphError::DependencyCycle {
+                packages: tasks
+                    .iter()
+                    .filter(|row| row.task.1 == TaskKind::Install)
+                    .map(|row| CycleBlockedPackage {
+                        package: row.task.0.clone(),
+                    })
+                    .collect(),
+            }
+            .into());
         }
 
         match running
@@ -1400,19 +1407,11 @@ async fn publish_artifact_response(
     Ok(())
 }
 
-async fn validate_package_graph(packages: &RequiredPackages) -> Result<(), SyncError> {
+async fn validate_package_dependencies(packages: &RequiredPackages) -> Result<(), SyncError> {
     let base_packages = base_packages().await?;
     let required_names = packages.keys().cloned().collect::<BTreeSet<_>>();
-    let indegree = required_names
-        .iter()
-        .map(|name| (name.clone(), 0_usize))
-        .collect::<BTreeMap<_, _>>();
-    let dependents = required_names
-        .iter()
-        .map(|name| (name.clone(), BTreeSet::new()))
-        .collect::<BTreeMap<_, _>>();
 
-    let dependencies = packages
+    let missing = packages
         .iter()
         .map(|(package, (version, description))| {
             required_dependencies(format!("{package} {}", version.version()), description)
@@ -1430,9 +1429,9 @@ async fn validate_package_graph(packages: &RequiredPackages) -> Result<(), SyncE
         .collect::<Result<Vec<_>, _>>()?
         .into_iter()
         .flatten()
-        .filter(|(_, dependency)| !base_packages.contains(dependency));
-    let (missing, internal): (Vec<_>, Vec<_>) =
-        dependencies.partition(|(_, dependency)| !required_names.contains(dependency));
+        .filter(|(_, dependency)| !base_packages.contains(dependency))
+        .filter(|(_, dependency)| !required_names.contains(dependency))
+        .collect::<Vec<_>>();
 
     if !missing.is_empty() {
         return Err(PackageGraphError::MissingDependencies {
@@ -1442,61 +1441,6 @@ async fn validate_package_graph(packages: &RequiredPackages) -> Result<(), SyncE
                     package,
                     dependency,
                 })
-                .collect(),
-        }
-        .into());
-    }
-
-    let (mut indegree, dependents) = internal.into_iter().fold(
-        (indegree, dependents),
-        |(mut indegree, mut dependents), (package, dependency)| {
-            *indegree
-                .get_mut(&package)
-                .expect("required package should have indegree") += 1;
-            dependents
-                .get_mut(&dependency)
-                .expect("required dependency should exist")
-                .insert(package);
-            (indegree, dependents)
-        },
-    );
-
-    let mut ready = indegree
-        .iter()
-        .filter(|(_, count)| **count == 0)
-        .map(|(name, _)| name.clone())
-        .collect::<BTreeSet<_>>();
-    let mut ordered = Vec::with_capacity(packages.len());
-
-    while let Some(name) = ready.pop_first() {
-        ordered.push(name.clone());
-
-        dependents
-            .get(&name)
-            .cloned()
-            .unwrap_or_default()
-            .into_iter()
-            .for_each(|dependent| {
-                let count = indegree
-                    .get_mut(&dependent)
-                    .expect("dependent should have indegree entry");
-                *count -= 1;
-                if *count == 0 {
-                    ready.insert(dependent);
-                }
-            });
-    }
-
-    if ordered.len() != packages.len() {
-        let unresolved = indegree
-            .into_iter()
-            .filter(|(_, count)| *count > 0)
-            .map(|(name, _)| name)
-            .collect::<Vec<_>>();
-        return Err(PackageGraphError::DependencyCycle {
-            packages: unresolved
-                .into_iter()
-                .map(|package| CycleBlockedPackage { package })
                 .collect(),
         }
         .into());
@@ -1666,17 +1610,17 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn package_graph_validation_accepts_complete_acyclic_graph() {
+    async fn package_dependency_validation_accepts_complete_graph() {
         let packages = required_packages(&[
             ("dependent", "Imports: dependency, testBasePackage\n"),
             ("dependency", ""),
             ("unrelated", ""),
         ]);
-        validate_package_graph(&packages).await.unwrap();
+        validate_package_dependencies(&packages).await.unwrap();
     }
 
     #[tokio::test]
-    async fn package_graph_validation_deduplicates_dependency_constraints() {
+    async fn package_dependency_validation_deduplicates_constraints() {
         let packages = required_packages(&[
             (
                 "dependent",
@@ -1684,16 +1628,16 @@ mod tests {
             ),
             ("dependency", ""),
         ]);
-        validate_package_graph(&packages).await.unwrap();
+        validate_package_dependencies(&packages).await.unwrap();
     }
 
     #[tokio::test]
-    async fn package_graph_validation_reports_missing_dependencies() {
+    async fn package_dependency_validation_reports_missing_dependencies() {
         let packages = required_packages(&[
             ("a", "Imports: missingB, missingA\n"),
             ("b", "Imports: missingA\n"),
         ]);
-        let error = validate_package_graph(&packages).await.unwrap_err();
+        let error = validate_package_dependencies(&packages).await.unwrap_err();
         let SyncError::PackageGraph(PackageGraphError::MissingDependencies { dependencies }) =
             error
         else {
@@ -1709,29 +1653,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn package_graph_validation_reports_all_blocked_names() {
-        let packages = required_packages(&[
-            ("a", "Imports: b\n"),
-            ("b", "Imports: a\n"),
-            ("c", "Imports: a\n"),
-        ]);
-        let error = validate_package_graph(&packages).await.unwrap_err();
-        let SyncError::PackageGraph(PackageGraphError::DependencyCycle { packages }) = error else {
-            panic!("cycles should produce a structured graph error");
-        };
-        assert_eq!(
-            packages
-                .iter()
-                .map(|package| package.package.as_str())
-                .collect::<Vec<_>>(),
-            ["a", "b", "c"]
-        );
-    }
-
-    #[tokio::test]
-    async fn package_graph_validation_names_invalid_dependency_metadata() {
+    async fn package_dependency_validation_names_invalid_metadata() {
         let packages = required_packages(&[("broken", "Imports: dependency (>= invalid)\n")]);
-        let error = validate_package_graph(&packages).await.unwrap_err();
+        let error = validate_package_dependencies(&packages).await.unwrap_err();
         assert!(matches!(
             error,
             SyncError::PackageGraph(PackageGraphError::InvalidDependencies { package, .. })

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -266,6 +266,56 @@ fn runs_rpx_sync_from_lockfile_without_mutating_it() {
 }
 
 #[test]
+fn refuses_to_sync_cyclic_package_dependencies() {
+    let container = start_container();
+    let project_path = "/tmp/rpx-project-sync-cycle";
+    write_description(
+        &container,
+        project_path,
+        "Package: testpkg
+Version: 0.1.0
+Title: Test Package
+Description: Test package for rpx integration tests.
+License: MIT
+Author: Test Author
+Maintainer: Test Author <test@example.com>
+Imports: digest, jsonlite",
+    );
+
+    let lock_command = format!("cd {project_path} && rpx lock");
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &lock_command);
+    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
+
+    let create_cycle_command = format!(
+        r#"cd {project_path} && perl -0pi -e 's/("digest": \{{.*?"dependencies": )\[[^\]]*\]/${{1}}["jsonlite"]/s; s/("jsonlite": \{{.*?"dependencies": )\[[^\]]*\]/${{1}}["digest"]/s' rpx.lock"#
+    );
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &create_cycle_command);
+    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
+
+    let lockfile =
+        serde_json::from_str::<Value>(&read_project_file(&container, project_path, "rpx.lock"))
+            .expect("lockfile should parse");
+    assert_eq!(
+        lockfile["packages"]["digest"]["dependencies"],
+        json!(["jsonlite"])
+    );
+    assert_eq!(
+        lockfile["packages"]["jsonlite"]["dependencies"],
+        json!(["digest"])
+    );
+
+    let sync_command = format!("cd {project_path} && rpx sync --no-install-project");
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &sync_command);
+    assert_eq!(exit_code, 1, "stdout was: {stdout}\nstderr was: {stderr}");
+    assert!(
+        stderr.contains("rpx::sync::dependency_cycle")
+            && stderr.contains("package `digest` is blocked by a dependency cycle")
+            && stderr.contains("package `jsonlite` is blocked by a dependency cycle"),
+        "stdout was: {stdout}\nstderr was: {stderr}"
+    );
+}
+
+#[test]
 fn sync_installs_project_without_mutating_its_sources() {
     let container = start_container();
     let project_path = "/tmp/rpx-project-sync-clean-sources";


### PR DESCRIPTION
## Summary
- remove the preliminary topological traversal while retaining dependency metadata and completeness validation
- report blocked install tasks through the existing dependency-cycle diagnostic when the sync scheduler cannot make progress
- add Docker-backed CLI coverage for syncing a cyclic locked package graph

## Testing
- `cargo fmt --check`
- `cargo test --lib sync::tests`
- `cargo test --test sync refuses_to_sync_cyclic_package_dependencies -- --exact --nocapture`
- `cargo test`

Closes #103
Linear: SCA-83