### PR TITLE
fix: restore case-insensitive package sorting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2203,9 +2203,9 @@ dependencies = [
 
 [[package]]
 name = "r-dcf-syntax"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6918555af9df51dd5d31ad4a2c05c69db643e666f105edf6dddcfb8dde79121c"
+checksum = "9ca8a6582d1332a2db03b195cbe1b01bd85449f957e5808280a2618c7a8a2f45"
 dependencies = [
  "rowan",
  "thiserror",
@@ -2213,9 +2213,9 @@ dependencies = [
 
 [[package]]
 name = "r-description-parser"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a3032e92cf785f42955016f3a3ef985df7d460eb6b45f3e8a05541b6701481"
+checksum = "8effe2fcc99137a6232481939d44bf5bb45e280f62f70aeebc1614871e76cad1"
 dependencies = [
  "r-dcf-syntax",
  "r-metadata",
@@ -2236,9 +2236,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "r-metadata"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884f184e42abe54b64d310703de4fa29bd2e5ecd74082383ca3a12021f376dd3"
+checksum = "966af3631ab883376c46f9476d0f7a0f6bd0e711dc0aea235606f715fa8eb054"
 dependencies = [
  "thiserror",
  "url",
@@ -2246,9 +2246,9 @@ dependencies = [
 
 [[package]]
 name = "r-packages-parser"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b95edd105580d7884763cfd7f9b3110550c9b78792ebfb3c0d90453808807841"
+checksum = "ce231431649ce8079c2b1b19bc5ea9eaee564c47ba12fa257b2c406958209f06"
 dependencies = [
  "r-dcf-syntax",
  "r-metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,9 +31,9 @@ reqwest = { version = "0.13", default-features = false, features = ["blocking", 
 reqwest-middleware = "0.5"
 reqwest-tracing = "0.7"
 rpassword = "7.3.1"
-r-description = { package = "r-description-parser", version = "=0.1.0" }
-r-metadata = "=0.1.0"
-r-packages = { package = "r-packages-parser", version = "=0.1.0" }
+r-description = { package = "r-description-parser", version = "=0.2.0" }
+r-metadata = "=0.2.0"
+r-packages = { package = "r-packages-parser", version = "=0.2.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"

--- a/src/description.rs
+++ b/src/description.rs
@@ -942,7 +942,7 @@ mod tests {
     #[test]
     fn normalizes_description_and_preserves_repository_priority() {
         let description = Description::parse(
-            "Version: 1.0.0\nAdditional_repositories: https://z.example/repo\nImports: zed\nPackage: project\nRemotes: github::z/repo, cran::alpha\nImports: alpha, zed\nAdditional_repositories: https://a.example/repo, https://z.example/repo\nRemotes: github::z/repo\n",
+            "Version: 1.0.0\nAdditional_repositories: https://z.example/repo\nImports: zed\nPackage: project\nRemotes: github::z/repo, cran::alpha\nImports: alpha, AzureAuth, zed\nAdditional_repositories: https://a.example/repo, https://z.example/repo\nRemotes: github::z/repo\n",
         );
 
         let normalized = normalize_description(Path::new("."), &description)
@@ -950,7 +950,7 @@ mod tests {
 
         assert_eq!(
             normalized.to_string(),
-            "Package: project\nVersion: 1.0.0\nImports:\n    alpha,\n    zed\nRemotes:\n    github::z/repo,\n    cran::alpha\nAdditional_repositories:\n    https://z.example/repo,\n    https://a.example/repo\n"
+            "Package: project\nVersion: 1.0.0\nImports:\n    alpha,\n    AzureAuth,\n    zed\nRemotes:\n    github::z/repo,\n    cran::alpha\nAdditional_repositories:\n    https://z.example/repo,\n    https://a.example/repo\n"
         );
         assert_eq!(
             normalize_description(Path::new("."), &normalized)
@@ -1255,7 +1255,7 @@ mod tests {
 
         assert_eq!(
             relation_strings(description.depends_parsed()),
-            ["R (>= 4.2)", "keepDepends"]
+            ["keepDepends", "R (>= 4.2)"]
         );
         assert_eq!(
             relation_strings(description.imports_parsed()),
@@ -1275,7 +1275,7 @@ mod tests {
         );
         assert_eq!(
             description.to_string(),
-            "Package: project\nVersion: 1.0.0\nDepends:\n    R (>= 4.2),\n    keepDepends\nImports:\n    keepImports\nLinkingTo:\n    keepLinking\nSuggests:\n    keepSuggests\nEnhances: removeMe, keepEnhances, keepEnhances\n"
+            "Package: project\nVersion: 1.0.0\nDepends:\n    keepDepends,\n    R (>= 4.2)\nImports:\n    keepImports\nLinkingTo:\n    keepLinking\nSuggests:\n    keepSuggests\nEnhances: removeMe, keepEnhances, keepEnhances\n"
         );
     }
 

--- a/src/lockfile.rs
+++ b/src/lockfile.rs
@@ -367,9 +367,9 @@ mod tests {
                         "version": "6.2.3",
                         "repository": "https://api.rrepo.org/cran",
                         "dependencies": [
-                            "R (>= 4.1.0)",
                             "jsonlite (>= 1.8.0)",
-                            "methods"
+                            "methods",
+                            "R (>= 4.1.0)"
                         ]
                     }
                 }


### PR DESCRIPTION
## Summary
- bump the R metadata parser crates to 0.2.0
- restore case-insensitive relation ordering in normalized DESCRIPTION files
- update DESCRIPTION and lockfile ordering regression coverage

Upstream: https://github.com/rrepo-org/r-metadata-rs/issues/7

## Verification
- `cargo fmt --check`
- `cargo test --lib`
- `cargo clippy --all-targets --all-features`

Closes #119
Linear: RRE-29