### PR TITLE
feat: make CRAN archive listing parsing failure tolerant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,6 +641,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,6 +715,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -748,6 +792,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,6 +817,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ego-tree"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
 
 [[package]]
 name = "either"
@@ -981,6 +1046,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,6 +1170,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
+dependencies = [
+ "log",
+ "markup5ever",
 ]
 
 [[package]]
@@ -1645,6 +1729,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "markup5ever"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
+dependencies = [
+ "log",
+ "tendril",
+ "web_atoms",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1766,6 +1861,12 @@ dependencies = [
  "tagptr",
  "uuid",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nu-ansi-term"
@@ -2010,6 +2111,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2070,6 +2224,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "priority-queue"
@@ -2497,6 +2657,7 @@ dependencies = [
  "reqwest-middleware",
  "reqwest-tracing",
  "rpassword",
+ "scraper",
  "semver",
  "serde",
  "serde_json",
@@ -2715,6 +2876,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "scraper"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdd0be4d296f048bfb06dd01bbc80ef789ddd2e55583e8d2e6b804942abfabc2"
+dependencies = [
+ "cssparser",
+ "ego-tree",
+ "getopts",
+ "html5ever",
+ "precomputed-hash",
+ "selectors",
+ "tendril",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2748,6 +2924,25 @@ checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "selectors"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
+dependencies = [
+ "bitflags",
+ "cssparser",
+ "derive_more",
+ "log",
+ "new_debug_unreachable",
+ "phf",
+ "phf_codegen",
+ "precomputed-hash",
+ "rustc-hash 2.1.3",
+ "servo_arc",
+ "smallvec",
 ]
 
 [[package]]
@@ -2859,6 +3054,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2923,6 +3127,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2955,6 +3165,30 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "string_cache"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+]
 
 [[package]]
 name = "strsim"
@@ -3088,6 +3322,15 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tendril"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fed54709c5b3a53d09bb1c113ea4f5ceafd1e772ddcb0030a82e1d56c087b08"
+dependencies = [
+ "new_debug_unreachable",
 ]
 
 [[package]]
@@ -3741,6 +3984,18 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "web_atoms"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba8b815c1b593dc0baf78dd0f4fc8fdb2de53198fb1163738093e9a311c33fb3"
+dependencies = [
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ reqwest-middleware = "0.5"
 reqwest-tracing = "0.7"
 rpassword = "7.3.1"
 r-description = { package = "r-description-scalerail", version = "0.7.0" }
+scraper = "0.27.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"

--- a/src/http.rs
+++ b/src/http.rs
@@ -10,9 +10,9 @@ use reqwest_middleware::{ClientBuilder, Middleware, Next};
 use reqwest_tracing::{
     ReqwestOtelSpanBackend, TracingMiddleware, default_on_request_end, reqwest_otel_span,
 };
+use scraper::{Html, Selector};
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::io::IsTerminal;
-use std::str::FromStr;
 use std::sync::{Arc, LazyLock};
 use target_lexicon::{Aarch64Architecture, Architecture, OperatingSystem, Triple};
 use thiserror::Error;
@@ -625,37 +625,45 @@ pub struct CranPackageArchiveListing {
     pub versions: Vec<Version>,
 }
 
-impl FromStr for CranPackageArchiveListing {
-    type Err = String;
-
-    fn from_str(input: &str) -> Result<Self, Self::Err> {
+impl CranPackageArchiveListing {
+    pub fn parse(package: &str, input: &str) -> Self {
+        let document = Html::parse_document(input);
+        let anchors = Selector::parse("a").expect("anchor selector should be valid");
         let mut versions = Vec::new();
-        for part in archive_listing_parts(input) {
-            let file_name = part.rsplit('/').next().unwrap_or(part);
-            if !file_name.ends_with(".tar.gz") || !file_name.contains('_') {
-                continue;
+
+        for anchor in document.select(&anchors) {
+            if let Some(href) = anchor.value().attr("href") {
+                push_archive_version(&mut versions, package, href);
             }
 
-            let file_name = html_unescape_minimal(file_name);
-            let stem = file_name
-                .strip_suffix(".tar.gz")
-                .expect("archive file name was checked for tar.gz suffix");
-            let Some((package, version)) = stem.rsplit_once('_') else {
-                continue;
-            };
-            if package.is_empty() || version.is_empty() {
-                continue;
-            }
-
-            let version = version
-                .parse::<Version>()
-                .map_err(|error| error.to_string())?;
-            if !versions.iter().any(|seen| seen == &version) {
-                versions.push(version);
+            for text in anchor.text() {
+                for candidate in text.split_ascii_whitespace() {
+                    push_archive_version(&mut versions, package, candidate);
+                }
             }
         }
 
-        Ok(Self { versions })
+        Self { versions }
+    }
+}
+
+fn push_archive_version(versions: &mut Vec<Version>, package: &str, candidate: &str) {
+    let candidate = candidate.split(['?', '#']).next().unwrap_or(candidate);
+    let file_name = candidate.rsplit('/').next().unwrap_or(candidate);
+    let Some(stem) = file_name.strip_suffix(".tar.gz") else {
+        return;
+    };
+    let Some((candidate_package, version)) = stem.rsplit_once('_') else {
+        return;
+    };
+    if candidate_package != package || version.is_empty() {
+        return;
+    }
+
+    if let Ok(version) = version.parse::<Version>()
+        && !versions.iter().any(|seen| seen == &version)
+    {
+        versions.push(version);
     }
 }
 
@@ -688,18 +696,6 @@ pub struct RrepoVersionSummary {
     pub version: String,
     #[serde(rename = "sourceUrl")]
     pub source_url: String,
-}
-
-fn archive_listing_parts(listing: &str) -> impl Iterator<Item = &str> {
-    listing.split(['"', '\'', '<', '>', ' ', '\n', '\r', '\t'])
-}
-
-fn html_unescape_minimal(value: &str) -> String {
-    value
-        .replace("&amp;", "&")
-        .replace("&lt;", "<")
-        .replace("&gt;", ">")
-        .replace("&quot;", "\"")
 }
 
 pub async fn rrepo_repository_packages(
@@ -937,8 +933,8 @@ pub async fn cran_binary(
 #[cfg(test)]
 mod tests {
     use super::{
-        BinaryArtifactRequestError, CranPackagesIndex, CranPackagesParseError,
-        CranPackagesParseIssue, display_safe_url, r_macos_binary_target,
+        BinaryArtifactRequestError, CranPackageArchiveListing, CranPackagesIndex,
+        CranPackagesParseError, CranPackagesParseIssue, display_safe_url, r_macos_binary_target,
     };
 
     fn parse_packages_index(input: &str) -> Result<CranPackagesIndex, CranPackagesParseError> {
@@ -970,6 +966,72 @@ mod tests {
             r_macos_binary_target(&linux),
             Err(BinaryArtifactRequestError::UnsupportedTarget { .. })
         ));
+    }
+
+    #[test]
+    fn parses_cran_archive_versions_from_audited_listing_shapes() {
+        let listing = CranPackageArchiveListing::parse(
+            "cli",
+            r#"
+                <table>
+                    <tr><td><a href="cli_1.0.0.tar.gz">cli_1.0.0.tar.gz</a></td></tr>
+                </table>
+                <pre><a href="/src/contrib/Archive/cli/cli_2.0.0.tar.gz">cli_2.0.0.tar.gz</a></pre>
+                <ul><li><a href="./cli_3.0.0.tar.gz">&rtrif; cli_3.0.0.tar.gz</a></li></ul>
+            "#,
+        );
+
+        assert_eq!(
+            listing
+                .versions
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
+            ["1.0.0", "2.0.0", "3.0.0"]
+        );
+    }
+
+    #[test]
+    fn tolerates_malformed_and_unrelated_archive_entries() {
+        let listing = CranPackageArchiveListing::parse(
+            "cli",
+            r#"
+                <a href="cli_1.0.0.tar.gz">cli_1.0.0.tar.gz</a>
+                <a href="cli_not-a-version.tar.gz">cli_not-a-version.tar.gz</a>
+                <a href="other_2.0.0.tar.gz">other_2.0.0.tar.gz</a>
+                <a href="cli_3.0.0.tar.gz?download=1#archive">cli_3.0.0.tar.gz</a>
+            "#,
+        );
+
+        assert_eq!(
+            listing
+                .versions
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
+            ["1.0.0", "3.0.0"]
+        );
+    }
+
+    #[test]
+    fn falls_back_to_anchor_text_and_deduplicates_versions() {
+        let listing = CranPackageArchiveListing::parse(
+            "cli",
+            r#"
+                <a href="invalid.tar.gz">cli_1.0.0.tar.gz</a>
+                <a>cli_2.0.0.tar.gz</a>
+                <a href="cli_2.0.0.tar.gz">cli_2.0.0.tar.gz</a>
+            "#,
+        );
+
+        assert_eq!(
+            listing
+                .versions
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
+            ["1.0.0", "2.0.0"]
+        );
     }
 
     #[test]

--- a/src/repository/cran.rs
+++ b/src/repository/cran.rs
@@ -136,12 +136,7 @@ impl PackageRepository for CranRepository {
                         .map_err(|source| RepositoryError::Response {
                             source: Arc::new(source),
                         })?;
-                    let listing =
-                        text.parse::<http::CranPackageArchiveListing>()
-                            .map_err(|source| RepositoryError::InvalidData {
-                                resource: "CRAN package archive listing".to_string(),
-                                details: source.to_string(),
-                            })?;
+                    let listing = http::CranPackageArchiveListing::parse(package, &text);
 
                     Ok::<BTreeSet<Version>, RepositoryError>(listing.versions.into_iter().collect())
                 })


### PR DESCRIPTION
## Summary
- parse CRAN archive listings with a tolerant HTML parser across table, preformatted, and list layouts
- inspect both anchor targets and visible text while validating filenames against the requested package
- skip malformed or unrelated archive entries without discarding valid versions

## Mirror audit
- audited the 89 mirrors currently marked healthy in `CRAN_mirrors.csv`
- reached 82 package archive listings: 48 table, 29 preformatted, 4 custom/list anchor layouts, and one JavaScript-only shell
- all static listings exposed archive names through standard anchors; the JavaScript-only PKU transport is intentionally outside this parser-only change

## Testing
- `cargo fmt --check`
- `cargo clippy --all-targets` (passes with existing repository warnings)
- `cargo test` (all unit tests and 60/61 integration tests passed; one Docker image stream failure passed on exact retry)
- `cargo test --test sync runs_rpx_sync_restores_locked_versions`

Closes #102