### PR TITLE
feat: support non-installable projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ rpx add digest
 rpx run R
 ```
 
+Use `rpx init --type project` when the project only needs dependency
+management. This writes `Config/rpx/type: project` to `DESCRIPTION`; the
+project keeps its package name and version as its resolver namespace, but is
+not installed into the project library.
+
 Interactive initialization can add `testthat`, `roxygen2`, and `devtools` to
 `Suggests`. `rpx init` resolves the initial lockfile and syncs the project
 library before completing.
@@ -155,6 +160,10 @@ rpx sync --no-install-project
 Like `uv sync`, synchronization is exact: this flag removes an already
 installed copy of the project while retaining its dependencies. The resulting
 package set must still contain every non-base dependency required for installation.
+
+Projects with `Config/rpx/type: project` always use dependency-only
+synchronization. Their package namespace is unavailable during resolution, so
+the project and other packages cannot depend on it.
 
 Commit both `DESCRIPTION` and `rpx.lock`. Do not commit the project library or local cache; `rpx sync` recreates local state from the lockfile.
 
@@ -260,7 +269,7 @@ The full user guide lives at [rrepo.org](https://rrepo.org/documentation/overvie
 - `rpx.lock` records the resolved package set, package sources, and R runtime metadata.
 - `rpx lock` resolves dependencies from enabled repositories and writes `rpx.lock`; it does not install packages.
 - `rpx` prefers existing locked versions when they are still available from enabled repositories.
-- `rpx sync` installs the packages in `rpx.lock` and the current project into the project library by default.
+- `rpx sync` installs the packages in `rpx.lock` and installable current projects into the project library by default.
 - `--no-install-project` is available on `rpx add`, `rpx remove`, and `rpx sync` for dependency-only synchronization.
 - `rpx sync` tries Windows and macOS binary artifacts from enabled repositories when available, then falls back to the locked source artifact.
 - `rpx run` sets the R library path for the command it runs.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -19,7 +19,7 @@ pub struct Cli {
 pub enum Commands {
     #[command(
         about = "Initialize an R project",
-        long_about = "Initialize an R package project in a new or empty target directory."
+        long_about = "Initialize an installable R package or dependency-only project in a new or empty target directory."
     )]
     Init(InitArgs),
 
@@ -81,6 +81,13 @@ pub struct InitArgs {
     )]
     pub path: Option<PathBuf>,
 
+    #[arg(
+        long = "type",
+        value_enum,
+        help = "Project type; packages are installed into the project library"
+    )]
+    pub project_type: Option<InitProjectType>,
+
     #[arg(long, help = "Package name; defaults to the target directory name")]
     pub name: Option<String>,
 
@@ -98,6 +105,13 @@ pub struct InitArgs {
 
     #[arg(long, value_enum, help = "Package license")]
     pub license: Option<InitLicense>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum)]
+pub enum InitProjectType {
+    #[default]
+    Package,
+    Project,
 }
 
 #[derive(Args, Debug)]
@@ -341,6 +355,7 @@ mod tests {
             parse(&["rpx", "init"]),
             Commands::Init(InitArgs {
                 path: None,
+                project_type: None,
                 name: None,
                 title: None,
                 description: None,
@@ -358,6 +373,8 @@ mod tests {
                 "rpx",
                 "init",
                 "projects/example",
+                "--type",
+                "project",
                 "--name",
                 "example.pkg",
                 "--title",
@@ -373,6 +390,7 @@ mod tests {
             ]),
             Commands::Init(InitArgs {
                 path: Some(path),
+                project_type: Some(project_type),
                 name: Some(name),
                 title: Some(title),
                 description: Some(description),
@@ -380,6 +398,7 @@ mod tests {
                 author_email: Some(author_email),
                 license: Some(license),
             }) if path == PathBuf::from("projects/example")
+                && project_type == InitProjectType::Project
                 && name == "example.pkg"
                 && title == "Example Package"
                 && description == "An example package."

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,9 +1,9 @@
 use crate::{
-    cli::{InitArgs, InitLicense},
+    cli::{InitArgs, InitLicense, InitProjectType},
     description::{
         DependencyField, DependencyMutationError, DescriptionNormalizationError,
-        NamespaceWriteError, add_dependencies, normalize_description, set_base_repository,
-        write_namespace_if_missing,
+        NamespaceWriteError, ProjectType, add_dependencies, normalize_description,
+        set_base_repository, set_project_type, write_namespace_if_missing,
     },
     git,
     output::status,
@@ -348,7 +348,7 @@ pub(crate) async fn run(args: InitArgs) -> Result<(), Error> {
     let interactive = std::io::stdin().is_terminal() && std::io::stderr().is_terminal();
 
     if interactive {
-        cliclack::intro("Create an R package").map_err(Error::InteractivePrompt)?;
+        cliclack::intro("Create an R project").map_err(Error::InteractivePrompt)?;
     }
 
     let target = match args.path {
@@ -362,6 +362,12 @@ pub(crate) async fn run(args: InitArgs) -> Result<(), Error> {
             validate_target(&current_dir)?;
             current_dir.clone()
         }
+    };
+
+    let project_type = match args.project_type {
+        Some(project_type) => project_type,
+        None if interactive => prompt_for_project_type()?,
+        None => InitProjectType::Package,
     };
 
     let package_name = match args.name {
@@ -432,6 +438,7 @@ pub(crate) async fn run(args: InitArgs) -> Result<(), Error> {
         maintainer: &maintainer,
         license: license.description_value(),
     });
+    set_project_type(&mut description, project_type.into())?;
     configure_base_repository(&mut description, base_repository)?;
     let development_relations = development_relations(&development_packages);
     add_dependencies(
@@ -485,6 +492,32 @@ pub(crate) async fn run(args: InitArgs) -> Result<(), Error> {
     }
     status(next_step_message(&current_dir, &target));
     Ok(())
+}
+
+impl From<InitProjectType> for ProjectType {
+    fn from(project_type: InitProjectType) -> Self {
+        match project_type {
+            InitProjectType::Package => Self::Package,
+            InitProjectType::Project => Self::Project,
+        }
+    }
+}
+
+fn prompt_for_project_type() -> Result<InitProjectType, Error> {
+    cliclack::select("Project type")
+        .item(
+            InitProjectType::Package,
+            "Package",
+            "Build and install the project as an R package",
+        )
+        .item(
+            InitProjectType::Project,
+            "Project",
+            "Manage dependencies without installing the project",
+        )
+        .initial_value(InitProjectType::Package)
+        .interact()
+        .map_err(Error::InteractivePrompt)
 }
 
 fn prompt_for_target(current_dir: &Path) -> Result<PathBuf, Error> {
@@ -1173,6 +1206,28 @@ mod tests {
         ));
         assert!(rendered.contains("Author: Package Author [aut, cre]"));
         assert!(rendered.contains("Maintainer: Package Author <author@example.com>"));
+    }
+
+    #[test]
+    fn marks_dependency_only_projects_in_description() {
+        let mut description = initial_description(InitialDescriptionOptions {
+            package_name: "my.project",
+            title: "My Project",
+            description: "Describe what this project does.",
+            authors_at_r: r#"person(given = "Project Author", email = "author@example.com", role = c("aut", "cre"))"#,
+            author: "Project Author [aut, cre]",
+            maintainer: "Project Author <author@example.com>",
+            license: "MIT + file LICENSE",
+        });
+
+        set_project_type(&mut description, InitProjectType::Project.into()).unwrap();
+
+        assert_eq!(description.package().unwrap().as_str(), "my.project");
+        assert_eq!(description.version().unwrap().to_string(), "0.1.0");
+        assert_eq!(
+            crate::description::project_type(Path::new("."), &description).unwrap(),
+            ProjectType::Project
+        );
     }
 
     #[test]

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1225,7 +1225,7 @@ mod tests {
         assert_eq!(description.package().unwrap().as_str(), "my.project");
         assert_eq!(description.version().unwrap().to_string(), "0.1.0");
         assert_eq!(
-            crate::description::project_type(Path::new("."), &description).unwrap(),
+            crate::description::project_type(&description),
             ProjectType::Project
         );
     }

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -1,5 +1,5 @@
 use crate::{
-    description::{DescriptionParseError, project_type, root_package},
+    description::{DescriptionParseError, ProjectType, project_type, root_package},
     output::status,
     project::{
         LibraryMismatches, LoadProjectResolutionError, ProjectLoadError, library_mismatches,
@@ -54,9 +54,10 @@ pub(crate) async fn run() -> Result<(), Error> {
         .map(|(name, package)| (name.clone(), package.version.clone()))
         .collect::<BTreeMap<_, _>>();
     let (root_name, _) = root_package(&project.root, &project.description)?;
-    let optional_root = project_type(&project.root, &project.description)?
-        .is_installable()
-        .then_some(root_name);
+    let optional_root = match project_type(&project.description) {
+        ProjectType::Package => Some(root_name),
+        ProjectType::Project => None,
+    };
 
     let project_library = project_library_path(&project.root);
     let installed = installed_packages(&project_library).await?;

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -1,5 +1,5 @@
 use crate::{
-    description::{DescriptionParseError, root_package},
+    description::{DescriptionParseError, project_type, root_package},
     output::status,
     project::{
         LibraryMismatches, LoadProjectResolutionError, ProjectLoadError, library_mismatches,
@@ -54,10 +54,13 @@ pub(crate) async fn run() -> Result<(), Error> {
         .map(|(name, package)| (name.clone(), package.version.clone()))
         .collect::<BTreeMap<_, _>>();
     let (root_name, _) = root_package(&project.root, &project.description)?;
+    let optional_root = project_type(&project.root, &project.description)?
+        .is_installable()
+        .then_some(root_name);
 
     let project_library = project_library_path(&project.root);
     let installed = installed_packages(&project_library).await?;
-    let mismatches = library_mismatches(&expected_packages, &installed, Some(&root_name));
+    let mismatches = library_mismatches(&expected_packages, &installed, optional_root.as_deref());
 
     if !mismatches.is_exact() {
         return Err(Error::OutOfSync { mismatches });

--- a/src/description.rs
+++ b/src/description.rs
@@ -30,12 +30,6 @@ pub enum ProjectType {
     Project,
 }
 
-impl ProjectType {
-    pub fn is_installable(self) -> bool {
-        self == Self::Package
-    }
-}
-
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum DependencyField {
     Depends,
@@ -240,62 +234,29 @@ pub fn root_package(
     )
 }
 
-pub fn project_type(
-    path: &Path,
-    description: &Description,
-) -> Result<ProjectType, DescriptionParseError> {
-    let fields = description.fields(PROJECT_TYPE_FIELD).collect::<Vec<_>>();
-    let Some(field) = fields.last() else {
-        return Ok(ProjectType::Package);
-    };
-    if fields.len() > 1 {
-        return Err(DescriptionParseError::new(
-            path.join(DESCRIPTION_NAME).display().to_string(),
-            description.to_string(),
-            fields
-                .into_iter()
-                .skip(1)
-                .map(|field| {
-                    let range = field.value().source_range();
-                    DescriptionParseIssue::positioned(
-                        std::io::Error::other("project type field is declared more than once"),
-                        range.start..range.end,
-                    )
-                })
-                .collect(),
-        ));
+pub fn project_type(description: &Description) -> ProjectType {
+    match description.field(PROJECT_TYPE_FIELD) {
+        Some(field) if field.value().as_str() == "project" => ProjectType::Project,
+        _ => ProjectType::Package,
     }
-    let value = field.value();
-    let project_type = match value.as_str() {
-        "package" => ProjectType::Package,
-        "project" => ProjectType::Project,
-        value => {
-            let range = field.value().source_range();
-            return Err(DescriptionParseError::new(
-                path.join(DESCRIPTION_NAME).display().to_string(),
-                description.to_string(),
-                vec![DescriptionParseIssue::positioned(
-                    std::io::Error::other(format!(
-                        "invalid project type `{value}`; expected `package` or `project`"
-                    )),
-                    range.start..range.end,
-                )],
-            ));
-        }
-    };
-    Ok(project_type)
 }
 
 pub fn set_project_type(
     description: &mut Description,
     project_type: ProjectType,
 ) -> Result<(), EditError> {
-    if project_type == ProjectType::Package {
-        return Ok(());
+    match project_type {
+        ProjectType::Package => {
+            if description.field(PROJECT_TYPE_FIELD).is_some() {
+                *description = description.remove_all(PROJECT_TYPE_FIELD)?;
+            }
+        }
+        ProjectType::Project => {
+            let name = FieldName::new(PROJECT_TYPE_FIELD).expect("constant field name is valid");
+            let value = LogicalValue::new("project").expect("constant field value is valid");
+            *description = description.set_field(&name, &value)?;
+        }
     }
-    let name = FieldName::new(PROJECT_TYPE_FIELD).expect("constant field name is valid");
-    let value = LogicalValue::new("project").expect("constant field value is valid");
-    *description = description.set_field(&name, &value)?;
     Ok(())
 }
 
@@ -1068,10 +1029,7 @@ mod tests {
     fn project_type_defaults_to_installable_package() {
         let description = Description::parse("Package: project\nVersion: 1.0.0\n");
 
-        assert_eq!(
-            project_type(Path::new("."), &description).unwrap(),
-            ProjectType::Package
-        );
+        assert_eq!(project_type(&description), ProjectType::Package);
     }
 
     #[test]
@@ -1079,36 +1037,36 @@ mod tests {
         let mut description = Description::parse("Package: project\nVersion: 1.0.0\n");
         set_project_type(&mut description, ProjectType::Project).unwrap();
 
-        assert_eq!(
-            project_type(Path::new("."), &description).unwrap(),
-            ProjectType::Project
-        );
+        assert_eq!(project_type(&description), ProjectType::Project);
         assert!(description.to_string().contains("Config/rpx/type: project"));
     }
 
     #[test]
-    fn rejects_unknown_project_type() {
+    fn treats_unknown_project_type_as_package() {
         let description =
             Description::parse("Package: project\nVersion: 1.0.0\nConfig/rpx/type: application\n");
 
-        let error = project_type(Path::new("."), &description).unwrap_err();
-        assert_eq!(
-            error.messages(),
-            ["invalid project type `application`; expected `package` or `project`"]
-        );
+        assert_eq!(project_type(&description), ProjectType::Package);
     }
 
     #[test]
-    fn rejects_duplicate_project_type_fields() {
+    fn project_type_uses_field_precedence() {
         let description = Description::parse(
             "Package: project\nVersion: 1.0.0\nConfig/rpx/type: project\nConfig/rpx/type: package\n",
         );
 
-        let error = project_type(Path::new("."), &description).unwrap_err();
-        assert_eq!(
-            error.messages(),
-            ["project type field is declared more than once"]
-        );
+        assert_eq!(project_type(&description), ProjectType::Package);
+    }
+
+    #[test]
+    fn setting_package_type_removes_existing_project_type() {
+        let mut description =
+            Description::parse("Package: project\nVersion: 1.0.0\nConfig/rpx/type: project\n");
+
+        set_project_type(&mut description, ProjectType::Package).unwrap();
+
+        assert_eq!(project_type(&description), ProjectType::Package);
+        assert!(description.field(PROJECT_TYPE_FIELD).is_none());
     }
 
     #[test]

--- a/src/description.rs
+++ b/src/description.rs
@@ -21,6 +21,20 @@ use crate::repository::{
 
 pub const DESCRIPTION_NAME: &str = "DESCRIPTION";
 pub const BASE_REPOSITORY_FIELD: &str = "Config/rpx/base-repository";
+pub const PROJECT_TYPE_FIELD: &str = "Config/rpx/type";
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum ProjectType {
+    #[default]
+    Package,
+    Project,
+}
+
+impl ProjectType {
+    pub fn is_installable(self) -> bool {
+        self == Self::Package
+    }
+}
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum DependencyField {
@@ -224,6 +238,65 @@ pub fn root_package(
         path.join(DESCRIPTION_NAME).display().to_string(),
         description,
     )
+}
+
+pub fn project_type(
+    path: &Path,
+    description: &Description,
+) -> Result<ProjectType, DescriptionParseError> {
+    let fields = description.fields(PROJECT_TYPE_FIELD).collect::<Vec<_>>();
+    let Some(field) = fields.last() else {
+        return Ok(ProjectType::Package);
+    };
+    if fields.len() > 1 {
+        return Err(DescriptionParseError::new(
+            path.join(DESCRIPTION_NAME).display().to_string(),
+            description.to_string(),
+            fields
+                .into_iter()
+                .skip(1)
+                .map(|field| {
+                    let range = field.value().source_range();
+                    DescriptionParseIssue::positioned(
+                        std::io::Error::other("project type field is declared more than once"),
+                        range.start..range.end,
+                    )
+                })
+                .collect(),
+        ));
+    }
+    let value = field.value();
+    let project_type = match value.as_str() {
+        "package" => ProjectType::Package,
+        "project" => ProjectType::Project,
+        value => {
+            let range = field.value().source_range();
+            return Err(DescriptionParseError::new(
+                path.join(DESCRIPTION_NAME).display().to_string(),
+                description.to_string(),
+                vec![DescriptionParseIssue::positioned(
+                    std::io::Error::other(format!(
+                        "invalid project type `{value}`; expected `package` or `project`"
+                    )),
+                    range.start..range.end,
+                )],
+            ));
+        }
+    };
+    Ok(project_type)
+}
+
+pub fn set_project_type(
+    description: &mut Description,
+    project_type: ProjectType,
+) -> Result<(), EditError> {
+    if project_type == ProjectType::Package {
+        return Ok(());
+    }
+    let name = FieldName::new(PROJECT_TYPE_FIELD).expect("constant field name is valid");
+    let value = LogicalValue::new("project").expect("constant field value is valid");
+    *description = description.set_field(&name, &value)?;
+    Ok(())
 }
 
 pub(crate) fn description_identity(
@@ -988,6 +1061,53 @@ mod tests {
         assert_eq!(
             fs::read_to_string(namespace).expect("NAMESPACE should be readable"),
             "export(example)\n"
+        );
+    }
+
+    #[test]
+    fn project_type_defaults_to_installable_package() {
+        let description = Description::parse("Package: project\nVersion: 1.0.0\n");
+
+        assert_eq!(
+            project_type(Path::new("."), &description).unwrap(),
+            ProjectType::Package
+        );
+    }
+
+    #[test]
+    fn parses_and_sets_dependency_only_project_type() {
+        let mut description = Description::parse("Package: project\nVersion: 1.0.0\n");
+        set_project_type(&mut description, ProjectType::Project).unwrap();
+
+        assert_eq!(
+            project_type(Path::new("."), &description).unwrap(),
+            ProjectType::Project
+        );
+        assert!(description.to_string().contains("Config/rpx/type: project"));
+    }
+
+    #[test]
+    fn rejects_unknown_project_type() {
+        let description =
+            Description::parse("Package: project\nVersion: 1.0.0\nConfig/rpx/type: application\n");
+
+        let error = project_type(Path::new("."), &description).unwrap_err();
+        assert_eq!(
+            error.messages(),
+            ["invalid project type `application`; expected `package` or `project`"]
+        );
+    }
+
+    #[test]
+    fn rejects_duplicate_project_type_fields() {
+        let description = Description::parse(
+            "Package: project\nVersion: 1.0.0\nConfig/rpx/type: project\nConfig/rpx/type: package\n",
+        );
+
+        let error = project_type(Path::new("."), &description).unwrap_err();
+        assert_eq!(
+            error.messages(),
+            ["project type field is declared more than once"]
         );
     }
 

--- a/src/project.rs
+++ b/src/project.rs
@@ -21,7 +21,7 @@ use crate::{
         ConfiguredRepository, DESCRIPTION_NAME, DependencyField, DependencyMutationError,
         DescriptionParseError, DescriptionReadError, RepositoriesFromDescriptionError,
         add_dependencies, configured_repositories, dependencies_from_fields, project_dependencies,
-        project_type, read_description, repositories_from_description, root_package,
+        project_type, read_description, repositories_from_description,
     },
     git,
     lockfile::{self, LOCKFILE_NAME, Lockfile, LockfileReadError, read_lockfile},
@@ -336,14 +336,6 @@ pub enum LockedResolutionFailure {
         locked: semver::Version,
         current: semver::Version,
     },
-
-    #[error("package `{package}` depends on unavailable project namespace `{namespace}`")]
-    #[diagnostic(code(rpx::project::unavailable_project_namespace))]
-    UnavailableProjectNamespace { package: String, namespace: String },
-
-    #[error("locked package `{namespace}` occupies the unavailable project namespace")]
-    #[diagnostic(code(rpx::project::locked_project_namespace))]
-    LockedProjectNamespace { namespace: String },
 }
 
 pub fn validate_locked_resolution(
@@ -352,9 +344,6 @@ pub fn validate_locked_resolution(
     r_version: &semver::Version,
     lockfile: &Lockfile,
 ) -> Result<(), LockedResolutionError> {
-    let (root_name, _) = root_package(project_path, description)?;
-    let unavailable_namespace =
-        (!project_type(project_path, description)?.is_installable()).then_some(root_name);
     let repositories = configured_repositories(project_path, description)?;
     let repository_validation = lockfile
         .repos
@@ -395,26 +384,6 @@ pub fn validate_locked_resolution(
             .iter()
             .any(|result| matches!(result, Ok(false)));
     let roots = project_dependencies(project_path, description)?;
-    let unavailable_dependents = unavailable_namespace
-        .as_ref()
-        .map(|namespace| {
-            roots
-                .iter()
-                .filter(|relation| relation.package() == namespace)
-                .map(|_| namespace.clone())
-                .chain(lockfile.packages.iter().filter_map(|(package, metadata)| {
-                    metadata
-                        .dependencies
-                        .iter()
-                        .any(|relation| relation.package() == namespace)
-                        .then(|| package.clone())
-                }))
-                .collect::<BTreeSet<_>>()
-        })
-        .unwrap_or_default();
-    let locked_project_namespace = unavailable_namespace
-        .as_ref()
-        .filter(|namespace| lockfile.packages.contains_key(namespace.as_str()));
     let failures = repository_validation
         .into_iter()
         .filter_map(Result::err)
@@ -429,19 +398,6 @@ pub fn validate_locked_resolution(
                 current: r_version.clone(),
             }),
         )
-        .chain(locked_project_namespace.map(|namespace| {
-            LockedResolutionFailure::LockedProjectNamespace {
-                namespace: namespace.clone(),
-            }
-        }))
-        .chain(unavailable_dependents.into_iter().map(|package| {
-            LockedResolutionFailure::UnavailableProjectNamespace {
-                package,
-                namespace: unavailable_namespace
-                    .clone()
-                    .expect("unavailable dependents require a project namespace"),
-            }
-        }))
         .collect::<Vec<_>>();
 
     if failures.is_empty() {
@@ -852,8 +808,7 @@ pub(crate) async fn resolve_project(
     let previous = read_previous_lockfile(&project.root)?;
     let r_version = r_version_async().await?;
     let requirements = project_dependencies(&project.root, &project.description)?;
-    let root_installable =
-        crate::description::project_type(&project.root, &project.description)?.is_installable();
+    let root_type = project_type(&project.description);
 
     let repositories = match (policy, previous.as_ref()) {
         (ResolutionPolicy::ReuseIfValid, Some(lockfile)) => {
@@ -913,7 +868,7 @@ pub(crate) async fn resolve_project(
     let selected = resolve_from_registry(
         repositories.clone(),
         Arc::clone(&root),
-        root_installable,
+        root_type,
         requirements.clone(),
         preferred_versions,
     )
@@ -1736,33 +1691,6 @@ mod tests {
         let (path, description, r_version, lockfile) = validation_fixture();
         validate_locked_resolution(&path, &description, &r_version, &lockfile)
             .expect("matching resolution should validate");
-    }
-
-    #[test]
-    fn rejects_locked_dependencies_on_project_namespace() {
-        let (path, description, r_version, mut lockfile) = validation_fixture();
-        let description = Description::parse(&format!("{}Config/rpx/type: project\n", description));
-        lockfile.packages.insert(
-            "dependent".into(),
-            package("1.0.0", lockfile.repos[0].url().as_str(), &["project"]),
-        );
-        lockfile.packages.insert(
-            "project".into(),
-            package("9.0.0", lockfile.repos[0].url().as_str(), &[]),
-        );
-
-        let failures = failures(&path, &description, &r_version, &lockfile);
-
-        assert!(failures.iter().any(|failure| matches!(
-            failure,
-            LockedResolutionFailure::UnavailableProjectNamespace { package, namespace }
-                if package == "dependent" && namespace == "project"
-        )));
-        assert!(failures.iter().any(|failure| matches!(
-            failure,
-            LockedResolutionFailure::LockedProjectNamespace { namespace }
-                if namespace == "project"
-        )));
     }
 
     #[test]

--- a/src/project.rs
+++ b/src/project.rs
@@ -21,7 +21,7 @@ use crate::{
         ConfiguredRepository, DESCRIPTION_NAME, DependencyField, DependencyMutationError,
         DescriptionParseError, DescriptionReadError, RepositoriesFromDescriptionError,
         add_dependencies, configured_repositories, dependencies_from_fields, project_dependencies,
-        read_description, repositories_from_description,
+        project_type, read_description, repositories_from_description, root_package,
     },
     git,
     lockfile::{self, LOCKFILE_NAME, Lockfile, LockfileReadError, read_lockfile},
@@ -336,6 +336,14 @@ pub enum LockedResolutionFailure {
         locked: semver::Version,
         current: semver::Version,
     },
+
+    #[error("package `{package}` depends on unavailable project namespace `{namespace}`")]
+    #[diagnostic(code(rpx::project::unavailable_project_namespace))]
+    UnavailableProjectNamespace { package: String, namespace: String },
+
+    #[error("locked package `{namespace}` occupies the unavailable project namespace")]
+    #[diagnostic(code(rpx::project::locked_project_namespace))]
+    LockedProjectNamespace { namespace: String },
 }
 
 pub fn validate_locked_resolution(
@@ -344,6 +352,9 @@ pub fn validate_locked_resolution(
     r_version: &semver::Version,
     lockfile: &Lockfile,
 ) -> Result<(), LockedResolutionError> {
+    let (root_name, _) = root_package(project_path, description)?;
+    let unavailable_namespace =
+        (!project_type(project_path, description)?.is_installable()).then_some(root_name);
     let repositories = configured_repositories(project_path, description)?;
     let repository_validation = lockfile
         .repos
@@ -384,6 +395,26 @@ pub fn validate_locked_resolution(
             .iter()
             .any(|result| matches!(result, Ok(false)));
     let roots = project_dependencies(project_path, description)?;
+    let unavailable_dependents = unavailable_namespace
+        .as_ref()
+        .map(|namespace| {
+            roots
+                .iter()
+                .filter(|relation| relation.package() == namespace)
+                .map(|_| namespace.clone())
+                .chain(lockfile.packages.iter().filter_map(|(package, metadata)| {
+                    metadata
+                        .dependencies
+                        .iter()
+                        .any(|relation| relation.package() == namespace)
+                        .then(|| package.clone())
+                }))
+                .collect::<BTreeSet<_>>()
+        })
+        .unwrap_or_default();
+    let locked_project_namespace = unavailable_namespace
+        .as_ref()
+        .filter(|namespace| lockfile.packages.contains_key(namespace.as_str()));
     let failures = repository_validation
         .into_iter()
         .filter_map(Result::err)
@@ -398,6 +429,19 @@ pub fn validate_locked_resolution(
                 current: r_version.clone(),
             }),
         )
+        .chain(locked_project_namespace.map(|namespace| {
+            LockedResolutionFailure::LockedProjectNamespace {
+                namespace: namespace.clone(),
+            }
+        }))
+        .chain(unavailable_dependents.into_iter().map(|package| {
+            LockedResolutionFailure::UnavailableProjectNamespace {
+                package,
+                namespace: unavailable_namespace
+                    .clone()
+                    .expect("unavailable dependents require a project namespace"),
+            }
+        }))
         .collect::<Vec<_>>();
 
     if failures.is_empty() {
@@ -808,6 +852,8 @@ pub(crate) async fn resolve_project(
     let previous = read_previous_lockfile(&project.root)?;
     let r_version = r_version_async().await?;
     let requirements = project_dependencies(&project.root, &project.description)?;
+    let root_installable =
+        crate::description::project_type(&project.root, &project.description)?.is_installable();
 
     let repositories = match (policy, previous.as_ref()) {
         (ResolutionPolicy::ReuseIfValid, Some(lockfile)) => {
@@ -867,6 +913,7 @@ pub(crate) async fn resolve_project(
     let selected = resolve_from_registry(
         repositories.clone(),
         Arc::clone(&root),
+        root_installable,
         requirements.clone(),
         preferred_versions,
     )
@@ -1689,6 +1736,33 @@ mod tests {
         let (path, description, r_version, lockfile) = validation_fixture();
         validate_locked_resolution(&path, &description, &r_version, &lockfile)
             .expect("matching resolution should validate");
+    }
+
+    #[test]
+    fn rejects_locked_dependencies_on_project_namespace() {
+        let (path, description, r_version, mut lockfile) = validation_fixture();
+        let description = Description::parse(&format!("{}Config/rpx/type: project\n", description));
+        lockfile.packages.insert(
+            "dependent".into(),
+            package("1.0.0", lockfile.repos[0].url().as_str(), &["project"]),
+        );
+        lockfile.packages.insert(
+            "project".into(),
+            package("9.0.0", lockfile.repos[0].url().as_str(), &[]),
+        );
+
+        let failures = failures(&path, &description, &r_version, &lockfile);
+
+        assert!(failures.iter().any(|failure| matches!(
+            failure,
+            LockedResolutionFailure::UnavailableProjectNamespace { package, namespace }
+                if package == "dependent" && namespace == "project"
+        )));
+        assert!(failures.iter().any(|failure| matches!(
+            failure,
+            LockedResolutionFailure::LockedProjectNamespace { namespace }
+                if namespace == "project"
+        )));
     }
 
     #[test]

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -106,6 +106,7 @@ impl std::fmt::Display for PackageVersion {
 pub(crate) struct RDependencyProvider {
     repositories: Vec<Arc<dyn PackageRepository>>,
     root: Arc<LocalRepository>,
+    root_installable: bool,
     root_dependencies: DependencyConstraints<String, Ranges<PackageVersion>>,
     preferred_versions: BTreeMap<String, Version>,
     base_packages: BTreeSet<String>,
@@ -116,6 +117,7 @@ impl RDependencyProvider {
     fn new(
         repositories: Vec<Arc<dyn PackageRepository>>,
         root: Arc<LocalRepository>,
+        root_installable: bool,
         root_dependencies: DependencyConstraints<String, Ranges<PackageVersion>>,
         preferred_versions: BTreeMap<String, Version>,
         base_packages: BTreeSet<String>,
@@ -123,6 +125,7 @@ impl RDependencyProvider {
         Self {
             repositories,
             root,
+            root_installable,
             root_dependencies,
             preferred_versions,
             base_packages,
@@ -285,6 +288,7 @@ impl DependencyProvider for RDependencyProvider {
             format!("{package} {} from {}", version.version, version.repository),
             &description,
             &self.base_packages,
+            (!self.root_installable).then_some(root_package.as_str()),
         );
         let Dependencies::Available(constraints) = dependencies else {
             return Ok(dependencies);
@@ -380,11 +384,14 @@ fn dependencies_from_description(
     source_name: impl Into<String>,
     description: &Description,
     base_packages: &BTreeSet<String>,
+    unavailable_package: Option<&str>,
 ) -> Dependencies<String, Ranges<PackageVersion>, String> {
     match required_dependencies(source_name, description) {
-        Ok(relations) => {
-            Dependencies::Available(dependency_ranges_from_relations(&relations, base_packages))
-        }
+        Ok(relations) => Dependencies::Available(dependency_ranges_from_relations(
+            &relations,
+            base_packages,
+            unavailable_package,
+        )),
         Err(error) => Dependencies::Unavailable(format!(
             "invalid dependency metadata: {}",
             error.messages().join("; ")
@@ -429,6 +436,7 @@ fn package_version_range_from_relation(relation: &Relation) -> Ranges<PackageVer
 pub(crate) async fn resolve_from_registry(
     repositories: Vec<Arc<dyn PackageRepository>>,
     root: Arc<LocalRepository>,
+    root_installable: bool,
     root_relations: BTreeSet<Relation>,
     preferred_versions: BTreeMap<String, Version>,
 ) -> Result<BTreeMap<String, PackageVersion>, ResolutionError> {
@@ -454,10 +462,15 @@ pub(crate) async fn resolve_from_registry(
         let (root_package, root_version) = tokio::runtime::Handle::current()
             .block_on(root.package())
             .map_err(ProviderError::from)?;
-        let root_dependencies = dependency_ranges_from_relations(&root_relations, &base_packages);
+        let root_dependencies = dependency_ranges_from_relations(
+            &root_relations,
+            &base_packages,
+            (!root_installable).then_some(root_package.as_str()),
+        );
         let provider = RDependencyProvider::new(
             repositories,
             root,
+            root_installable,
             root_dependencies,
             preferred_versions,
             base_packages,
@@ -482,14 +495,22 @@ pub(crate) async fn resolve_from_registry(
 fn dependency_ranges_from_relations(
     relations: &BTreeSet<Relation>,
     base_packages: &BTreeSet<String>,
+    unavailable_package: Option<&str>,
 ) -> DependencyConstraints<String, Ranges<PackageVersion>> {
     relations
         .iter()
-        .filter(|relation| !base_packages.contains(relation.package()))
+        .filter(|relation| {
+            unavailable_package == Some(relation.package())
+                || !base_packages.contains(relation.package())
+        })
         .fold(
             DependencyConstraints::default(),
             |mut dependencies, relation| {
-                let range = package_version_range_from_relation(relation);
+                let range = if unavailable_package == Some(relation.package()) {
+                    Ranges::empty()
+                } else {
+                    package_version_range_from_relation(relation)
+                };
                 dependencies
                     .entry(relation.package().to_string())
                     .and_modify(|existing| *existing = existing.intersection(&range))
@@ -612,7 +633,7 @@ mod tests {
         );
 
         let Dependencies::Unavailable(reason) =
-            dependencies_from_description("example 1.0.0", &description, &BTreeSet::new())
+            dependencies_from_description("example 1.0.0", &description, &BTreeSet::new(), None)
         else {
             panic!("malformed Imports should make the package version unavailable");
         };
@@ -654,6 +675,7 @@ mod tests {
         let selected = resolve_from_registry(
             vec![Arc::new(remote_repository)],
             local_repository,
+            true,
             BTreeSet::from([Relation::any("example").expect("valid example relation")]),
             BTreeMap::new(),
         )
@@ -670,7 +692,7 @@ mod tests {
         );
 
         let Dependencies::Available(dependencies) =
-            dependencies_from_description("example 1.0.0", &description, &BTreeSet::new())
+            dependencies_from_description("example 1.0.0", &description, &BTreeSet::new(), None)
         else {
             panic!("malformed Suggests should not make the package version unavailable");
         };
@@ -684,7 +706,7 @@ mod tests {
         );
 
         let Dependencies::Available(dependencies) =
-            dependencies_from_description("example 1.0.0", &description, &BTreeSet::new())
+            dependencies_from_description("example 1.0.0", &description, &BTreeSet::new(), None)
         else {
             panic!("hard dependencies should be available");
         };
@@ -699,6 +721,36 @@ mod tests {
         assert!(!range.contains(&candidate("0.9.0")));
         assert!(range.contains(&candidate("1.5.0")));
         assert!(!range.contains(&candidate("2.0.0")));
+    }
+
+    #[test]
+    fn project_namespace_is_unsatisfiable_in_root_and_transitive_dependencies() {
+        let project_relation = Relation::any("project").expect("valid project relation");
+        let root_dependencies = dependency_ranges_from_relations(
+            &BTreeSet::from([project_relation]),
+            &BTreeSet::new(),
+            Some("project"),
+        );
+        assert_eq!(root_dependencies["project"], Ranges::empty());
+
+        let description =
+            Description::parse("Package: dependent\nVersion: 1.0.0\nImports: project\n");
+        let Dependencies::Available(transitive_dependencies) = dependencies_from_description(
+            "dependent 1.0.0",
+            &description,
+            &BTreeSet::new(),
+            Some("project"),
+        ) else {
+            panic!("dependency metadata should be available");
+        };
+        assert_eq!(transitive_dependencies["project"], Ranges::empty());
+
+        let base_namespace = dependency_ranges_from_relations(
+            &BTreeSet::from([Relation::any("stats").expect("valid base package relation")]),
+            &BTreeSet::from(["stats".to_string()]),
+            Some("stats"),
+        );
+        assert_eq!(base_namespace["stats"], Ranges::empty());
     }
 
     #[tokio::test]
@@ -857,6 +909,7 @@ mod tests {
         let provider = RDependencyProvider::new(
             vec![remote_repository.clone()],
             local_repository,
+            true,
             DependencyConstraints::default(),
             BTreeMap::new(),
             BTreeSet::new(),
@@ -890,6 +943,7 @@ mod tests {
         let provider = RDependencyProvider::new(
             vec![remote_repository.clone()],
             local_repository,
+            true,
             DependencyConstraints::default(),
             BTreeMap::new(),
             BTreeSet::new(),
@@ -919,10 +973,11 @@ mod tests {
         )
         .expect("valid suggested relation");
         let roots = BTreeSet::from([suggested]);
-        let root_dependencies = dependency_ranges_from_relations(&roots, &BTreeSet::new());
+        let root_dependencies = dependency_ranges_from_relations(&roots, &BTreeSet::new(), None);
         let provider = RDependencyProvider::new(
             Vec::new(),
             Arc::clone(&local_repository),
+            true,
             root_dependencies,
             BTreeMap::new(),
             BTreeSet::new(),
@@ -963,6 +1018,7 @@ mod tests {
         let selected = resolve_from_registry(
             vec![remote_repository.clone()],
             local_repository,
+            true,
             BTreeSet::from([Relation::any("testBasePackage").expect("valid base relation")]),
             BTreeMap::new(),
         )
@@ -985,6 +1041,7 @@ mod tests {
         let selected = resolve_from_registry(
             vec![remote_repository.clone()],
             local_repository,
+            true,
             BTreeSet::new(),
             BTreeMap::new(),
         )
@@ -996,6 +1053,54 @@ mod tests {
             BTreeMap::from([("project".to_string(), root_version)])
         );
         assert_eq!(remote_repository.package_queries.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn package_depending_on_project_namespace_is_unsatisfiable() {
+        let local_repository = local_repository("project", "1.0.0");
+        let mut metadata_repository = TestRepository::empty("remote metadata");
+        metadata_repository.descriptions.insert(
+            (
+                "dependent".to_string(),
+                Version::from_str("1.0.0").expect("valid test version"),
+            ),
+            Arc::new(Description::parse(
+                "Package: dependent\nVersion: 1.0.0\nImports: project\n",
+            )),
+        );
+        let metadata: Arc<dyn PackageRepository> = Arc::new(metadata_repository);
+        let mut remote_repository = TestRepository::empty("remote index");
+        remote_repository.packages.insert(
+            "dependent".to_string(),
+            version("1.0.0", Arc::clone(&metadata)),
+        );
+        remote_repository
+            .packages
+            .insert("project".to_string(), version("9.0.0", metadata));
+        let remote_repository = Arc::new(remote_repository);
+
+        let error = resolve_from_registry(
+            vec![remote_repository.clone()],
+            local_repository,
+            false,
+            BTreeSet::from([Relation::any("dependent").expect("valid dependent relation")]),
+            BTreeMap::new(),
+        )
+        .await
+        .expect_err("dependency on project namespace should be unsatisfiable");
+
+        assert!(matches!(
+            error,
+            ResolutionError::PubGrub(PubGrubError::NoSolution(_))
+        ));
+        assert!(
+            !remote_repository
+                .version_queries
+                .lock()
+                .expect("version query lock should not be poisoned")
+                .iter()
+                .any(|package| package == "project")
+        );
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -1045,6 +1150,7 @@ mod tests {
         let selected = resolve_from_registry(
             vec![remote_repository.clone()],
             local_repository,
+            true,
             BTreeSet::from([Relation::new(
                 "testthat",
                 VersionRequirement::GreaterThanEqual(RequirementVersion::Version(

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -2,6 +2,7 @@ use pubgrub::{
     Dependencies, DependencyConstraints, DependencyProvider, PackageResolutionStatistics,
     PubGrubError, Ranges, resolve,
 };
+#[cfg(test)]
 use r_description::Description;
 use r_metadata::{Relation, RequirementVersion, Version, VersionRequirement};
 use std::{
@@ -14,7 +15,7 @@ use tracing::Instrument;
 use tracing_indicatif::span_ext::IndicatifSpanExt;
 
 use crate::{
-    description::required_dependencies,
+    description::{ProjectType, required_dependencies},
     r::{BasePackagesError, base_packages},
     repository::{LocalRepository, PackageRepository, RepositoryError, built_in_repository},
 };
@@ -106,8 +107,8 @@ impl std::fmt::Display for PackageVersion {
 pub(crate) struct RDependencyProvider {
     repositories: Vec<Arc<dyn PackageRepository>>,
     root: Arc<LocalRepository>,
-    root_installable: bool,
-    root_dependencies: DependencyConstraints<String, Ranges<PackageVersion>>,
+    root_type: ProjectType,
+    root_relations: BTreeSet<Relation>,
     preferred_versions: BTreeMap<String, Version>,
     base_packages: BTreeSet<String>,
     description_prefetch_permits: Arc<Semaphore>,
@@ -117,16 +118,16 @@ impl RDependencyProvider {
     fn new(
         repositories: Vec<Arc<dyn PackageRepository>>,
         root: Arc<LocalRepository>,
-        root_installable: bool,
-        root_dependencies: DependencyConstraints<String, Ranges<PackageVersion>>,
+        root_type: ProjectType,
+        root_relations: BTreeSet<Relation>,
         preferred_versions: BTreeMap<String, Version>,
         base_packages: BTreeSet<String>,
     ) -> Self {
         Self {
             repositories,
             root,
-            root_installable,
-            root_dependencies,
+            root_type,
+            root_relations,
             preferred_versions,
             base_packages,
             description_prefetch_permits: Arc::new(Semaphore::new(DESCRIPTION_PREFETCH_WORKERS)),
@@ -218,6 +219,26 @@ impl RDependencyProvider {
             .block_on(self.root.package())
             .map_err(Into::into)
     }
+
+    fn dependency_ranges(
+        &self,
+        relations: &BTreeSet<Relation>,
+    ) -> Result<DependencyConstraints<String, Ranges<PackageVersion>>, ProviderError> {
+        let mut constraints = dependency_ranges_from_relations(relations, &self.base_packages);
+        match self.root_type {
+            ProjectType::Package => {}
+            ProjectType::Project => {
+                let (root_package, _) = self.root_package()?;
+                if relations
+                    .iter()
+                    .any(|relation| relation.package() == root_package)
+                {
+                    constraints.insert(root_package, Ranges::empty());
+                }
+            }
+        }
+        Ok(constraints)
+    }
 }
 
 impl DependencyProvider for RDependencyProvider {
@@ -262,11 +283,7 @@ impl DependencyProvider for RDependencyProvider {
     ) -> Result<Dependencies<Self::P, Self::VS, Self::M>, Self::Err> {
         let (root_package, _) = self.root_package()?;
         if package == &root_package {
-            let constraints = self
-                .root_dependencies
-                .iter()
-                .map(|(package, range)| (package.clone(), range.clone()))
-                .collect::<DependencyConstraints<_, _>>();
+            let constraints = self.dependency_ranges(&self.root_relations)?;
 
             self.prefetch_descriptions(&constraints)?;
 
@@ -284,15 +301,17 @@ impl DependencyProvider for RDependencyProvider {
                 source,
             })?;
 
-        let dependencies = dependencies_from_description(
-            format!("{package} {} from {}", version.version, version.repository),
-            &description,
-            &self.base_packages,
-            (!self.root_installable).then_some(root_package.as_str()),
-        );
-        let Dependencies::Available(constraints) = dependencies else {
-            return Ok(dependencies);
+        let source_name = format!("{package} {} from {}", version.version, version.repository);
+        let relations = match required_dependencies(source_name, &description) {
+            Ok(relations) => relations,
+            Err(error) => {
+                return Ok(Dependencies::Unavailable(format!(
+                    "invalid dependency metadata: {}",
+                    error.messages().join("; ")
+                )));
+            }
         };
+        let constraints = self.dependency_ranges(&relations)?;
 
         self.prefetch_descriptions(&constraints)?;
 
@@ -380,25 +399,6 @@ async fn choose_repository_version(
         .max())
 }
 
-fn dependencies_from_description(
-    source_name: impl Into<String>,
-    description: &Description,
-    base_packages: &BTreeSet<String>,
-    unavailable_package: Option<&str>,
-) -> Dependencies<String, Ranges<PackageVersion>, String> {
-    match required_dependencies(source_name, description) {
-        Ok(relations) => Dependencies::Available(dependency_ranges_from_relations(
-            &relations,
-            base_packages,
-            unavailable_package,
-        )),
-        Err(error) => Dependencies::Unavailable(format!(
-            "invalid dependency metadata: {}",
-            error.messages().join("; ")
-        )),
-    }
-}
-
 fn package_version_range_from_relation(relation: &Relation) -> Ranges<PackageVersion> {
     let bound = |version: &Version| PackageVersion::new(version.clone(), built_in_repository());
 
@@ -436,7 +436,7 @@ fn package_version_range_from_relation(relation: &Relation) -> Ranges<PackageVer
 pub(crate) async fn resolve_from_registry(
     repositories: Vec<Arc<dyn PackageRepository>>,
     root: Arc<LocalRepository>,
-    root_installable: bool,
+    root_type: ProjectType,
     root_relations: BTreeSet<Relation>,
     preferred_versions: BTreeMap<String, Version>,
 ) -> Result<BTreeMap<String, PackageVersion>, ResolutionError> {
@@ -462,16 +462,11 @@ pub(crate) async fn resolve_from_registry(
         let (root_package, root_version) = tokio::runtime::Handle::current()
             .block_on(root.package())
             .map_err(ProviderError::from)?;
-        let root_dependencies = dependency_ranges_from_relations(
-            &root_relations,
-            &base_packages,
-            (!root_installable).then_some(root_package.as_str()),
-        );
         let provider = RDependencyProvider::new(
             repositories,
             root,
-            root_installable,
-            root_dependencies,
+            root_type,
+            root_relations,
             preferred_versions,
             base_packages,
         );
@@ -495,22 +490,14 @@ pub(crate) async fn resolve_from_registry(
 fn dependency_ranges_from_relations(
     relations: &BTreeSet<Relation>,
     base_packages: &BTreeSet<String>,
-    unavailable_package: Option<&str>,
 ) -> DependencyConstraints<String, Ranges<PackageVersion>> {
     relations
         .iter()
-        .filter(|relation| {
-            unavailable_package == Some(relation.package())
-                || !base_packages.contains(relation.package())
-        })
+        .filter(|relation| !base_packages.contains(relation.package()))
         .fold(
             DependencyConstraints::default(),
             |mut dependencies, relation| {
-                let range = if unavailable_package == Some(relation.package()) {
-                    Ranges::empty()
-                } else {
-                    package_version_range_from_relation(relation)
-                };
+                let range = package_version_range_from_relation(relation);
                 dependencies
                     .entry(relation.package().to_string())
                     .and_modify(|existing| *existing = existing.intersection(&range))
@@ -626,6 +613,22 @@ mod tests {
         )
     }
 
+    fn dependencies_from_description(
+        source_name: impl Into<String>,
+        description: &Description,
+        base_packages: &BTreeSet<String>,
+    ) -> Dependencies<String, Ranges<PackageVersion>, String> {
+        match required_dependencies(source_name, description) {
+            Ok(relations) => {
+                Dependencies::Available(dependency_ranges_from_relations(&relations, base_packages))
+            }
+            Err(error) => Dependencies::Unavailable(format!(
+                "invalid dependency metadata: {}",
+                error.messages().join("; ")
+            )),
+        }
+    }
+
     #[test]
     fn rejects_malformed_hard_dependency_metadata() {
         let description = Description::parse(
@@ -633,7 +636,7 @@ mod tests {
         );
 
         let Dependencies::Unavailable(reason) =
-            dependencies_from_description("example 1.0.0", &description, &BTreeSet::new(), None)
+            dependencies_from_description("example 1.0.0", &description, &BTreeSet::new())
         else {
             panic!("malformed Imports should make the package version unavailable");
         };
@@ -675,7 +678,7 @@ mod tests {
         let selected = resolve_from_registry(
             vec![Arc::new(remote_repository)],
             local_repository,
-            true,
+            ProjectType::Package,
             BTreeSet::from([Relation::any("example").expect("valid example relation")]),
             BTreeMap::new(),
         )
@@ -692,7 +695,7 @@ mod tests {
         );
 
         let Dependencies::Available(dependencies) =
-            dependencies_from_description("example 1.0.0", &description, &BTreeSet::new(), None)
+            dependencies_from_description("example 1.0.0", &description, &BTreeSet::new())
         else {
             panic!("malformed Suggests should not make the package version unavailable");
         };
@@ -706,7 +709,7 @@ mod tests {
         );
 
         let Dependencies::Available(dependencies) =
-            dependencies_from_description("example 1.0.0", &description, &BTreeSet::new(), None)
+            dependencies_from_description("example 1.0.0", &description, &BTreeSet::new())
         else {
             panic!("hard dependencies should be available");
         };
@@ -723,34 +726,40 @@ mod tests {
         assert!(!range.contains(&candidate("2.0.0")));
     }
 
-    #[test]
-    fn project_namespace_is_unsatisfiable_in_root_and_transitive_dependencies() {
+    #[tokio::test(flavor = "multi_thread")]
+    async fn project_namespace_is_unsatisfiable_even_when_it_is_a_base_package() {
         let project_relation = Relation::any("project").expect("valid project relation");
-        let root_dependencies = dependency_ranges_from_relations(
-            &BTreeSet::from([project_relation]),
-            &BTreeSet::new(),
-            Some("project"),
+        let provider = RDependencyProvider::new(
+            Vec::new(),
+            local_repository("project", "1.0.0"),
+            ProjectType::Project,
+            BTreeSet::from([project_relation]),
+            BTreeMap::new(),
+            BTreeSet::new(),
         );
-        assert_eq!(root_dependencies["project"], Ranges::empty());
+        let project_dependencies = tokio::task::spawn_blocking(move || {
+            provider.dependency_ranges(&provider.root_relations)
+        })
+        .await
+        .expect("dependency task should join")
+        .expect("project dependencies should resolve");
+        assert_eq!(project_dependencies["project"], Ranges::empty());
 
-        let description =
-            Description::parse("Package: dependent\nVersion: 1.0.0\nImports: project\n");
-        let Dependencies::Available(transitive_dependencies) = dependencies_from_description(
-            "dependent 1.0.0",
-            &description,
-            &BTreeSet::new(),
-            Some("project"),
-        ) else {
-            panic!("dependency metadata should be available");
-        };
-        assert_eq!(transitive_dependencies["project"], Ranges::empty());
-
-        let base_namespace = dependency_ranges_from_relations(
-            &BTreeSet::from([Relation::any("stats").expect("valid base package relation")]),
-            &BTreeSet::from(["stats".to_string()]),
-            Some("stats"),
+        let provider = RDependencyProvider::new(
+            Vec::new(),
+            local_repository("stats", "1.0.0"),
+            ProjectType::Project,
+            BTreeSet::from([Relation::any("stats").expect("valid base package relation")]),
+            BTreeMap::new(),
+            BTreeSet::from(["stats".to_string()]),
         );
-        assert_eq!(base_namespace["stats"], Ranges::empty());
+        let base_dependencies = tokio::task::spawn_blocking(move || {
+            provider.dependency_ranges(&provider.root_relations)
+        })
+        .await
+        .expect("dependency task should join")
+        .expect("base dependencies should resolve");
+        assert_eq!(base_dependencies["stats"], Ranges::empty());
     }
 
     #[tokio::test]
@@ -909,8 +918,8 @@ mod tests {
         let provider = RDependencyProvider::new(
             vec![remote_repository.clone()],
             local_repository,
-            true,
-            DependencyConstraints::default(),
+            ProjectType::Package,
+            BTreeSet::new(),
             BTreeMap::new(),
             BTreeSet::new(),
         );
@@ -943,8 +952,8 @@ mod tests {
         let provider = RDependencyProvider::new(
             vec![remote_repository.clone()],
             local_repository,
-            true,
-            DependencyConstraints::default(),
+            ProjectType::Package,
+            BTreeSet::new(),
             BTreeMap::new(),
             BTreeSet::new(),
         );
@@ -973,12 +982,11 @@ mod tests {
         )
         .expect("valid suggested relation");
         let roots = BTreeSet::from([suggested]);
-        let root_dependencies = dependency_ranges_from_relations(&roots, &BTreeSet::new(), None);
         let provider = RDependencyProvider::new(
             Vec::new(),
             Arc::clone(&local_repository),
-            true,
-            root_dependencies,
+            ProjectType::Package,
+            roots,
             BTreeMap::new(),
             BTreeSet::new(),
         );
@@ -1018,7 +1026,7 @@ mod tests {
         let selected = resolve_from_registry(
             vec![remote_repository.clone()],
             local_repository,
-            true,
+            ProjectType::Package,
             BTreeSet::from([Relation::any("testBasePackage").expect("valid base relation")]),
             BTreeMap::new(),
         )
@@ -1041,7 +1049,7 @@ mod tests {
         let selected = resolve_from_registry(
             vec![remote_repository.clone()],
             local_repository,
-            true,
+            ProjectType::Package,
             BTreeSet::new(),
             BTreeMap::new(),
         )
@@ -1082,7 +1090,7 @@ mod tests {
         let error = resolve_from_registry(
             vec![remote_repository.clone()],
             local_repository,
-            false,
+            ProjectType::Project,
             BTreeSet::from([Relation::any("dependent").expect("valid dependent relation")]),
             BTreeMap::new(),
         )
@@ -1150,7 +1158,7 @@ mod tests {
         let selected = resolve_from_registry(
             vec![remote_repository.clone()],
             local_repository,
-            true,
+            ProjectType::Package,
             BTreeSet::from([Relation::new(
                 "testthat",
                 VersionRequirement::GreaterThanEqual(RequirementVersion::Version(

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -4,7 +4,9 @@ use crate::{
         SourceArtifactIdentity, binary_artifact_cache_path, compiled_package_cache_path,
         source_artifact_cache_path,
     },
-    description::{DescriptionParseError, project_type, required_dependencies, root_package},
+    description::{
+        DescriptionParseError, ProjectType, project_type, required_dependencies, root_package,
+    },
     http,
     project::{
         Project, ProjectLibraryError, ProjectResolution, RequiredPackages, cache_dir_path,
@@ -110,20 +112,21 @@ pub(crate) async fn sync_resolved_project(
     let mut required = resolution.packages;
     let (root_name, root_version) = root_package(&project.root, &project.description)?;
     required.remove(&root_name);
-    if project_type(&project.root, &project.description)?.is_installable()
-        && project_package == ProjectPackageMode::Install
-    {
-        let root = Arc::new(
-            LocalRepository::new(project.root.clone())
-                .with_description(project.description.clone()),
-        );
-        required.insert(
-            root_name,
-            (
-                PackageVersion::new(root_version, root),
-                Arc::new(project.description.clone()),
-            ),
-        );
+    match (project_type(&project.description), project_package) {
+        (ProjectType::Package, ProjectPackageMode::Install) => {
+            let root = Arc::new(
+                LocalRepository::new(project.root.clone())
+                    .with_description(project.description.clone()),
+            );
+            required.insert(
+                root_name,
+                (
+                    PackageVersion::new(root_version, root),
+                    Arc::new(project.description.clone()),
+                ),
+            );
+        }
+        (ProjectType::Package, ProjectPackageMode::Omit) | (ProjectType::Project, _) => {}
     }
 
     validate_package_graph(&required).await?;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -4,7 +4,7 @@ use crate::{
         SourceArtifactIdentity, binary_artifact_cache_path, compiled_package_cache_path,
         source_artifact_cache_path,
     },
-    description::{DescriptionParseError, required_dependencies, root_package},
+    description::{DescriptionParseError, project_type, required_dependencies, root_package},
     http,
     project::{
         Project, ProjectLibraryError, ProjectResolution, RequiredPackages, cache_dir_path,
@@ -110,8 +110,9 @@ pub(crate) async fn sync_resolved_project(
     let mut required = resolution.packages;
     let (root_name, root_version) = root_package(&project.root, &project.description)?;
     required.remove(&root_name);
-
-    if project_package == ProjectPackageMode::Install {
+    if project_type(&project.root, &project.description)?.is_installable()
+        && project_package == ProjectPackageMode::Install
+    {
         let root = Arc::new(
             LocalRepository::new(project.root.clone())
                 .with_description(project.description.clone()),

--- a/tests/deps.rs
+++ b/tests/deps.rs
@@ -146,6 +146,50 @@ fn add_and_remove_can_sync_without_installing_project() {
 }
 
 #[test]
+fn dependency_only_project_never_installs_the_root_package() {
+    let container = start_container();
+    let project_path = "/tmp/rpx-dependency-only-project";
+    let command = format!(
+        "mkdir -p {project_path} && cd {project_path} && rpx init --type project && rpx add digest && rpx status"
+    );
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &command);
+    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
+
+    let description = read_project_file(&container, project_path, "DESCRIPTION");
+    assert!(
+        description.contains("Config/rpx/type: project"),
+        "DESCRIPTION was: {description}"
+    );
+    assert_package_state(&container, project_path, "digest", "TRUE");
+    assert_package_state(
+        &container,
+        project_path,
+        "rpx.dependency.only.project",
+        "FALSE",
+    );
+}
+
+#[test]
+fn dependency_only_project_cannot_depend_on_its_namespace() {
+    let container = start_container();
+    let project_path = "/tmp/rpx-project-self-dependency";
+    write_description(
+        &container,
+        project_path,
+        "Package: digest\nVersion: 0.1.0\nTitle: Digest Project\nDescription: Dependency-only project fixture.\nLicense: MIT\nAuthor: Test Author\nMaintainer: Test Author <test@example.com>\nConfig/rpx/type: project\nImports: digest",
+    );
+
+    let command = format!("cd {project_path} && rpx lock");
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &command);
+
+    assert_eq!(exit_code, 1, "stdout was: {stdout}\nstderr was: {stderr}");
+    assert!(
+        stderr.contains("rpx::lock::no_solution"),
+        "stdout was: {stdout}\nstderr was: {stderr}"
+    );
+}
+
+#[test]
 fn constrained_add_replaces_default_dependency_bounds() {
     let container = start_container();
     let project_path = "/tmp/rpx-project-add-constraint";


### PR DESCRIPTION
## Summary
- add `Config/rpx/type: project` and expose package/project selection in `rpx init`
- keep the local repository as the resolver root while making project namespaces unsatisfiable dependency targets
- skip root installation for dependency-only projects and validate stale lockfiles against unavailable namespaces
- document the dependency-only workflow

## Testing
- `cargo fmt --all -- --check`
- `cargo test`
- `cargo clippy --all-targets --all-features` (passes with existing warnings)
- `cargo test --test deps dependency_only_project -- --nocapture`

Closes #111
Linear: RRE-26