### PR TITLE
ci: add cross-platform end-to-end tests

### DIFF
--- a/.github/workflows/cross-platform-e2e.yml
+++ b/.github/workflows/cross-platform-e2e.yml
@@ -1,0 +1,147 @@
+name: Cross-platform E2E
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  e2e-unix:
+    name: ${{ matrix.os }} / R ${{ matrix.r }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+        r:
+          - release
+          - oldrel
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.r }}
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build release binary
+        run: |
+          set -euo pipefail
+          cargo build --release --locked
+          echo "$GITHUB_WORKSPACE/target/release" >> "$GITHUB_PATH"
+
+      - name: Initialize and sync a project
+        run: |
+          set -euo pipefail
+          project="$RUNNER_TEMP/rpx-e2e"
+
+          rpx init "$project" --name rpxe2e
+          cd "$project"
+          rpx status
+          rpx sync
+          rpx run Rscript --vanilla -e 'library("rpxe2e", lib.loc = .libPaths()[1L])'
+
+      - name: Add and use packages
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP/rpx-e2e"
+
+          rpx add R6
+          rpx add digest
+          rpx status
+          rpx run Rscript --vanilla -e 'library("R6", lib.loc = .libPaths()[1L]); library("digest", lib.loc = .libPaths()[1L]); stopifnot(nzchar(digest("rpx")))'
+
+      - name: Remove packages
+        run: |
+          set -euo pipefail
+          cd "$RUNNER_TEMP/rpx-e2e"
+
+          rpx remove R6
+          rpx run Rscript --vanilla -e 'packages <- rownames(installed.packages(lib.loc = .libPaths()[1L], noCache = TRUE)); stopifnot(!("R6" %in% packages), "digest" %in% packages)'
+          rpx remove digest
+          rpx status
+
+  e2e-windows:
+    name: windows-latest / R ${{ matrix.r }}
+    runs-on: windows-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        r:
+          - release
+          - oldrel
+    defaults:
+      run:
+        shell: pwsh
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up R
+        uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.r }}
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Build release binary
+        run: |
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
+          cargo build --release --locked
+          Join-Path $env:GITHUB_WORKSPACE "target/release" |
+            Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Initialize and sync a project
+        run: |
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
+          $project = Join-Path $env:RUNNER_TEMP "rpx-e2e"
+
+          rpx init $project --name rpxe2e
+          Set-Location $project
+          rpx status
+          rpx sync
+          rpx run Rscript --vanilla -e 'library("rpxe2e", lib.loc = .libPaths()[1L])'
+
+      - name: Add and use packages
+        run: |
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
+          Set-Location (Join-Path $env:RUNNER_TEMP "rpx-e2e")
+
+          rpx add R6
+          rpx add digest
+          rpx status
+          rpx run Rscript --vanilla -e 'library("R6", lib.loc = .libPaths()[1L]); library("digest", lib.loc = .libPaths()[1L]); stopifnot(nzchar(digest("rpx")))'
+
+      - name: Remove packages
+        run: |
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
+          Set-Location (Join-Path $env:RUNNER_TEMP "rpx-e2e")
+
+          rpx remove R6
+          rpx run Rscript --vanilla -e 'packages <- rownames(installed.packages(lib.loc = .libPaths()[1L], noCache = TRUE)); stopifnot(!("R6" %in% packages), "digest" %in% packages)'
+          rpx remove digest
+          rpx status


### PR DESCRIPTION
## Summary
- build and exercise the release binary on Linux, macOS, and Windows
- test current and previous R releases
- cover project initialization, synchronization, package addition, usage, and removal

## Follow-up PR
The RcppParallel Windows installation failure tracked separately will also be addressed in a follow up PR after the new matrix establishes the failing Windows coverage.

## Testing
- GitHub Actions cross-platform E2E matrix

Closes RRE-22