### PR TITLE
fix: preserve package install failure diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -527,6 +536,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "command-group"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a68fa787550392a9d58f44c21a3022cfb3ea3e2458b7f85d3b399d0ceeccf409"
+dependencies = [
+ "nix",
+ "winapi",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,6 +700,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -848,6 +878,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1711,6 +1742,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2162,6 +2204,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-package-installer"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ce15b1d7afd940e2b981263d0e7489eb086db44e21817e805fe08028224775"
+dependencies = [
+ "command-group",
+ "flate2",
+ "hex",
+ "object",
+ "r-dcf-syntax",
+ "r-description-parser",
+ "sha2",
+ "tar",
+ "thiserror",
+ "windows-sys 0.61.2",
+ "zip",
+]
+
+[[package]]
 name = "r-packages-parser"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2437,6 +2498,7 @@ dependencies = [
  "pubgrub",
  "r-description-parser",
  "r-metadata",
+ "r-package-installer",
  "r-packages-parser",
  "relative-path",
  "reqwest",
@@ -4087,7 +4149,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "5.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f852905151ac8d4d06fdca66520a661c09730a74c6d4e2b0f27b436b382e532"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,7 +71,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -82,7 +82,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -522,7 +522,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -741,7 +741,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -803,7 +803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1758,7 +1758,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2148,7 +2148,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2205,9 +2205,9 @@ dependencies = [
 
 [[package]]
 name = "r-package-installer"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ce15b1d7afd940e2b981263d0e7489eb086db44e21817e805fe08028224775"
+checksum = "dcb3acbefe72402fb290ac0a97e42d988da0af4d6f92ffa1620f120934eb6709"
 dependencies = [
  "command-group",
  "flate2",
@@ -2582,7 +2582,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2641,7 +2641,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2955,7 +2955,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3095,7 +3095,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3105,7 +3105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3776,7 +3776,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ reqwest-tracing = "0.7"
 rpassword = "7.3.1"
 r-description = { package = "r-description-parser", version = "=0.2.0" }
 r-metadata = "=0.2.0"
+r-package-installer = "0.1"
 r-packages = { package = "r-packages-parser", version = "=0.2.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ reqwest-tracing = "0.7"
 rpassword = "7.3.1"
 r-description = { package = "r-description-parser", version = "=0.2.0" }
 r-metadata = "=0.2.0"
-r-package-installer = "0.1"
+r-package-installer = "0.1.1"
 r-packages = { package = "r-packages-parser", version = "=0.2.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -14,7 +14,7 @@ use url::Url;
 
 const SOURCE_ARTIFACT_CACHE_VERSION: &str = "v1";
 const BINARY_ARTIFACT_CACHE_VERSION: &str = "v1";
-const COMPILED_PACKAGE_CACHE_VERSION: &str = "v1";
+pub(crate) const INSTALLER_CACHE_VERSION: &str = "v1";
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 pub(crate) enum RegistryIdentity {
@@ -114,40 +114,10 @@ pub(crate) fn binary_artifact_cache_path(key: &BinaryArtifactCacheKey) -> PathBu
         .join(file_name)
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct CompiledPackageCacheKey {
-    repository: RegistryIdentity,
-    package: String,
-    version: Version,
-    target: Triple,
-    r_version: RVersion,
-}
-
-impl CompiledPackageCacheKey {
-    pub(crate) fn new(
-        repository: RegistryIdentity,
-        package: impl Into<String>,
-        version: Version,
-        target: Triple,
-        r_version: RVersion,
-    ) -> Self {
-        Self {
-            repository,
-            package: package.into(),
-            version,
-            target,
-            r_version,
-        }
-    }
-}
-
-pub(crate) fn compiled_package_cache_path(key: &CompiledPackageCacheKey) -> PathBuf {
+pub(crate) fn installer_cache_path() -> PathBuf {
     cache_dir_path()
-        .join("builds")
-        .join(COMPILED_PACKAGE_CACHE_VERSION)
-        .join(&key.package)
-        .join(cache_key_digest(key))
-        .join("package")
+        .join("installer")
+        .join(INSTALLER_CACHE_VERSION)
 }
 
 #[cfg(test)]
@@ -271,59 +241,7 @@ mod tests {
     }
 
     #[test]
-    fn compiled_package_cache_uses_binary_compatibility_identity() {
-        let repository = || RegistryIdentity::Cran("https://example.test/cran".parse().unwrap());
-        let key = |repository, version: &str, target: &str, r_version: &str| {
-            CompiledPackageCacheKey::new(
-                repository,
-                "package",
-                version.parse().unwrap(),
-                target.parse().unwrap(),
-                r_version.parse().unwrap(),
-            )
-        };
-        let base = compiled_package_cache_path(&key(
-            repository(),
-            "1.2.3",
-            "x86_64-pc-windows-msvc",
-            "4.3.0",
-        ));
-
-        assert_ne!(
-            base,
-            compiled_package_cache_path(&key(
-                RegistryIdentity::Cran("https://mirror.example.test/cran".parse().unwrap()),
-                "1.2.3",
-                "x86_64-pc-windows-msvc",
-                "4.3.0",
-            ))
-        );
-        assert_ne!(
-            base,
-            compiled_package_cache_path(&key(
-                repository(),
-                "1.2.3",
-                "aarch64-pc-windows-msvc",
-                "4.3.0",
-            ))
-        );
-        assert_ne!(
-            base,
-            compiled_package_cache_path(&key(
-                repository(),
-                "1.2.3",
-                "x86_64-pc-windows-msvc",
-                "4.3.1",
-            ))
-        );
-        assert_eq!(
-            base,
-            compiled_package_cache_path(&key(
-                repository(),
-                "1.2.3.0",
-                "x86_64-pc-windows-msvc",
-                "4.3.0",
-            ))
-        );
+    fn installer_cache_is_versioned() {
+        assert!(installer_cache_path().ends_with("installer/v1"));
     }
 }

--- a/src/commands/remove.rs
+++ b/src/commands/remove.rs
@@ -7,8 +7,9 @@ use crate::{
     output::status,
     project::{
         ProjectLoadError, ProjectWriteError, ResolutionPolicy, ResolveProjectError, load_project,
-        resolve_project, write_project_files,
+        project_library_path, resolve_project, write_project_files,
     },
+    r::{InstalledPackagesError, installed_packages},
     sync::{SyncError, sync_resolved_project},
 };
 use miette::Diagnostic;
@@ -39,11 +40,16 @@ pub(crate) enum Error {
 
     #[error(transparent)]
     #[diagnostic(transparent)]
+    InstalledPackages(#[from] InstalledPackagesError),
+
+    #[error(transparent)]
+    #[diagnostic(transparent)]
     Install(#[from] SyncError),
 }
 
 pub(crate) async fn run(args: RemoveArgs) -> Result<(), Error> {
     let mut project = load_project()?;
+    let installed = installed_packages(&project_library_path(&project.root)).await?;
     let removed_packages = args.packages.iter().cloned().collect::<BTreeSet<_>>();
     remove_dependencies(&project.root, &mut project.description, &removed_packages)?;
     project.description = normalize_description(&project.root, &project.description)?;
@@ -53,18 +59,17 @@ pub(crate) async fn run(args: RemoveArgs) -> Result<(), Error> {
         Some(&project.description),
         &resolution.lockfile,
     )?;
-    let report =
-        sync_resolved_project(&project, resolution, args.no_install_project.into()).await?;
+    sync_resolved_project(&project, resolution, args.no_install_project.into()).await?;
     let removed = args
         .packages
         .iter()
-        .filter(|package| report.installed_before.contains(package.as_str()))
+        .filter(|package| installed.contains_key(package.as_str()))
         .cloned()
         .collect::<BTreeSet<_>>();
     let missing = args
         .packages
         .iter()
-        .filter(|package| !report.installed_before.contains(package.as_str()))
+        .filter(|package| !installed.contains_key(package.as_str()))
         .cloned()
         .collect::<BTreeSet<_>>();
 

--- a/src/r.rs
+++ b/src/r.rs
@@ -206,10 +206,12 @@ pub async fn install_package_artifact(
     package: &str,
     version: &str,
     pkg_type: &str,
+    r_version: &semver::Version,
     target_library: &Path,
-) -> Result<(), PackageInstallError> {
+) -> Result<Output, PackageInstallError> {
     let mut command = project_r_command("Rscript", project_library);
     command
+        .arg("--vanilla")
         .arg("-e")
         .arg(concat!(
             "args <- commandArgs(trailingOnly = TRUE);",
@@ -219,12 +221,17 @@ pub async fn install_package_artifact(
             "package_name <- args[[4L]];",
             "expected_version <- args[[5L]];",
             "utils::install.packages(artifact, repos = NULL, type = package_type, lib = target_library);",
-            "packages <- utils::installed.packages(lib.loc = target_library);",
-            "if (!(package_name %in% rownames(packages))) ",
-            "stop(sprintf('Expected package %s to be installed', package_name));",
-            "installed_version <- packages[package_name, 'Version'];",
-            "if (installed_version != expected_version) ",
-            "warning(sprintf('Installed %s version %s, expected %s', package_name, installed_version, expected_version))"
+            "package_dir <- file.path(target_library, package_name);",
+            "description <- file.path(package_dir, 'DESCRIPTION');",
+            "if (!dir.exists(package_dir) || !file.exists(description)) ",
+            "stop(sprintf('Expected package %s at %s after installation. Library entries: %s', package_name, package_dir, paste(list.files(target_library, all.files = TRUE), collapse = ', ')));",
+            "metadata <- read.dcf(description, fields = c('Package', 'Version'));",
+            "installed_name <- unname(metadata[1L, 'Package']);",
+            "installed_version <- unname(metadata[1L, 'Version']);",
+            "if (!identical(installed_name, package_name)) ",
+            "stop(sprintf('Installed package name is %s, expected %s', installed_name, package_name));",
+            "if (!identical(installed_version, expected_version)) ",
+            "stop(sprintf('Installed %s version %s, expected %s', package_name, installed_version, expected_version))"
         ))
         .arg(artifact_path)
         .arg(pkg_type)
@@ -234,10 +241,12 @@ pub async fn install_package_artifact(
     command.kill_on_drop(true);
     run_subprocess(command)
         .await
-        .map(|_| ())
         .map_err(|source| PackageInstallError::Command {
             action: "install",
-            target: format!("{package}@{version}"),
+            target: format!(
+                "{package}@{version} from {} as {pkg_type} with R {r_version}",
+                artifact_path.display()
+            ),
             source: Box::new(source),
         })
 }

--- a/src/r.rs
+++ b/src/r.rs
@@ -1,12 +1,12 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
-    ffi::OsStr,
     path::{Path, PathBuf},
     process::Output,
 };
 
 use miette::Diagnostic;
 use r_metadata::Version;
+use r_package_installer::{LibraryEntry, scan_library};
 use thiserror::Error;
 use tokio::{process::Command, sync::OnceCell};
 
@@ -91,57 +91,37 @@ pub enum PackageBuildError {
 }
 
 #[derive(Debug, Error, Diagnostic)]
-pub enum PackageInstallError {
-    #[error("failed to {action} {target}: {source}")]
-    #[diagnostic(code(rpx::install::command_failed))]
-    Command {
-        action: &'static str,
-        target: String,
-        #[source]
-        source: Box<RSubprocessError>,
-    },
-}
-
-#[derive(Debug, Error, Diagnostic)]
 pub enum InstalledPackagesError {
-    #[error("failed to inspect project library at {}: {source}", path.display())]
+    #[error("failed to inspect project library: {source}")]
     #[diagnostic(code(rpx::runtime::project_library_inspection_failed))]
-    LibraryMetadata {
-        path: PathBuf,
+    Scan {
         #[source]
-        source: std::io::Error,
+        source: r_package_installer::Error,
     },
 
-    #[error("project library path is not a directory: {}", path.display())]
-    #[diagnostic(code(rpx::runtime::project_library_not_directory))]
-    LibraryNotDirectory { path: PathBuf },
-
-    #[error("failed to inspect installed R packages: {source}")]
-    #[diagnostic(code(rpx::runtime::installed_packages_failed))]
-    Command {
+    #[error("failed to join project library inspection: {source}")]
+    #[diagnostic(code(rpx::runtime::project_library_inspection_join_failed))]
+    Join {
         #[source]
-        source: RSubprocessError,
+        source: tokio::task::JoinError,
     },
 
-    #[error("installed package output is not valid UTF-8: {source}")]
-    #[diagnostic(code(rpx::runtime::installed_packages_invalid_utf8))]
-    InvalidUtf8 {
-        #[source]
-        source: std::string::FromUtf8Error,
-    },
-
-    #[error("invalid installed package output on line {line}: {contents}")]
-    #[diagnostic(code(rpx::runtime::installed_packages_invalid_row))]
-    InvalidRow { line: usize, contents: String },
-
-    #[error("invalid installed version {version} for {package} on line {line}: {details}")]
+    #[error("invalid installed version {version} for {package}: {details}")]
     #[diagnostic(code(rpx::runtime::installed_package_invalid_version))]
     InvalidVersion {
-        line: usize,
         package: String,
         version: String,
         details: String,
     },
+
+    #[error("project library contains an active or interrupted package transaction at {}", path.display())]
+    #[diagnostic(
+        code(rpx::runtime::project_library_locked),
+        help(
+            "Finish the other package operation or remove the stale lock after confirming its owner is no longer running."
+        )
+    )]
+    Locked { path: PathBuf },
 }
 
 #[derive(Debug, Error, Diagnostic)]
@@ -185,65 +165,8 @@ pub enum RVersionError {
     },
 }
 
-fn project_r_command(program: impl AsRef<OsStr>, project_library: &Path) -> Command {
-    let mut command = Command::new(program.as_ref());
-    command.env("R_LIBS_USER", project_library);
-    command
-}
-
 static BASE_PACKAGES: OnceCell<BTreeSet<String>> = OnceCell::const_new();
 static R_VERSION: OnceCell<semver::Version> = OnceCell::const_new();
-
-pub async fn install_package_artifact(
-    project_library: &Path,
-    artifact_path: &Path,
-    package: &str,
-    version: &str,
-    pkg_type: &str,
-    r_version: &semver::Version,
-    target_library: &Path,
-) -> Result<Output, PackageInstallError> {
-    let mut command = project_r_command("Rscript", project_library);
-    command
-        .arg("--vanilla")
-        .arg("-e")
-        .arg(concat!(
-            "args <- commandArgs(trailingOnly = TRUE);",
-            "artifact <- args[[1L]];",
-            "package_type <- args[[2L]];",
-            "target_library <- args[[3L]];",
-            "package_name <- args[[4L]];",
-            "expected_version <- args[[5L]];",
-            "utils::install.packages(artifact, repos = NULL, type = package_type, lib = target_library);",
-            "package_dir <- file.path(target_library, package_name);",
-            "description <- file.path(package_dir, 'DESCRIPTION');",
-            "if (!dir.exists(package_dir) || !file.exists(description)) ",
-            "stop(sprintf('Expected package %s at %s after installation. Library entries: %s', package_name, package_dir, paste(list.files(target_library, all.files = TRUE), collapse = ', ')));",
-            "metadata <- read.dcf(description, fields = c('Package', 'Version'));",
-            "installed_name <- unname(metadata[1L, 'Package']);",
-            "installed_version <- unname(metadata[1L, 'Version']);",
-            "if (!identical(installed_name, package_name)) ",
-            "stop(sprintf('Installed package name is %s, expected %s', installed_name, package_name));",
-            "if (!identical(installed_version, expected_version)) ",
-            "stop(sprintf('Installed %s version %s, expected %s', package_name, installed_version, expected_version))"
-        ))
-        .arg(artifact_path)
-        .arg(pkg_type)
-        .arg(target_library)
-        .arg(package)
-        .arg(version);
-    command.kill_on_drop(true);
-    run_subprocess(command)
-        .await
-        .map_err(|source| PackageInstallError::Command {
-            action: "install",
-            target: format!(
-                "{package}@{version} from {} as {pkg_type} with R {r_version}",
-                artifact_path.display()
-            ),
-            source: Box::new(source),
-        })
-}
 
 pub async fn build_package_archive(
     package_root: &Path,
@@ -371,135 +294,47 @@ pub async fn base_packages() -> Result<BTreeSet<String>, BasePackagesError> {
 pub async fn installed_packages(
     project_library: &Path,
 ) -> Result<BTreeMap<String, PackageVersion>, InstalledPackagesError> {
-    let metadata = match tokio::fs::metadata(project_library).await {
-        Ok(metadata) => metadata,
-        Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
-            return Ok(BTreeMap::new());
-        }
-        Err(source) => {
-            return Err(InstalledPackagesError::LibraryMetadata {
-                path: project_library.to_path_buf(),
-                source,
-            });
-        }
-    };
-    if !metadata.is_dir() {
-        return Err(InstalledPackagesError::LibraryNotDirectory {
-            path: project_library.to_path_buf(),
-        });
-    }
-
-    let expression = concat!(
-        "args <- commandArgs(trailingOnly = TRUE);",
-        "packages <- utils::installed.packages(lib.loc = args[[1L]]);",
-        "if (nrow(packages) == 0) quit(save = 'no', status = 0);",
-        "utils::write.table(packages[, c('Package', 'Version'), drop = FALSE], ",
-        "sep = '\t', row.names = FALSE, col.names = TRUE, quote = FALSE)"
-    );
-
-    let mut command = Command::new("Rscript");
-    command
-        .arg("--vanilla")
-        .arg("-e")
-        .arg(expression)
-        .arg(project_library);
-    let output = run_subprocess(command)
+    let project_library = project_library.to_path_buf();
+    let entries = tokio::task::spawn_blocking(move || scan_library(&project_library))
         .await
-        .map_err(|source| InstalledPackagesError::Command { source })?;
-    let stdout = String::from_utf8(output.stdout)
-        .map_err(|source| InstalledPackagesError::InvalidUtf8 { source })?;
-
-    parse_installed_packages(&stdout)
-}
-
-#[derive(Debug, Error, Diagnostic)]
-pub enum PackageRemovalError {
-    #[error("failed to remove package {package} at {}: {source}", path.display())]
-    #[diagnostic(code(rpx::library::package_remove_failed))]
-    Remove {
-        package: String,
-        path: PathBuf,
-        #[source]
-        source: std::io::Error,
-    },
-}
-
-pub fn remove_packages_from_venv(
-    project_library: &Path,
-    packages: &BTreeSet<String>,
-) -> Result<(), PackageRemovalError> {
-    packages
-        .iter()
-        .try_for_each(|package| remove_package_from_venv(project_library, package))
-}
-
-pub fn remove_package_from_venv(
-    project_library: &Path,
-    package: &str,
-) -> Result<(), PackageRemovalError> {
-    let package_dir = project_library.join(package);
-
-    if !package_dir.exists() {
-        return Ok(());
-    }
-
-    std::fs::remove_dir_all(&package_dir).map_err(|source| PackageRemovalError::Remove {
-        package: package.to_string(),
-        path: package_dir,
-        source,
-    })
-}
-
-fn parse_installed_packages(
-    output: &str,
-) -> Result<BTreeMap<String, PackageVersion>, InstalledPackagesError> {
-    let mut lines = output.lines().enumerate();
-    let Some((_, header)) = lines.next() else {
-        return Ok(BTreeMap::new());
-    };
-    if header != "Package\tVersion" {
-        return Err(InstalledPackagesError::InvalidRow {
-            line: 1,
-            contents: header.to_string(),
-        });
-    }
-
+        .map_err(|source| InstalledPackagesError::Join { source })?
+        .map_err(|source| InstalledPackagesError::Scan { source })?;
     let repository = built_in_repository();
-    lines
-        .filter(|(_, line)| !line.trim().is_empty())
-        .map(|(index, line)| {
-            let mut parts = line.split('\t');
-            let (Some(package), Some(version), None) = (parts.next(), parts.next(), parts.next())
-            else {
-                return Err(InstalledPackagesError::InvalidRow {
-                    line: index + 1,
-                    contents: line.to_string(),
-                });
-            };
-            let package = package.trim();
-            let version = version.trim();
-            if package.is_empty() || version.is_empty() {
-                return Err(InstalledPackagesError::InvalidRow {
-                    line: index + 1,
-                    contents: line.to_string(),
+    let mut installed = BTreeMap::new();
+    for entry in entries {
+        match entry {
+            LibraryEntry::Installed(package) => {
+                let version = package
+                    .metadata
+                    .version
+                    .parse::<Version>()
+                    .map_err(|source| InstalledPackagesError::InvalidVersion {
+                        package: package.metadata.name.clone(),
+                        version: package.metadata.version.clone(),
+                        details: source.to_string(),
+                    })?;
+                installed.insert(
+                    package.metadata.name,
+                    PackageVersion::new(version, repository.clone()),
+                );
+            }
+            LibraryEntry::Locked(lock) => {
+                return Err(InstalledPackagesError::Locked { path: lock.path });
+            }
+            LibraryEntry::Recoverable(plan) => {
+                return Err(InstalledPackagesError::Locked {
+                    path: plan.lock.path,
                 });
             }
-
-            let parsed_version = version.parse::<Version>().map_err(|source| {
-                InstalledPackagesError::InvalidVersion {
-                    line: index + 1,
-                    package: package.to_string(),
-                    version: version.to_string(),
-                    details: source.to_string(),
-                }
-            })?;
-
-            Ok((
-                package.to_string(),
-                PackageVersion::new(parsed_version, repository.clone()),
-            ))
-        })
-        .collect()
+            LibraryEntry::Incomplete { path, reason } => {
+                tracing::debug!(path = %path.display(), %reason, "found incomplete project library entry");
+            }
+            LibraryEntry::Foreign(path) => {
+                tracing::debug!(path = %path.display(), "ignoring foreign project library entry");
+            }
+        }
+    }
+    Ok(installed)
 }
 
 pub async fn r_version_async() -> Result<semver::Version, RVersionError> {
@@ -604,29 +439,27 @@ fn summarize_subprocess_output(stdout: &[u8], stderr: &[u8]) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::{fs, sync::Arc};
+    use std::fs;
 
     use super::*;
 
-    #[test]
-    fn parses_installed_packages_with_builtin_repository() {
-        let packages = parse_installed_packages("Package\tVersion\ndigest\t0.6.37\n").unwrap();
+    #[tokio::test]
+    async fn scans_installed_packages_with_builtin_repository() {
+        let directory = tempfile::tempdir().unwrap();
+        let package = directory.path().join("digest");
+        fs::create_dir_all(package.join("Meta")).unwrap();
+        fs::write(
+            package.join("DESCRIPTION"),
+            "Package: digest\nVersion: 0.6.37\nBuilt: R 4.5.1; x86_64-pc-linux-gnu; 2026-01-01; unix\n",
+        )
+        .unwrap();
+        fs::write(package.join("Meta/package.rds"), "metadata").unwrap();
+
+        let packages = installed_packages(directory.path()).await.unwrap();
         let digest = packages.get("digest").unwrap();
 
         assert_eq!(digest.version().to_string(), "0.6.37");
-        assert!(Arc::ptr_eq(digest.repository(), &built_in_repository()));
-    }
-
-    #[test]
-    fn rejects_invalid_installed_package_version() {
-        let error =
-            parse_installed_packages("Package\tVersion\ndigest\tnot-a-version\n").unwrap_err();
-
-        assert!(matches!(
-            error,
-            InstalledPackagesError::InvalidVersion { package, version, .. }
-                if package == "digest" && version == "not-a-version"
-        ));
+        assert!(digest.repository().equals(built_in_repository().as_ref()));
     }
 
     #[tokio::test]
@@ -651,9 +484,6 @@ mod tests {
             .await
             .expect_err("file should not be accepted as a library");
 
-        assert!(matches!(
-            error,
-            InstalledPackagesError::LibraryNotDirectory { path: actual } if actual == path
-        ));
+        assert!(matches!(error, InstalledPackagesError::Scan { .. }));
     }
 }

--- a/src/r.rs
+++ b/src/r.rs
@@ -191,12 +191,6 @@ fn project_r_command(program: impl AsRef<OsStr>, project_library: &Path) -> Comm
     command
 }
 
-fn rscript_query() -> Command {
-    let mut command = Command::new("Rscript");
-    command.arg("--vanilla");
-    command
-}
-
 static BASE_PACKAGES: OnceCell<BTreeSet<String>> = OnceCell::const_new();
 static R_VERSION: OnceCell<semver::Version> = OnceCell::const_new();
 
@@ -403,8 +397,12 @@ pub async fn installed_packages(
         "sep = '\t', row.names = FALSE, col.names = TRUE, quote = FALSE)"
     );
 
-    let mut command = rscript_query();
-    command.arg("-e").arg(expression).arg(project_library);
+    let mut command = Command::new("Rscript");
+    command
+        .arg("--vanilla")
+        .arg("-e")
+        .arg(expression)
+        .arg(project_library);
     let output = run_subprocess(command)
         .await
         .map_err(|source| InstalledPackagesError::Command { source })?;
@@ -558,8 +556,9 @@ async fn run_subprocess(mut command: Command) -> Result<Output, RSubprocessError
 }
 
 async fn fetch_base_packages() -> Result<BTreeSet<String>, BasePackagesError> {
-    let mut command = rscript_query();
+    let mut command = Command::new("Rscript");
     command
+        .arg("--vanilla")
         .arg("-e")
         .arg("writeLines(rownames(utils::installed.packages(priority = 'base')))");
     let output = run_subprocess(command)

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -913,8 +913,8 @@ pub(crate) enum InstallPackageError {
     },
     #[error(transparent)]
     Command(#[from] r::PackageInstallError),
-    #[error("installed package directory is missing at {}", path.display())]
-    InstalledPackageMissing { path: PathBuf },
+    #[error(transparent)]
+    InstalledPackageMissing(Box<InstalledPackageMissingError>),
     #[error("failed to inspect installed package directory at {}: {source}", path.display())]
     InspectInstalledPackage {
         path: PathBuf,
@@ -943,6 +943,23 @@ pub(crate) enum InstallPackageError {
         #[source]
         source: std::io::Error,
     },
+}
+
+#[derive(Debug, Error)]
+#[error(
+        "installed package directory is missing at {} after Rscript exited successfully installing {package} {version} from {} as {install_type} with R {r_version}\n\nstdout:\n{stdout}\n\nstderr:\n{stderr}",
+        path.display(),
+        artifact.display()
+    )]
+pub(crate) struct InstalledPackageMissingError {
+    path: PathBuf,
+    package: String,
+    version: String,
+    artifact: PathBuf,
+    install_type: String,
+    r_version: semver::Version,
+    stdout: String,
+    stderr: String,
 }
 
 #[derive(Debug, Error)]
@@ -1135,24 +1152,39 @@ async fn install_package(
             span.record("stage", "installing");
             span.pb_set_message(&format!("{package} {version} installing"));
             span.pb_tick();
-            install_package_artifact(
+            let output = install_package_artifact(
                 project_library,
                 &artifact,
                 package,
                 &version,
                 &install_type,
+                r_version,
                 &temporary_library,
             )
             .await?;
 
             let installed = temporary_library.join(package);
+            let missing_error = |path| {
+                InstallPackageError::InstalledPackageMissing(Box::new(
+                    InstalledPackageMissingError {
+                        path,
+                        package: package.to_string(),
+                        version: version.clone(),
+                        artifact: artifact.clone(),
+                        install_type: install_type.clone(),
+                        r_version: r_version.clone(),
+                        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
+                        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
+                    },
+                ))
+            };
             match tokio::fs::metadata(&installed).await {
                 Ok(metadata) if metadata.is_dir() => {}
                 Ok(_) => {
-                    return Err(InstallPackageError::InstalledPackageMissing { path: installed });
+                    return Err(missing_error(installed));
                 }
                 Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
-                    return Err(InstallPackageError::InstalledPackageMissing { path: installed });
+                    return Err(missing_error(installed));
                 }
                 Err(source) => {
                     return Err(InstallPackageError::InspectInstalledPackage {
@@ -1201,6 +1233,17 @@ async fn install_package(
             Ok(())
         }
         .await;
+
+        if result.is_err()
+            && std::env::var("RPX_KEEP_BUILD_TEMP").is_ok_and(|value| value == "1")
+        {
+            let preserved = workspace.keep();
+            tracing::warn!(
+                path = %preserved.display(),
+                "preserved failed package install workspace"
+            );
+            return result;
+        }
 
         span.record("stage", "cleaning up");
         span.pb_set_message(&format!("{package} {version} cleaning up"));

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,7 +1,7 @@
 use crate::{
     cache::{
-        BinaryArtifactCacheKey, CompiledPackageCacheKey, RegistryIdentity, SourceArtifactCacheKey,
-        SourceArtifactIdentity, binary_artifact_cache_path, compiled_package_cache_path,
+        BinaryArtifactCacheKey, INSTALLER_CACHE_VERSION, RegistryIdentity, SourceArtifactCacheKey,
+        SourceArtifactIdentity, binary_artifact_cache_path, installer_cache_path,
         source_artifact_cache_path,
     },
     description::{
@@ -9,24 +9,26 @@ use crate::{
     },
     http,
     project::{
-        Project, ProjectLibraryError, ProjectResolution, RequiredPackages, cache_dir_path,
-        ensure_project_library,
+        Project, ProjectLibraryError, ProjectResolution, RequiredPackages, ensure_project_library,
     },
-    r::{
-        self, BasePackagesError, base_packages, build_package_archive, install_package_artifact,
-        installed_packages, remove_packages_from_venv,
-    },
+    r::{self, BasePackagesError, base_packages, build_package_archive, installed_packages},
     repository::{
         CranRepository, GitRepository, LocalRepository, RepositoryError, RrepoRepository,
     },
     resolver::PackageVersion,
-    ui::{progress_bar_style, progress_spinner_style},
+    ui::{progress_bar_style, progress_count_style, progress_spinner_style},
 };
 use futures_util::StreamExt;
 use miette::Diagnostic;
+use r_package_installer::{
+    Artifact, BinaryArtifact, BinaryFormat, CacheKey, Digest as InstallerDigest, ExpectedPackage,
+    InstallOutcome, Installer, PrepareRequest, RemovalOutcome, SourceArtifact, SourceOptions,
+};
+use sha2::{Digest as _, Sha256};
 use std::{
     collections::{BTreeMap, BTreeSet},
     fs,
+    io::Read,
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -50,9 +52,19 @@ pub(crate) enum SyncError {
     #[error(transparent)]
     #[diagnostic(transparent)]
     InstalledPackages(#[from] r::InstalledPackagesError),
-    #[error(transparent)]
-    #[diagnostic(transparent)]
-    RemovePackages(#[from] r::PackageRemovalError),
+    #[error("failed to remove package {package}: {source}")]
+    #[diagnostic(code(rpx::sync::package_remove_failed))]
+    RemovePackage {
+        package: String,
+        #[source]
+        source: r_package_installer::Error,
+    },
+    #[error("failed to join blocking package operation: {source}")]
+    #[diagnostic(code(rpx::sync::blocking_task_failed))]
+    BlockingTask {
+        #[source]
+        source: tokio::task::JoinError,
+    },
     #[error("failed to prepare source artifacts: {details}")]
     #[diagnostic(code(rpx::sync::download_failed))]
     DownloadArtifactsFailed { details: String },
@@ -99,16 +111,11 @@ impl From<bool> for ProjectPackageMode {
     }
 }
 
-#[derive(Debug, Default, Eq, PartialEq)]
-pub(crate) struct SyncReport {
-    pub(crate) installed_before: BTreeSet<String>,
-}
-
 pub(crate) async fn sync_resolved_project(
     project: &Project,
     resolution: ProjectResolution,
     project_package: ProjectPackageMode,
-) -> Result<SyncReport, SyncError> {
+) -> Result<(), SyncError> {
     let mut required = resolution.packages;
     let (root_name, root_version) = root_package(&project.root, &project.description)?;
     required.remove(&root_name);
@@ -132,27 +139,102 @@ pub(crate) async fn sync_resolved_project(
     validate_package_graph(&required).await?;
 
     let project_library = ensure_project_library(&project.root)?;
+    let installer = Installer::new(installer_cache_path());
     let installed = installed_packages(&project_library).await?;
-    let installed_before = installed.keys().cloned().collect();
-    let removed = installed
-        .iter()
-        .filter(|(name, installed_version)| {
-            required.get(*name).is_none_or(|(required_version, _)| {
-                package_requires_install(required_version, Some(installed_version))
-            })
-        })
-        .map(|(name, _)| name.clone())
-        .collect::<BTreeSet<_>>();
-    let packages_to_install = required
-        .into_iter()
-        .filter(|(name, (required_version, _))| {
-            package_requires_install(required_version, installed.get(name))
-        })
-        .collect::<RequiredPackages>();
-    remove_packages_from_venv(&project_library, &removed)?;
-    install_required_packages(&project_library, packages_to_install, &resolution.r_version).await?;
+    let mut tasks = sync_tasks(&required, &installed)?;
+    let total_packages = pending_package_count(&tasks) as u64;
+    let sync_span = tracing::info_span!(
+        "sync_packages",
+        total = total_packages,
+        completed = 0_u64,
+        running = 0_u64,
+        pending = total_packages,
+        stage = tracing::field::Empty,
+        indicatif.pb_show = true,
+    );
+    sync_span.pb_set_style(&progress_count_style());
+    sync_span.pb_set_message("sync packages");
+    sync_span.pb_set_length(total_packages);
+    sync_span.pb_start();
 
-    Ok(SyncReport { installed_before })
+    let context = SyncTaskContext {
+        installer,
+        project_library,
+        r_version: Arc::new(resolution.r_version),
+    };
+    let mut resources = ResourcePool::new();
+    let mut running = tokio::task::JoinSet::<(TaskRow, Result<(), SyncError>)>::new();
+    let mut completed = 0_u64;
+
+    let result = loop {
+        while let Some(row) = pop_startable(&mut tasks, &resources) {
+            resources.reserve(row.task.1);
+            let task = row.task.clone();
+            let version = row.version.clone();
+            let dependencies = row.dependencies.clone();
+            let context = context.clone();
+            running.spawn(
+                async move {
+                    let result = run_sync_task(task, version, dependencies, context).await;
+                    (row, result)
+                }
+                .instrument(sync_span.clone()),
+            );
+        }
+
+        sync_span.record("running", running.len() as u64);
+        sync_span.record("pending", pending_package_count(&tasks) as u64);
+
+        if running.is_empty() && tasks.is_empty() {
+            break Ok(());
+        }
+        if running.is_empty() {
+            break Err(SyncError::DownloadArtifactsFailed {
+                details: "package task graph stalled with no runnable tasks".to_string(),
+            });
+        }
+
+        match running
+            .join_next()
+            .await
+            .expect("running task set should not be empty")
+        {
+            Ok((row, Ok(()))) => {
+                resources.release(row.task.1);
+                if row.task.1 == TaskKind::Install {
+                    completed += 1;
+                    sync_span.pb_inc(1);
+                }
+                complete_task(&mut tasks, row);
+            }
+            Ok((row, Err(error))) => {
+                resources.release(row.task.1);
+                break Err(error);
+            }
+            Err(error) => {
+                break Err(SyncError::DownloadArtifactsFailed {
+                    details: format!("sync task failed to join: {error}"),
+                });
+            }
+        }
+
+        sync_span.record("completed", completed);
+        sync_span.record("running", running.len() as u64);
+        sync_span.record("pending", pending_package_count(&tasks) as u64);
+    };
+
+    if result.is_err() {
+        while running.join_next().await.is_some() {}
+    }
+
+    sync_span.record("completed", completed);
+    sync_span.record("running", 0_u64);
+    sync_span.record("pending", 0_u64);
+    sync_span.record("stage", "done");
+    sync_span.pb_set_finish_message(&format!("sync packages {completed}/{total_packages}"));
+    result?;
+
+    Ok(())
 }
 
 fn package_requires_install(required: &PackageVersion, installed: Option<&PackageVersion>) -> bool {
@@ -170,12 +252,14 @@ const SYNC_R_WORKERS: usize = 8;
 
 #[derive(Clone)]
 struct SyncTaskContext {
+    installer: Installer,
     project_library: PathBuf,
     r_version: Arc<semver::Version>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 enum TaskKind {
+    Remove,
     Download,
     Checkout,
     Build,
@@ -185,10 +269,17 @@ enum TaskKind {
 type TaskId = (String, TaskKind);
 
 #[derive(Clone)]
+struct DependencyInput {
+    name: String,
+    version: Option<String>,
+}
+
+#[derive(Clone)]
 struct TaskRow {
     blockers: usize,
     task: TaskId,
     version: PackageVersion,
+    dependencies: Vec<DependencyInput>,
     dependents: BTreeSet<TaskId>,
 }
 
@@ -255,20 +346,28 @@ impl ResourcePool {
     }
 }
 
-fn install_tasks(packages: RequiredPackages) -> Result<BTreeSet<TaskRow>, SyncError> {
-    let package_names = packages.keys().cloned().collect::<BTreeSet<_>>();
-    let packages = packages
-        .into_iter()
+fn sync_tasks(
+    required: &RequiredPackages,
+    installed: &BTreeMap<String, PackageVersion>,
+) -> Result<BTreeSet<TaskRow>, SyncError> {
+    let package_names = required
+        .iter()
+        .filter(|(name, (version, _))| package_requires_install(version, installed.get(*name)))
+        .map(|(name, _)| name.clone())
+        .collect::<BTreeSet<_>>();
+    let packages = required
+        .iter()
+        .filter(|(package, _)| package_names.contains(*package))
         .map(|(package, (version, description))| {
             let dependencies =
-                required_dependencies(format!("{package} {}", version.version()), &description)?
+                required_dependencies(format!("{package} {}", version.version()), description)?
                     .into_iter()
                     .map(|relation| relation.package().to_string())
                     .collect::<BTreeSet<_>>();
-            Ok((package, version, dependencies))
+            Ok((package.clone(), version.clone(), dependencies))
         })
         .collect::<Result<Vec<_>, SyncError>>()?;
-    Ok(packages
+    let install_tasks = packages
         .iter()
         .flat_map(|(package, package_version, dependencies)| {
             let install = (package.clone(), TaskKind::Install);
@@ -281,6 +380,15 @@ fn install_tasks(packages: RequiredPackages) -> Result<BTreeSet<TaskRow>, SyncEr
                 .filter(|(_, _, dependencies)| dependencies.contains(package))
                 .map(|(dependent, _, _)| (dependent.clone(), TaskKind::Install))
                 .collect::<BTreeSet<_>>();
+            let dependency_inputs = dependencies
+                .iter()
+                .map(|dependency| DependencyInput {
+                    name: dependency.clone(),
+                    version: required
+                        .get(dependency)
+                        .map(|(version, _)| version.version().to_string()),
+                })
+                .collect::<Vec<_>>();
             let repository = package_version.repository();
 
             match (
@@ -292,12 +400,14 @@ fn install_tasks(packages: RequiredPackages) -> Result<BTreeSet<TaskRow>, SyncEr
                         blockers: 0,
                         task: (package.clone(), TaskKind::Build),
                         version: package_version.clone(),
+                        dependencies: Vec::new(),
                         dependents: BTreeSet::from([install.clone()]),
                     },
                     TaskRow {
                         blockers: install_blockers,
                         task: install,
                         version: package_version.clone(),
+                        dependencies: dependency_inputs,
                         dependents: install_dependents,
                     },
                 ],
@@ -308,18 +418,21 @@ fn install_tasks(packages: RequiredPackages) -> Result<BTreeSet<TaskRow>, SyncEr
                             blockers: 0,
                             task: (package.clone(), TaskKind::Checkout),
                             version: package_version.clone(),
+                            dependencies: Vec::new(),
                             dependents: BTreeSet::from([build.clone()]),
                         },
                         TaskRow {
                             blockers: 1,
                             task: build,
                             version: package_version.clone(),
+                            dependencies: Vec::new(),
                             dependents: BTreeSet::from([install.clone()]),
                         },
                         TaskRow {
                             blockers: install_blockers,
                             task: install,
                             version: package_version.clone(),
+                            dependencies: dependency_inputs,
                             dependents: install_dependents,
                         },
                     ]
@@ -329,18 +442,30 @@ fn install_tasks(packages: RequiredPackages) -> Result<BTreeSet<TaskRow>, SyncEr
                         blockers: 0,
                         task: (package.clone(), TaskKind::Download),
                         version: package_version.clone(),
+                        dependencies: Vec::new(),
                         dependents: BTreeSet::from([install.clone()]),
                     },
                     TaskRow {
                         blockers: install_blockers,
                         task: install,
                         version: package_version.clone(),
+                        dependencies: dependency_inputs,
                         dependents: install_dependents,
                     },
                 ],
             }
-        })
-        .collect())
+        });
+    let remove_tasks = installed
+        .iter()
+        .filter(|(package, _)| !required.contains_key(*package))
+        .map(|(package, version)| TaskRow {
+            blockers: 0,
+            task: (package.clone(), TaskKind::Remove),
+            version: version.clone(),
+            dependencies: Vec::new(),
+            dependents: BTreeSet::new(),
+        });
+    Ok(install_tasks.chain(remove_tasks).collect())
 }
 
 fn pop_startable(tasks: &mut BTreeSet<TaskRow>, resources: &ResourcePool) -> Option<TaskRow> {
@@ -414,116 +539,31 @@ pub(crate) struct CycleBlockedPackage {
     package: String,
 }
 
-async fn install_required_packages(
-    project_library: &Path,
-    packages: RequiredPackages,
-    r_version: &semver::Version,
-) -> Result<(), SyncError> {
-    let total_packages = packages.len() as u64;
-    let sync_span = tracing::info_span!(
-        "sync_packages",
-        total = total_packages,
-        completed = 0_u64,
-        running = 0_u64,
-        pending = total_packages,
-        stage = tracing::field::Empty,
-        indicatif.pb_show = true,
-    );
-    sync_span.pb_set_style(&progress_spinner_style());
-    sync_span.pb_set_message(&format!("sync packages 0/{total_packages}"));
-    sync_span.pb_set_length(total_packages);
-    sync_span.pb_start();
-
-    if packages.is_empty() {
-        sync_span.record("stage", "done");
-        sync_span.pb_set_finish_message("sync packages 0/0");
-        return Ok(());
-    }
-
-    let context = SyncTaskContext {
-        project_library: project_library.to_path_buf(),
-        r_version: Arc::new(r_version.clone()),
-    };
-    let mut tasks = install_tasks(packages)?;
-    let mut resources = ResourcePool::new();
-    let mut running = tokio::task::JoinSet::<(TaskRow, Result<(), SyncError>)>::new();
-    let mut completed = 0_u64;
-
-    let result = loop {
-        while let Some(row) = pop_startable(&mut tasks, &resources) {
-            resources.reserve(row.task.1);
-            let task = row.task.clone();
-            let version = row.version.clone();
-            let context = context.clone();
-            running.spawn(
-                async move {
-                    let result = run_sync_task(task, version, context).await;
-                    (row, result)
-                }
-                .instrument(sync_span.clone()),
-            );
-        }
-
-        sync_span.record("running", running.len() as u64);
-        sync_span.record("pending", pending_package_count(&tasks) as u64);
-
-        if running.is_empty() && tasks.is_empty() {
-            break Ok(());
-        }
-        if running.is_empty() {
-            break Err(SyncError::DownloadArtifactsFailed {
-                details: "package task graph stalled with no runnable tasks".to_string(),
-            });
-        }
-
-        match running
-            .join_next()
-            .await
-            .expect("running task set should not be empty")
-        {
-            Ok((row, Ok(()))) => {
-                resources.release(row.task.1);
-                if row.task.1 == TaskKind::Install {
-                    completed += 1;
-                }
-                complete_task(&mut tasks, row);
-            }
-            Ok((row, Err(error))) => {
-                resources.release(row.task.1);
-                break Err(error);
-            }
-            Err(error) => {
-                break Err(SyncError::DownloadArtifactsFailed {
-                    details: format!("sync task failed to join: {error}"),
-                });
-            }
-        }
-
-        sync_span.record("completed", completed);
-        sync_span.record("running", running.len() as u64);
-        sync_span.record("pending", pending_package_count(&tasks) as u64);
-        sync_span.pb_set_position(completed);
-        sync_span.pb_set_message(&format!("sync packages {completed}/{total_packages}"));
-    };
-
-    if result.is_err() {
-        while running.join_next().await.is_some() {}
-    }
-
-    sync_span.record("completed", completed);
-    sync_span.record("running", 0_u64);
-    sync_span.record("pending", 0_u64);
-    sync_span.record("stage", "done");
-    sync_span.pb_set_finish_message(&format!("sync packages {completed}/{total_packages}"));
-    result
-}
-
 async fn run_sync_task(
     (package, kind): TaskId,
     package_version: PackageVersion,
+    dependencies: Vec<DependencyInput>,
     context: SyncTaskContext,
 ) -> Result<(), SyncError> {
     match kind {
+        TaskKind::Remove => {
+            let installer = context.installer;
+            let project_library = context.project_library;
+            let package_for_remove = package.clone();
+            let outcome = tokio::task::spawn_blocking(move || {
+                installer.remove(&project_library, &package_for_remove)
+            })
+            .await
+            .map_err(|source| SyncError::BlockingTask { source })?
+            .map_err(|source| SyncError::RemovePackage {
+                package: package.clone(),
+                source,
+            })?;
+            if let RemovalOutcome::CommittedCleanupPending { lock } = outcome {
+                tracing::warn!(package, path = %lock.display(), "package removal committed but cleanup remains pending");
+            }
+            Ok(())
+        }
         TaskKind::Download => {
             let version = package_version.version().to_string();
             download_package_artifact(package.clone(), package_version, context.r_version)
@@ -601,10 +641,12 @@ async fn run_sync_task(
             })
         }
         TaskKind::Install => install_package(
+            &context.installer,
             &context.project_library,
             &package,
             &package_version,
             context.r_version.as_ref(),
+            &dependencies,
         )
         .await
         .map_err(|source| SyncError::PackageInstall {
@@ -618,6 +660,8 @@ async fn run_sync_task(
 pub(crate) enum DownloadPackageArtifactError {
     #[error("unsupported remote package repository")]
     UnsupportedRepository,
+    #[error("artifact cache entry is not a file: {}", path.display())]
+    InvalidArtifact { path: PathBuf },
     #[error("failed to request binary artifact: {source}")]
     BinaryRequest {
         #[source]
@@ -703,120 +747,104 @@ async fn download_package_artifact(
         total_bytes = tracing::field::Empty,
         indicatif.pb_show = true,
     );
-    span.pb_set_style(&progress_spinner_style());
     span.pb_set_message(&format!("{package} {version} preparing"));
     span.pb_start();
 
     async {
-        let repository = package_version.repository();
-        let repository =
-            if let Some(repository) = repository.as_ref().downcast_ref::<RrepoRepository>() {
-                RegistryIdentity::Rrepo(repository.url().clone())
-            } else if let Some(repository) = repository.as_ref().downcast_ref::<CranRepository>() {
-                RegistryIdentity::Cran(repository.url().clone())
-            } else {
-                return Err(DownloadPackageArtifactError::UnsupportedRepository);
-            };
+        let repository = registry_identity(&package_version)
+            .ok_or(DownloadPackageArtifactError::UnsupportedRepository)?;
         span.record(
             "repository",
             match &repository {
                 RegistryIdentity::Cran(url) | RegistryIdentity::Rrepo(url) => url.as_str(),
             },
         );
-        let compiled = compiled_package_cache_path(&CompiledPackageCacheKey::new(
-            repository.clone(),
-            &package,
-            package_version.version().clone(),
-            HOST.clone(),
-            r_version.as_ref().clone(),
-        ));
-        if compiled.is_dir() {
-            span.record("artifact_kind", "compiled-cache");
-            span.record("stage", "prepared");
-            span.pb_set_message(&format!("{package} {version} prepared"));
-            span.pb_tick();
-            return Ok(());
-        }
-
         span.record("stage", "downloading binary");
         span.pb_set_message(&format!("{package} {version} downloading binary"));
-        span.pb_tick();
-        let binary = async {
-            let key = BinaryArtifactCacheKey::new(
-                repository.clone(),
-                &package,
-                package_version.version().clone(),
-                HOST.clone(),
-                r_version.as_ref().clone(),
-            );
-            let path = binary_artifact_cache_path(&key);
-            if path.exists() {
-                return Ok(());
-            }
+        match registry_binary_artifact(&repository, &package, &package_version, r_version.as_ref()) {
+            Ok(Some(binary)) => {
+                let binary_result = async {
+                    match artifact_cache_entry(&binary.path) {
+                        ArtifactCacheEntry::File => return Ok(()),
+                        ArtifactCacheEntry::Invalid => {
+                            return Err(DownloadPackageArtifactError::InvalidArtifact {
+                                path: binary.path,
+                            });
+                        }
+                        ArtifactCacheEntry::Missing => {}
+                    }
+                    let response = match &repository {
+                        RegistryIdentity::Rrepo(url) => http::rrepo_binary(
+                            url,
+                            &package,
+                            &version,
+                            &HOST,
+                            r_version.as_ref(),
+                        )
+                        .await,
+                        RegistryIdentity::Cran(url) => http::cran_binary(
+                            url,
+                            &package,
+                            &version,
+                            &HOST,
+                            r_version.as_ref(),
+                        )
+                        .await,
+                    }
+                    .map_err(|source| DownloadPackageArtifactError::BinaryRequest { source })?
+                    .error_for_status()
+                    .map_err(|source| DownloadPackageArtifactError::Response {
+                        artifact: "binary",
+                        source,
+                    })?;
+                    span.record("artifact_kind", "binary");
+                    publish_artifact_response(binary.path, response, &span).await
+                }
+                .await;
 
-            let response = match &repository {
-                RegistryIdentity::Rrepo(url) => http::rrepo_binary(
-                    url,
-                    &package,
-                    &version,
-                    &HOST,
-                    r_version.as_ref(),
-                )
-                .await,
-                RegistryIdentity::Cran(url) => http::cran_binary(
-                    url,
-                    &package,
-                    &version,
-                    &HOST,
-                    r_version.as_ref(),
-                )
-                .await,
+                match binary_result {
+                    Ok(()) => {
+                        span.record("stage", "prepared");
+                        span.pb_set_message(&format!("{package} {version} prepared"));
+                        return Ok(());
+                    }
+                    Err(error @ DownloadPackageArtifactError::InvalidArtifact { .. }) => {
+                        return Err(error);
+                    }
+                    Err(error) => tracing::debug!(
+                        package = %package,
+                        version = %version,
+                        %error,
+                        "binary artifact unavailable; falling back to source"
+                    ),
+                }
             }
-            .map_err(|source| DownloadPackageArtifactError::BinaryRequest { source })?
-            .error_for_status()
-            .map_err(|source| DownloadPackageArtifactError::Response {
-                artifact: "binary",
-                source,
-            })?;
-            span.record("artifact_kind", "binary");
-            publish_artifact_response(path, response, &span).await
+            Ok(None) => {}
+            Err(error) => tracing::debug!(
+                package = %package,
+                version = %version,
+                %error,
+                "binary artifact unavailable; falling back to source"
+            ),
         }
-        .await;
-
-        let binary_error = match binary {
-            Ok(()) => {
-                span.record("stage", "prepared");
-                span.pb_set_message(&format!("{package} {version} prepared"));
-                span.pb_tick();
-                return Ok(());
-            }
-            Err(error) => error,
-        };
-        tracing::debug!(
-            package = %package,
-            version = %version,
-            error = %binary_error,
-            "binary artifact unavailable; falling back to source"
-        );
 
         span.pb_set_style(&progress_spinner_style());
         span.record("stage", "falling back to source");
         span.pb_set_message(&format!("{package} {version} falling back to source"));
-        span.pb_tick();
         span.record("stage", "downloading source");
         span.pb_set_message(&format!("{package} {version} downloading source"));
-        span.pb_tick();
-        let key = SourceArtifactCacheKey::new(
-            SourceArtifactIdentity::Registry(repository.clone()),
-            &package,
-            package_version.version().clone(),
-        );
-        let path = source_artifact_cache_path(&key);
-        if path.exists() {
-            span.record("stage", "prepared");
-            span.pb_set_message(&format!("{package} {version} prepared"));
-            span.pb_tick();
-            return Ok(());
+        let source = registry_source_artifact(&repository, &package, &package_version);
+        let path = source.path;
+        match artifact_cache_entry(&path) {
+            ArtifactCacheEntry::File => {
+                span.record("stage", "prepared");
+                span.pb_set_message(&format!("{package} {version} prepared"));
+                return Ok(());
+            }
+            ArtifactCacheEntry::Invalid => {
+                return Err(DownloadPackageArtifactError::InvalidArtifact { path });
+            }
+            ArtifactCacheEntry::Missing => {}
         }
 
         let response = match &repository {
@@ -869,7 +897,6 @@ async fn download_package_artifact(
         publish_artifact_response(path, response, &span).await?;
         span.record("stage", "prepared");
         span.pb_set_message(&format!("{package} {version} prepared"));
-        span.pb_tick();
         Ok(())
     }
     .instrument(span.clone())
@@ -893,117 +920,218 @@ pub(crate) enum InstallPackageError {
     },
     #[error("no installable artifact exists for {package} {version}")]
     MissingArtifact { package: String, version: String },
-    #[error("failed to prepare package install workspace root at {}: {source}", path.display())]
-    WorkspaceRoot {
+    #[error("artifact cache entry is not a file: {}", path.display())]
+    InvalidArtifact { path: PathBuf },
+    #[error("failed to determine the artifact digest at {}: {source}", path.display())]
+    ArtifactDigest {
         path: PathBuf,
         #[source]
         source: std::io::Error,
     },
-    #[error("failed to create package install workspace in {}: {source}", path.display())]
-    Workspace {
-        path: PathBuf,
+    #[error("package installer failed: {source}")]
+    Installer {
         #[source]
-        source: std::io::Error,
+        source: r_package_installer::Error,
     },
-    #[error("failed to create temporary package library at {}: {source}", path.display())]
-    TemporaryLibrary {
-        path: PathBuf,
-        #[source]
-        source: std::io::Error,
-    },
-    #[error(transparent)]
-    Command(#[from] r::PackageInstallError),
-    #[error(transparent)]
-    InstalledPackageMissing(Box<InstalledPackageMissingError>),
-    #[error("failed to inspect installed package directory at {}: {source}", path.display())]
-    InspectInstalledPackage {
-        path: PathBuf,
-        #[source]
-        source: std::io::Error,
-    },
-    #[error("failed to prepare compiled package cache directory at {}: {source}", path.display())]
-    CompiledCacheDirectory {
-        path: PathBuf,
-        #[source]
-        source: std::io::Error,
-    },
-    #[error("compiled package cache path is not a directory: {}", path.display())]
-    InvalidCompiledCache { path: PathBuf },
-    #[error("failed to publish compiled package at {}: {source}", path.display())]
-    PublishCompiledPackage {
-        path: PathBuf,
-        #[source]
-        source: std::io::Error,
-    },
-    #[error(transparent)]
-    PublishProject(#[from] PublishInstalledPackageError),
-    #[error("failed to clean package install workspace at {}: {source}", path.display())]
-    Cleanup {
-        path: PathBuf,
-        #[source]
-        source: std::io::Error,
-    },
-}
-
-#[derive(Debug, Error)]
-#[error(
-        "installed package directory is missing at {} after Rscript exited successfully installing {package} {version} from {} as {install_type} with R {r_version}\n\nstdout:\n{stdout}\n\nstderr:\n{stderr}",
-        path.display(),
-        artifact.display()
-    )]
-pub(crate) struct InstalledPackageMissingError {
-    path: PathBuf,
-    package: String,
-    version: String,
-    artifact: PathBuf,
-    install_type: String,
-    r_version: semver::Version,
-    stdout: String,
-    stderr: String,
-}
-
-#[derive(Debug, Error)]
-pub(crate) enum PublishInstalledPackageError {
-    #[error("failed to publish package because the destination already exists: {}", path.display())]
-    DestinationExists { path: PathBuf },
-    #[error("failed to create package staging directory in {}: {source}", path.display())]
-    CreateStagingDirectory {
-        path: PathBuf,
-        #[source]
-        source: std::io::Error,
-    },
-    #[error("failed to stage installed package from {}: {source}", path.display())]
-    StagePackage {
-        path: PathBuf,
-        #[source]
-        source: std::io::Error,
-    },
-    #[error("staged package metadata is missing at {}", path.display())]
-    MissingMetadata { path: PathBuf },
-    #[error("failed to publish installed package at {}: {source}", path.display())]
-    Publish {
-        path: PathBuf,
-        #[source]
-        source: std::io::Error,
-    },
-    #[error("failed to clean package staging directory at {}: {source}", path.display())]
-    Cleanup {
-        path: PathBuf,
-        #[source]
-        source: std::io::Error,
-    },
-    #[error("failed to join package publication task: {source}")]
+    #[error("failed to join package installer task: {source}")]
     Join {
         #[source]
         source: tokio::task::JoinError,
     },
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ArtifactKind {
+    Binary(BinaryFormat),
+    Source,
+}
+
+struct InstallArtifact {
+    path: PathBuf,
+    kind: ArtifactKind,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ArtifactCacheEntry {
+    File,
+    Missing,
+    Invalid,
+}
+
+fn artifact_cache_entry(path: &Path) -> ArtifactCacheEntry {
+    if path.is_file() {
+        ArtifactCacheEntry::File
+    } else if path.exists() {
+        ArtifactCacheEntry::Invalid
+    } else {
+        ArtifactCacheEntry::Missing
+    }
+}
+
+impl InstallArtifact {
+    fn trace_kind(&self) -> &'static str {
+        match self.kind {
+            ArtifactKind::Binary(_) => "binary",
+            ArtifactKind::Source => "source",
+        }
+    }
+
+    fn progress_action(&self) -> &'static str {
+        match self.kind {
+            ArtifactKind::Binary(_) => "extracting",
+            ArtifactKind::Source => "installing",
+        }
+    }
+
+    fn into_installer_artifact(self, project_library: PathBuf) -> Artifact {
+        match self.kind {
+            ArtifactKind::Binary(format) => Artifact::Binary(BinaryArtifact {
+                path: self.path,
+                format,
+            }),
+            ArtifactKind::Source => Artifact::Source(SourceArtifact {
+                path: self.path,
+                options: SourceOptions {
+                    dependency_libraries: vec![project_library],
+                    allow_non_staged: true,
+                    ..SourceOptions::default()
+                },
+            }),
+        }
+    }
+}
+
+fn registry_identity(package_version: &PackageVersion) -> Option<RegistryIdentity> {
+    let repository = package_version.repository();
+    let repository = repository.as_ref();
+    if let Some(repository) = repository.downcast_ref::<RrepoRepository>() {
+        Some(RegistryIdentity::Rrepo(repository.url().clone()))
+    } else {
+        repository
+            .downcast_ref::<CranRepository>()
+            .map(|repository| RegistryIdentity::Cran(repository.url().clone()))
+    }
+}
+
+fn registry_binary_artifact(
+    registry: &RegistryIdentity,
+    package: &str,
+    package_version: &PackageVersion,
+    r_version: &semver::Version,
+) -> Result<Option<InstallArtifact>, http::BinaryArtifactRequestError> {
+    let format = match HOST.operating_system {
+        OperatingSystem::Windows => BinaryFormat::Zip,
+        OperatingSystem::Darwin(_) | OperatingSystem::MacOSX(_) => {
+            http::r_macos_binary_target(&HOST)?;
+            BinaryFormat::TarGz
+        }
+        _ => return Ok(None),
+    };
+    let path = binary_artifact_cache_path(&BinaryArtifactCacheKey::new(
+        registry.clone(),
+        package,
+        package_version.version().clone(),
+        HOST.clone(),
+        r_version.clone(),
+    ));
+    Ok(Some(InstallArtifact {
+        path,
+        kind: ArtifactKind::Binary(format),
+    }))
+}
+
+fn registry_source_artifact(
+    registry: &RegistryIdentity,
+    package: &str,
+    package_version: &PackageVersion,
+) -> InstallArtifact {
+    InstallArtifact {
+        path: source_artifact_cache_path(&SourceArtifactCacheKey::new(
+            SourceArtifactIdentity::Registry(registry.clone()),
+            package,
+            package_version.version().clone(),
+        )),
+        kind: ArtifactKind::Source,
+    }
+}
+
+async fn select_install_artifact(
+    package: &str,
+    package_version: &PackageVersion,
+    r_version: &semver::Version,
+) -> Result<InstallArtifact, InstallPackageError> {
+    let repository = package_version.repository();
+    let repository = repository.as_ref();
+    let artifact = if let Some(registry) = registry_identity(package_version) {
+        if let Some(binary) =
+            registry_binary_artifact(&registry, package, package_version, r_version)
+                .map_err(|source| InstallPackageError::MacBinaryType { source })?
+        {
+            match artifact_cache_entry(&binary.path) {
+                ArtifactCacheEntry::File => binary,
+                ArtifactCacheEntry::Invalid => {
+                    return Err(InstallPackageError::InvalidArtifact { path: binary.path });
+                }
+                ArtifactCacheEntry::Missing => {
+                    registry_source_artifact(&registry, package, package_version)
+                }
+            }
+        } else {
+            registry_source_artifact(&registry, package, package_version)
+        }
+    } else if let Some(repository) = repository.downcast_ref::<LocalRepository>() {
+        InstallArtifact {
+            path: source_artifact_cache_path(&SourceArtifactCacheKey::new(
+                SourceArtifactIdentity::Local(repository.path().to_path_buf()),
+                package,
+                package_version.version().clone(),
+            )),
+            kind: ArtifactKind::Source,
+        }
+    } else if let Some(repository) = repository.downcast_ref::<GitRepository>() {
+        let commit =
+            repository
+                .commit()
+                .await
+                .map_err(|source| InstallPackageError::GitCommit {
+                    package: package.to_string(),
+                    source,
+                })?;
+        InstallArtifact {
+            path: source_artifact_cache_path(&SourceArtifactCacheKey::new(
+                SourceArtifactIdentity::Git {
+                    remote: repository.remote().clone(),
+                    commit,
+                    subdirectory: repository.subdirectory().map(Path::to_path_buf),
+                },
+                package,
+                package_version.version().clone(),
+            )),
+            kind: ArtifactKind::Source,
+        }
+    } else {
+        return Err(InstallPackageError::UnsupportedRepository);
+    };
+
+    match artifact_cache_entry(&artifact.path) {
+        ArtifactCacheEntry::File => Ok(artifact),
+        ArtifactCacheEntry::Invalid => Err(InstallPackageError::InvalidArtifact {
+            path: artifact.path,
+        }),
+        ArtifactCacheEntry::Missing => Err(InstallPackageError::MissingArtifact {
+            package: package.to_string(),
+            version: package_version.version().to_string(),
+        }),
+    }
+}
+
 async fn install_package(
+    installer: &Installer,
     project_library: &Path,
     package: &str,
     package_version: &PackageVersion,
     r_version: &semver::Version,
+    dependencies: &[DependencyInput],
 ) -> Result<(), InstallPackageError> {
     let version = package_version.version().to_string();
     let span = tracing::info_span!(
@@ -1014,331 +1142,137 @@ async fn install_package(
         artifact_kind = tracing::field::Empty,
         indicatif.pb_show = true,
     );
-    span.pb_set_style(&progress_spinner_style());
-    span.pb_set_message(&format!("{package} {version} installing"));
+    span.pb_set_message(&format!("{package} {version} preparing"));
     span.pb_start();
 
     async {
-        let repository = package_version.repository();
-        let repository = repository.as_ref();
-        let registry = if let Some(repository) = repository.downcast_ref::<RrepoRepository>() {
-            Some(RegistryIdentity::Rrepo(repository.url().clone()))
-        } else {
-            repository
-                .downcast_ref::<CranRepository>()
-                .map(|repository| RegistryIdentity::Cran(repository.url().clone()))
-        };
-        let compiled = registry.as_ref().map(|registry| {
-            compiled_package_cache_path(&CompiledPackageCacheKey::new(
-                registry.clone(),
-                package,
-                package_version.version().clone(),
-                HOST.clone(),
-                r_version.clone(),
-            ))
-        });
+        let artifact = select_install_artifact(package, package_version, r_version).await?;
+        span.record("artifact_kind", artifact.trace_kind());
 
-        if let Some(compiled) = &compiled
-            && compiled.is_dir()
-        {
-            span.record("artifact_kind", "compiled-cache");
-            span.record("stage", "restoring project library");
-            span.pb_set_message(&format!("{package} {version} restoring project library"));
-            span.pb_tick();
-            publish_installed_package(compiled, project_library, package).await?;
-            span.record("stage", "done");
-            span.pb_set_message(&format!("{package} {version} done"));
-            span.pb_tick();
-            return Ok(());
-        }
+        let dependency_inputs = dependencies
+            .iter()
+            .map(|dependency| (dependency.name.clone(), dependency.version.clone()))
+            .collect::<Vec<_>>();
+        let prepare_installer = installer.clone();
+        let artifact_path = artifact.path.clone();
+        let artifact_kind = artifact.kind;
+        let project_library_for_prepare = project_library.to_path_buf();
+        let package_for_prepare = package.to_string();
+        let version_for_prepare = version.clone();
+        let r_version_for_prepare = r_version.clone();
 
-        let (artifact, install_type) = if let Some(registry) = &registry {
-            let binary = match HOST.operating_system {
-                OperatingSystem::Windows => Some("win.binary".to_string()),
-                OperatingSystem::Darwin(_) | OperatingSystem::MacOSX(_) => Some(format!(
-                    "mac.binary.{}",
-                    http::r_macos_binary_target(&HOST)
-                        .map_err(|source| InstallPackageError::MacBinaryType { source })?
-                )),
-                _ => None,
-            }
-            .map(|install_type| {
-                let path = binary_artifact_cache_path(&BinaryArtifactCacheKey::new(
-                    registry.clone(),
-                    package,
-                    package_version.version().clone(),
-                    HOST.clone(),
-                    r_version.clone(),
-                ));
-                (path, install_type)
-            });
-            if let Some((path, install_type)) = binary
-                && path.is_file()
-            {
-                (path, install_type)
-            } else {
-                (
-                    source_artifact_cache_path(&SourceArtifactCacheKey::new(
-                        SourceArtifactIdentity::Registry(registry.clone()),
-                        package,
-                        package_version.version().clone(),
-                    )),
-                    "source".to_string(),
-                )
-            }
-        } else if let Some(repository) = repository.downcast_ref::<LocalRepository>() {
-            (
-                source_artifact_cache_path(&SourceArtifactCacheKey::new(
-                    SourceArtifactIdentity::Local(repository.path().to_path_buf()),
-                    package,
-                    package_version.version().clone(),
-                )),
-                "source".to_string(),
-            )
-        } else if let Some(repository) = repository.downcast_ref::<GitRepository>() {
-            let commit = repository.commit().await.map_err(|source| {
-                InstallPackageError::GitCommit {
-                    package: package.to_string(),
+        span.record("stage", "preparing cache");
+        span.pb_set_message(&format!(
+            "{package} {version} {}",
+            artifact.progress_action()
+        ));
+        let entry = tokio::task::spawn_blocking(move || {
+            let artifact_digest = artifact_digest(&artifact_path).map_err(|source| {
+                InstallPackageError::ArtifactDigest {
+                    path: artifact_path.clone(),
                     source,
                 }
             })?;
-            (
-                source_artifact_cache_path(&SourceArtifactCacheKey::new(
-                    SourceArtifactIdentity::Git {
-                        remote: repository.remote().clone(),
-                        commit,
-                        subdirectory: repository.subdirectory().map(Path::to_path_buf),
-                    },
-                    package,
-                    package_version.version().clone(),
-                )),
-                "source".to_string(),
-            )
-        } else {
-            return Err(InstallPackageError::UnsupportedRepository);
-        };
-        if !artifact.is_file() {
-            return Err(InstallPackageError::MissingArtifact {
-                package: package.to_string(),
-                version,
-            });
-        }
-        span.record("artifact_kind", install_type.as_str());
-
-        let workspace_parent = cache_dir_path().join("build-temp");
-        tokio::fs::create_dir_all(&workspace_parent)
-            .await
-            .map_err(|source| InstallPackageError::WorkspaceRoot {
-                path: workspace_parent.clone(),
-                source,
-            })?;
-        let workspace = tempfile::Builder::new()
-            .prefix("rpx-install-")
-            .tempdir_in(&workspace_parent)
-            .map_err(|source| InstallPackageError::Workspace {
-                path: workspace_parent,
-                source,
-            })?;
-        let workspace_path = workspace.path().to_path_buf();
-        let temporary_library = workspace.path().join("library");
-        tokio::fs::create_dir(&temporary_library)
-            .await
-            .map_err(|source| InstallPackageError::TemporaryLibrary {
-                path: temporary_library.clone(),
-                source,
-            })?;
-
-        let result = async {
-            span.record("stage", "installing");
-            span.pb_set_message(&format!("{package} {version} installing"));
-            span.pb_tick();
-            let output = install_package_artifact(
-                project_library,
-                &artifact,
-                package,
-                &version,
-                &install_type,
-                r_version,
-                &temporary_library,
-            )
-            .await?;
-
-            let installed = temporary_library.join(package);
-            let missing_error = |path| {
-                InstallPackageError::InstalledPackageMissing(Box::new(
-                    InstalledPackageMissingError {
-                        path,
-                        package: package.to_string(),
-                        version: version.clone(),
-                        artifact: artifact.clone(),
-                        install_type: install_type.clone(),
-                        r_version: r_version.clone(),
-                        stdout: String::from_utf8_lossy(&output.stdout).into_owned(),
-                        stderr: String::from_utf8_lossy(&output.stderr).into_owned(),
-                    },
-                ))
-            };
-            match tokio::fs::metadata(&installed).await {
-                Ok(metadata) if metadata.is_dir() => {}
-                Ok(_) => {
-                    return Err(missing_error(installed));
-                }
-                Err(source) if source.kind() == std::io::ErrorKind::NotFound => {
-                    return Err(missing_error(installed));
-                }
-                Err(source) => {
-                    return Err(InstallPackageError::InspectInstalledPackage {
-                        path: installed,
-                        source,
-                    });
-                }
-            }
-
-            let installed = if let Some(compiled) = &compiled {
-                span.record("stage", "storing cache");
-                span.pb_set_message(&format!("{package} {version} storing cache"));
-                span.pb_tick();
-                let parent = compiled
-                    .parent()
-                    .expect("compiled package cache path should have a parent");
-                tokio::fs::create_dir_all(parent).await.map_err(|source| {
-                    InstallPackageError::CompiledCacheDirectory {
-                        path: parent.to_path_buf(),
-                        source,
-                    }
-                })?;
-                if compiled.exists() {
-                    if !compiled.is_dir() {
-                        return Err(InstallPackageError::InvalidCompiledCache {
-                            path: compiled.clone(),
-                        });
-                    }
-                } else {
-                    tokio::fs::rename(&installed, compiled).await.map_err(|source| {
-                        InstallPackageError::PublishCompiledPackage {
-                            path: compiled.clone(),
-                            source,
-                        }
-                    })?;
-                }
-                compiled.clone()
-            } else {
-                installed
-            };
-
-            span.record("stage", "restoring project library");
-            span.pb_set_message(&format!("{package} {version} restoring project library"));
-            span.pb_tick();
-            publish_installed_package(&installed, project_library, package).await?;
-            Ok(())
-        }
-        .await;
-
-        if result.is_err()
-            && std::env::var("RPX_KEEP_BUILD_TEMP").is_ok_and(|value| value == "1")
-        {
-            let preserved = workspace.keep();
-            tracing::warn!(
-                path = %preserved.display(),
-                "preserved failed package install workspace"
+            let key = installer_build_key(
+                artifact_kind,
+                artifact_digest,
+                &package_for_prepare,
+                &version_for_prepare,
+                &r_version_for_prepare,
+                &dependency_inputs,
             );
-            return result;
-        }
+            let expected = ExpectedPackage {
+                name: package_for_prepare,
+                version: version_for_prepare,
+                r_major_minor: Some(format!(
+                    "{}.{}",
+                    r_version_for_prepare.major, r_version_for_prepare.minor
+                )),
+                platform: None,
+                architecture: None,
+            };
+            let artifact = artifact.into_installer_artifact(project_library_for_prepare);
+            prepare_installer
+                .prepare(&PrepareRequest {
+                    key,
+                    artifact_digest,
+                    expected,
+                    artifact,
+                })
+                .map_err(|source| InstallPackageError::Installer { source })
+        })
+        .await
+        .map_err(|source| InstallPackageError::Join { source })??;
 
-        span.record("stage", "cleaning up");
-        span.pb_set_message(&format!("{package} {version} cleaning up"));
-        span.pb_tick();
-        let cleanup = tokio::task::spawn_blocking(move || workspace.close())
-            .await
-            .map_err(std::io::Error::other)
-            .and_then(|result| result);
-        if let Err(error) = &cleanup
-            && result.is_err()
-        {
-            tracing::warn!(%error, path = %workspace_path.display(), "failed to clean package install workspace");
+        span.record("stage", "updating project library");
+        span.pb_set_message(&format!("{package} {version} publishing"));
+        let installer = installer.clone();
+        let project_library = project_library.to_path_buf();
+        let outcome =
+            tokio::task::spawn_blocking(move || installer.materialize(&entry, &project_library))
+                .await
+                .map_err(|source| InstallPackageError::Join { source })?
+                .map_err(|source| InstallPackageError::Installer { source })?;
+        if let InstallOutcome::CommittedCleanupPending { lock, .. } = outcome {
+            tracing::warn!(package, path = %lock.display(), "package installation committed but cleanup remains pending");
         }
-        result?;
-        cleanup.map_err(|source| InstallPackageError::Cleanup {
-            path: workspace_path,
-            source,
-        })?;
 
         span.record("stage", "done");
         span.pb_set_message(&format!("{package} {version} done"));
-        span.pb_tick();
         Ok(())
     }
     .instrument(span.clone())
     .await
 }
 
-async fn publish_installed_package(
-    source: &Path,
-    project_library: &Path,
-    package: &str,
-) -> Result<(), PublishInstalledPackageError> {
-    let source = source.to_path_buf();
-    let project_library = project_library.to_path_buf();
-    let package = package.to_string();
-    tokio::task::spawn_blocking(move || {
-        let destination = project_library.join(&package);
-        if destination.exists() {
-            return Err(PublishInstalledPackageError::DestinationExists { path: destination });
+fn artifact_digest(path: &Path) -> Result<InstallerDigest, std::io::Error> {
+    let mut file = fs::File::open(path)?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let count = file.read(&mut buffer)?;
+        if count == 0 {
+            break;
         }
-        let staging = tempfile::Builder::new()
-            .prefix(".rpx-install-")
-            .tempdir_in(&project_library)
-            .map_err(
-                |source| PublishInstalledPackageError::CreateStagingDirectory {
-                    path: project_library.clone(),
-                    source,
-                },
-            )?;
-        let staging_path = staging.path().to_path_buf();
-        let staged_package = staging.path().join(&package);
-        copy_directory(&source, &staged_package).map_err(|error| {
-            PublishInstalledPackageError::StagePackage {
-                path: source,
-                source: error,
-            }
-        })?;
-        let metadata = staged_package.join("DESCRIPTION");
-        if !metadata.is_file() {
-            return Err(PublishInstalledPackageError::MissingMetadata { path: metadata });
-        }
-        if destination.exists() {
-            return Err(PublishInstalledPackageError::DestinationExists { path: destination });
-        }
-        fs::rename(&staged_package, &destination).map_err(|source| {
-            PublishInstalledPackageError::Publish {
-                path: destination,
-                source,
-            }
-        })?;
-        staging
-            .close()
-            .map_err(|source| PublishInstalledPackageError::Cleanup {
-                path: staging_path,
-                source,
-            })
-    })
-    .await
-    .map_err(|source| PublishInstalledPackageError::Join { source })?
+        hasher.update(&buffer[..count]);
+    }
+    Ok(InstallerDigest::from_bytes(hasher.finalize().into()))
 }
 
-fn copy_directory(source: &Path, destination: &Path) -> Result<(), std::io::Error> {
-    fs::create_dir(destination)?;
-    for entry in fs::read_dir(source)? {
-        let entry = entry?;
-        let source = entry.path();
-        let destination = destination.join(entry.file_name());
-        if entry.file_type()?.is_dir() {
-            copy_directory(&source, &destination)?;
-        } else {
-            fs::copy(source, destination)?;
+fn installer_build_key(
+    artifact_kind: ArtifactKind,
+    artifact_digest: InstallerDigest,
+    package: &str,
+    version: &str,
+    r_version: &semver::Version,
+    dependencies: &[(String, Option<String>)],
+) -> CacheKey {
+    let mut hasher = Sha256::new();
+    let mut field = |value: &[u8]| {
+        hasher.update(value.len().to_le_bytes());
+        hasher.update(value);
+    };
+    field(INSTALLER_CACHE_VERSION.as_bytes());
+    field(match artifact_kind {
+        ArtifactKind::Binary(BinaryFormat::Zip) => b"binary-zip",
+        ArtifactKind::Binary(BinaryFormat::TarGz) => b"binary-tar-gz",
+        ArtifactKind::Source => b"source",
+    });
+    field(artifact_digest.as_bytes());
+    field(package.as_bytes());
+    field(version.as_bytes());
+    field(r_version.to_string().as_bytes());
+    field(HOST.to_string().as_bytes());
+    if matches!(artifact_kind, ArtifactKind::Source) {
+        field(b"allow-non-staged=true");
+        let mut dependencies = dependencies.to_vec();
+        dependencies.sort();
+        for (name, version) in &dependencies {
+            field(name.as_bytes());
+            field(version.as_deref().unwrap_or("").as_bytes());
         }
     }
-    Ok(())
+    CacheKey::from_digest(InstallerDigest::from_bytes(hasher.finalize().into()))
 }
 
 async fn publish_artifact_response(
@@ -1410,8 +1344,6 @@ async fn publish_artifact_response(
 
         if content_length.is_some() {
             span.pb_inc(chunk_len);
-        } else {
-            span.pb_tick();
         }
     }
 
@@ -1604,10 +1536,10 @@ mod tests {
     }
 
     #[test]
-    fn install_tasks_release_by_kind_and_package_dependency() {
+    fn sync_tasks_release_by_kind_and_package_dependency() {
         let packages =
             required_packages(&[("dependency", ""), ("dependent", "Imports: dependency\n")]);
-        let mut tasks = install_tasks(packages).unwrap();
+        let mut tasks = sync_tasks(&packages, &BTreeMap::new()).unwrap();
         let resources = ResourcePool::new();
 
         let dependency_download = pop_startable(&mut tasks, &resources).unwrap();
@@ -1628,6 +1560,34 @@ mod tests {
         let dependent_install = pop_startable(&mut tasks, &resources).unwrap();
         assert_eq!(dependent_install.task.0, "dependent");
         assert_eq!(dependent_install.task.1, TaskKind::Install);
+        assert_eq!(dependent_install.dependencies.len(), 1);
+        assert_eq!(dependent_install.dependencies[0].name, "dependency");
+        assert_eq!(
+            dependent_install.dependencies[0].version.as_deref(),
+            Some("1.0.0")
+        );
+    }
+
+    #[test]
+    fn sync_tasks_schedule_extra_packages_for_removal() {
+        let required = required_packages(&[("required", "")]);
+        let installed = BTreeMap::from([
+            (
+                "required".to_string(),
+                PackageVersion::new("1.0.0".parse().unwrap(), built_in_repository()),
+            ),
+            (
+                "extra".to_string(),
+                PackageVersion::new("2.0.0".parse().unwrap(), built_in_repository()),
+            ),
+        ]);
+
+        let tasks = sync_tasks(&required, &installed).unwrap();
+
+        assert_eq!(tasks.len(), 1);
+        assert!(tasks.iter().any(|row| {
+            row.task == ("extra".to_string(), TaskKind::Remove) && row.blockers == 0
+        }));
     }
 
     #[test]
@@ -1650,66 +1610,197 @@ mod tests {
         assert!(!resources.can_reserve(TaskKind::Download));
     }
 
-    #[tokio::test]
-    async fn publishes_complete_installed_package() {
-        let source_root = tempfile::tempdir().unwrap();
-        let source = source_root.path().join("package");
-        fs::create_dir(&source).unwrap();
-        fs::write(
-            source.join("DESCRIPTION"),
-            "Package: package\nVersion: 1.0.0\n",
-        )
-        .unwrap();
-        fs::write(source.join("contents"), "complete").unwrap();
-        let project_library = tempfile::tempdir().unwrap();
+    #[test]
+    fn artifact_digest_tracks_file_contents() {
+        let directory = tempfile::tempdir().unwrap();
+        let artifact = directory.path().join("artifact.tar.gz");
+        fs::write(&artifact, "package artifact").unwrap();
+        let first = artifact_digest(&artifact).unwrap();
+        fs::write(&artifact, "changed package artifact").unwrap();
 
-        publish_installed_package(&source, project_library.path(), "package")
-            .await
-            .unwrap();
-
-        assert_eq!(
-            fs::read_to_string(project_library.path().join("package/contents")).unwrap(),
-            "complete"
-        );
-        assert!(fs::read_dir(project_library.path()).unwrap().all(|entry| {
-            !entry
-                .unwrap()
-                .file_name()
-                .to_string_lossy()
-                .starts_with(".rpx-install-")
-        }));
+        assert_ne!(artifact_digest(&artifact).unwrap(), first);
     }
 
-    #[tokio::test]
-    async fn package_publication_does_not_replace_existing_destination() {
-        let source_root = tempfile::tempdir().unwrap();
-        let source = source_root.path().join("package");
-        fs::create_dir(&source).unwrap();
-        fs::write(
-            source.join("DESCRIPTION"),
-            "Package: package\nVersion: 2.0.0\n",
-        )
-        .unwrap();
-        let project_library = tempfile::tempdir().unwrap();
-        let existing = project_library.path().join("package");
-        fs::create_dir(&existing).unwrap();
-        fs::write(
-            existing.join("DESCRIPTION"),
-            "Package: package\nVersion: 1.0.0\n",
-        )
-        .unwrap();
+    #[test]
+    fn artifact_cache_entries_distinguish_files_directories_and_missing_paths() {
+        let directory = tempfile::tempdir().unwrap();
+        let file = directory.path().join("artifact.tar.gz");
+        let nested_directory = directory.path().join("artifact-directory");
+        fs::write(&file, "artifact").unwrap();
+        fs::create_dir(&nested_directory).unwrap();
 
-        let error = publish_installed_package(&source, project_library.path(), "package")
-            .await
-            .unwrap_err();
-
-        assert!(matches!(
-            error,
-            PublishInstalledPackageError::DestinationExists { path } if path == existing
-        ));
+        assert_eq!(artifact_cache_entry(&file), ArtifactCacheEntry::File);
         assert_eq!(
-            fs::read_to_string(existing.join("DESCRIPTION")).unwrap(),
-            "Package: package\nVersion: 1.0.0\n"
+            artifact_cache_entry(&nested_directory),
+            ArtifactCacheEntry::Invalid
+        );
+        assert_eq!(
+            artifact_cache_entry(&directory.path().join("missing")),
+            ArtifactCacheEntry::Missing
+        );
+    }
+
+    #[test]
+    fn install_artifact_maps_source_options_for_the_installer() {
+        let artifact_path = PathBuf::from("package.tar.gz");
+        let project_library = PathBuf::from("project-library");
+        let artifact = InstallArtifact {
+            path: artifact_path.clone(),
+            kind: ArtifactKind::Source,
+        }
+        .into_installer_artifact(project_library.clone());
+
+        let Artifact::Source(source) = artifact else {
+            panic!("source selection should produce a source artifact");
+        };
+        assert_eq!(source.path, artifact_path);
+        assert_eq!(source.options.dependency_libraries, vec![project_library]);
+        assert!(source.options.allow_non_staged);
+    }
+
+    #[test]
+    fn install_artifact_preserves_binary_format() {
+        let artifact_path = PathBuf::from("package.zip");
+        let artifact = InstallArtifact {
+            path: artifact_path.clone(),
+            kind: ArtifactKind::Binary(BinaryFormat::Zip),
+        }
+        .into_installer_artifact(PathBuf::from("unused-library"));
+
+        let Artifact::Binary(binary) = artifact else {
+            panic!("binary selection should produce a binary artifact");
+        };
+        assert_eq!(binary.path, artifact_path);
+        assert_eq!(binary.format, BinaryFormat::Zip);
+    }
+
+    #[test]
+    fn installer_build_key_tracks_build_inputs() {
+        fn key(
+            kind: ArtifactKind,
+            digest: u8,
+            package: &str,
+            version: &str,
+            r_version: &str,
+            dependencies: &[(String, Option<String>)],
+        ) -> String {
+            installer_build_key(
+                kind,
+                InstallerDigest::from_bytes([digest; 32]),
+                package,
+                version,
+                &semver::Version::parse(r_version).unwrap(),
+                dependencies,
+            )
+            .to_string()
+        }
+        let dependencies = vec![("dependency".into(), Some("1.0.0".into()))];
+        let baseline = key(
+            ArtifactKind::Source,
+            1,
+            "package",
+            "1.0.0",
+            "4.5.1",
+            &dependencies,
+        );
+
+        assert_ne!(
+            baseline,
+            key(
+                ArtifactKind::Binary(BinaryFormat::Zip),
+                1,
+                "package",
+                "1.0.0",
+                "4.5.1",
+                &dependencies
+            )
+        );
+        assert_ne!(
+            baseline,
+            key(
+                ArtifactKind::Source,
+                2,
+                "package",
+                "1.0.0",
+                "4.5.1",
+                &dependencies
+            )
+        );
+        assert_ne!(
+            baseline,
+            key(
+                ArtifactKind::Source,
+                1,
+                "other",
+                "1.0.0",
+                "4.5.1",
+                &dependencies
+            )
+        );
+        assert_ne!(
+            baseline,
+            key(
+                ArtifactKind::Source,
+                1,
+                "package",
+                "2.0.0",
+                "4.5.1",
+                &dependencies
+            )
+        );
+        assert_ne!(
+            baseline,
+            key(
+                ArtifactKind::Source,
+                1,
+                "package",
+                "1.0.0",
+                "4.4.2",
+                &dependencies
+            )
+        );
+        assert_ne!(
+            baseline,
+            key(
+                ArtifactKind::Source,
+                1,
+                "package",
+                "1.0.0",
+                "4.5.1",
+                &[("other".into(), Some("1.0.0".into()))]
+            )
+        );
+        assert_ne!(
+            baseline,
+            key(
+                ArtifactKind::Source,
+                1,
+                "package",
+                "1.0.0",
+                "4.5.1",
+                &[("dependency".into(), Some("2.0.0".into()))]
+            )
+        );
+    }
+
+    #[test]
+    fn installer_build_key_sorts_dependencies() {
+        let digest = InstallerDigest::from_bytes([1; 32]);
+        let key = |dependencies: &[(String, Option<String>)]| {
+            installer_build_key(
+                ArtifactKind::Source,
+                digest,
+                "package",
+                "1.0.0",
+                &semver::Version::new(4, 5, 1),
+                dependencies,
+            )
+            .to_string()
+        };
+
+        assert_eq!(
+            key(&[("a".into(), Some("1.0.0".into())), ("b".into(), None)]),
+            key(&[("b".into(), None), ("a".into(), Some("1.0.0".into()))])
         );
     }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -11,7 +11,7 @@ use crate::{
     project::{
         Project, ProjectLibraryError, ProjectResolution, RequiredPackages, ensure_project_library,
     },
-    r::{self, BasePackagesError, base_packages, build_package_archive, installed_packages},
+    r::{self, build_package_archive, installed_packages},
     repository::{
         CranRepository, GitRepository, LocalRepository, RepositoryError, RrepoRepository,
     },
@@ -48,9 +48,6 @@ pub(crate) enum SyncError {
     ProjectLibrary(#[from] ProjectLibraryError),
     #[error(transparent)]
     #[diagnostic(transparent)]
-    BasePackages(#[from] BasePackagesError),
-    #[error(transparent)]
-    #[diagnostic(transparent)]
     InstalledPackages(#[from] r::InstalledPackagesError),
     #[error("failed to remove package {package}: {source}")]
     #[diagnostic(code(rpx::sync::package_remove_failed))]
@@ -78,7 +75,7 @@ pub(crate) enum SyncError {
     },
     #[error(transparent)]
     #[diagnostic(transparent)]
-    PackageGraph(#[from] PackageGraphError),
+    DependencyCycle(#[from] DependencyCycleError),
     #[error("failed to build package {package}: {source}")]
     #[diagnostic(code(rpx::sync::package_build_failed))]
     PackageBuild {
@@ -136,8 +133,6 @@ pub(crate) async fn sync_resolved_project(
         (ProjectType::Package, ProjectPackageMode::Omit) | (ProjectType::Project, _) => {}
     }
 
-    validate_package_graph(&required).await?;
-
     let project_library = ensure_project_library(&project.root)?;
     let installer = Installer::new(installer_cache_path());
     let installed = installed_packages(&project_library).await?;
@@ -189,9 +184,16 @@ pub(crate) async fn sync_resolved_project(
             break Ok(());
         }
         if running.is_empty() {
-            break Err(SyncError::DownloadArtifactsFailed {
-                details: "package task graph stalled with no runnable tasks".to_string(),
-            });
+            break Err(DependencyCycleError {
+                packages: tasks
+                    .iter()
+                    .filter(|row| row.task.1 == TaskKind::Install)
+                    .map(|row| CycleBlockedPackage {
+                        package: row.task.0.clone(),
+                    })
+                    .collect(),
+            }
+            .into());
         }
 
         match running
@@ -498,39 +500,14 @@ fn pending_package_count(tasks: &BTreeSet<TaskRow>) -> usize {
 }
 
 #[derive(Debug, Error, Diagnostic)]
-pub(crate) enum PackageGraphError {
-    #[error("package dependency metadata for `{package}` is invalid: {details}")]
-    #[diagnostic(code(rpx::sync::invalid_package_dependencies))]
-    InvalidDependencies { package: String, details: String },
-
-    #[error("package dependency graph is incomplete")]
-    #[diagnostic(
-        code(rpx::sync::missing_package_dependencies),
-        help("Include the missing packages in the sync or update the package requirements.")
-    )]
-    MissingDependencies {
-        #[related]
-        dependencies: Vec<MissingPackageDependency>,
-    },
-
-    #[error("cannot determine package installation order")]
-    #[diagnostic(
-        code(rpx::sync::dependency_cycle),
-        help("Update the package requirements to break the dependency cycle before syncing.")
-    )]
-    DependencyCycle {
-        #[related]
-        packages: Vec<CycleBlockedPackage>,
-    },
-}
-
-#[derive(Debug, Error, Diagnostic)]
-#[error(
-    "package `{package}` requires `{dependency}`, but `{dependency}` is not included in the sync"
+#[error("cannot determine package installation order")]
+#[diagnostic(
+    code(rpx::sync::dependency_cycle),
+    help("Update the package requirements to break the dependency cycle before syncing.")
 )]
-pub(crate) struct MissingPackageDependency {
-    package: String,
-    dependency: String,
+pub(crate) struct DependencyCycleError {
+    #[related]
+    packages: Vec<CycleBlockedPackage>,
 }
 
 #[derive(Debug, Error, Diagnostic)]
@@ -1379,111 +1356,6 @@ async fn publish_artifact_response(
     Ok(())
 }
 
-async fn validate_package_graph(packages: &RequiredPackages) -> Result<(), SyncError> {
-    let base_packages = base_packages().await?;
-    let required_names = packages.keys().cloned().collect::<BTreeSet<_>>();
-    let indegree = required_names
-        .iter()
-        .map(|name| (name.clone(), 0_usize))
-        .collect::<BTreeMap<_, _>>();
-    let dependents = required_names
-        .iter()
-        .map(|name| (name.clone(), BTreeSet::new()))
-        .collect::<BTreeMap<_, _>>();
-
-    let dependencies = packages
-        .iter()
-        .map(|(package, (version, description))| {
-            required_dependencies(format!("{package} {}", version.version()), description)
-                .map(|dependencies| {
-                    dependencies
-                        .into_iter()
-                        .map(|dependency| (package.clone(), dependency.package().to_string()))
-                        .collect::<BTreeSet<_>>()
-                })
-                .map_err(|error| PackageGraphError::InvalidDependencies {
-                    package: package.clone(),
-                    details: error.to_string(),
-                })
-        })
-        .collect::<Result<Vec<_>, _>>()?
-        .into_iter()
-        .flatten()
-        .filter(|(_, dependency)| !base_packages.contains(dependency));
-    let (missing, internal): (Vec<_>, Vec<_>) =
-        dependencies.partition(|(_, dependency)| !required_names.contains(dependency));
-
-    if !missing.is_empty() {
-        return Err(PackageGraphError::MissingDependencies {
-            dependencies: missing
-                .into_iter()
-                .map(|(package, dependency)| MissingPackageDependency {
-                    package,
-                    dependency,
-                })
-                .collect(),
-        }
-        .into());
-    }
-
-    let (mut indegree, dependents) = internal.into_iter().fold(
-        (indegree, dependents),
-        |(mut indegree, mut dependents), (package, dependency)| {
-            *indegree
-                .get_mut(&package)
-                .expect("required package should have indegree") += 1;
-            dependents
-                .get_mut(&dependency)
-                .expect("required dependency should exist")
-                .insert(package);
-            (indegree, dependents)
-        },
-    );
-
-    let mut ready = indegree
-        .iter()
-        .filter(|(_, count)| **count == 0)
-        .map(|(name, _)| name.clone())
-        .collect::<BTreeSet<_>>();
-    let mut ordered = Vec::with_capacity(packages.len());
-
-    while let Some(name) = ready.pop_first() {
-        ordered.push(name.clone());
-
-        dependents
-            .get(&name)
-            .cloned()
-            .unwrap_or_default()
-            .into_iter()
-            .for_each(|dependent| {
-                let count = indegree
-                    .get_mut(&dependent)
-                    .expect("dependent should have indegree entry");
-                *count -= 1;
-                if *count == 0 {
-                    ready.insert(dependent);
-                }
-            });
-    }
-
-    if ordered.len() != packages.len() {
-        let unresolved = indegree
-            .into_iter()
-            .filter(|(_, count)| *count > 0)
-            .map(|(name, _)| name)
-            .collect::<Vec<_>>();
-        return Err(PackageGraphError::DependencyCycle {
-            packages: unresolved
-                .into_iter()
-                .map(|package| CycleBlockedPackage { package })
-                .collect(),
-        }
-        .into());
-    }
-
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1802,79 +1674,5 @@ mod tests {
             key(&[("a".into(), Some("1.0.0".into())), ("b".into(), None)]),
             key(&[("b".into(), None), ("a".into(), Some("1.0.0".into()))])
         );
-    }
-
-    #[tokio::test]
-    async fn package_graph_validation_accepts_complete_acyclic_graph() {
-        let packages = required_packages(&[
-            ("dependent", "Imports: dependency, testBasePackage\n"),
-            ("dependency", ""),
-            ("unrelated", ""),
-        ]);
-        validate_package_graph(&packages).await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn package_graph_validation_deduplicates_dependency_constraints() {
-        let packages = required_packages(&[
-            (
-                "dependent",
-                "Imports: dependency (>= 1.0.0), dependency (< 2.0.0)\n",
-            ),
-            ("dependency", ""),
-        ]);
-        validate_package_graph(&packages).await.unwrap();
-    }
-
-    #[tokio::test]
-    async fn package_graph_validation_reports_missing_dependencies() {
-        let packages = required_packages(&[
-            ("a", "Imports: missingB, missingA\n"),
-            ("b", "Imports: missingA\n"),
-        ]);
-        let error = validate_package_graph(&packages).await.unwrap_err();
-        let SyncError::PackageGraph(PackageGraphError::MissingDependencies { dependencies }) =
-            error
-        else {
-            panic!("missing dependencies should produce a structured graph error");
-        };
-        assert_eq!(
-            dependencies
-                .iter()
-                .map(|dependency| { (dependency.package.as_str(), dependency.dependency.as_str()) })
-                .collect::<Vec<_>>(),
-            vec![("a", "missingA"), ("a", "missingB"), ("b", "missingA")]
-        );
-    }
-
-    #[tokio::test]
-    async fn package_graph_validation_reports_all_blocked_names() {
-        let packages = required_packages(&[
-            ("a", "Imports: b\n"),
-            ("b", "Imports: a\n"),
-            ("c", "Imports: a\n"),
-        ]);
-        let error = validate_package_graph(&packages).await.unwrap_err();
-        let SyncError::PackageGraph(PackageGraphError::DependencyCycle { packages }) = error else {
-            panic!("cycles should produce a structured graph error");
-        };
-        assert_eq!(
-            packages
-                .iter()
-                .map(|package| package.package.as_str())
-                .collect::<Vec<_>>(),
-            ["a", "b", "c"]
-        );
-    }
-
-    #[tokio::test]
-    async fn package_graph_validation_names_invalid_dependency_metadata() {
-        let packages = required_packages(&[("broken", "Imports: dependency (>= invalid)\n")]);
-        let error = validate_package_graph(&packages).await.unwrap_err();
-        assert!(matches!(
-            error,
-            SyncError::PackageGraph(PackageGraphError::InvalidDependencies { package, .. })
-                if package == "broken"
-        ));
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -3,6 +3,13 @@ pub(crate) fn progress_spinner_style() -> tracing_indicatif::style::ProgressStyl
         .expect("progress spinner style should be valid")
 }
 
+pub(crate) fn progress_count_style() -> tracing_indicatif::style::ProgressStyle {
+    tracing_indicatif::style::ProgressStyle::with_template(
+        "{span_child_prefix}{spinner} {msg} [{bar:24.cyan/blue}] {pos}/{len}",
+    )
+    .expect("progress count style should be valid")
+}
+
 pub(crate) fn progress_bar_style() -> tracing_indicatif::style::ProgressStyle {
     tracing_indicatif::style::ProgressStyle::with_template(
         "{span_child_prefix}{spinner} {msg} [{bar:24.cyan/blue}] {bytes}/{total_bytes}",

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -251,6 +251,56 @@ fn runs_rpx_sync_from_lockfile_without_mutating_it() {
 }
 
 #[test]
+fn refuses_to_sync_cyclic_package_dependencies() {
+    let container = start_container();
+    let project_path = "/tmp/rpx-project-sync-cycle";
+    write_description(
+        &container,
+        project_path,
+        "Package: testpkg
+Version: 0.1.0
+Title: Test Package
+Description: Test package for rpx integration tests.
+License: MIT
+Author: Test Author
+Maintainer: Test Author <test@example.com>
+Imports: digest, jsonlite",
+    );
+
+    let lock_command = format!("cd {project_path} && rpx lock");
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &lock_command);
+    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
+
+    let create_cycle_command = format!(
+        r#"cd {project_path} && perl -0pi -e 's/("digest": \{{.*?"dependencies": )\[[^\]]*\]/${{1}}["jsonlite"]/s; s/("jsonlite": \{{.*?"dependencies": )\[[^\]]*\]/${{1}}["digest"]/s' rpx.lock"#
+    );
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &create_cycle_command);
+    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
+
+    let lockfile =
+        serde_json::from_str::<Value>(&read_project_file(&container, project_path, "rpx.lock"))
+            .expect("lockfile should parse");
+    assert_eq!(
+        lockfile["packages"]["digest"]["dependencies"],
+        json!(["jsonlite"])
+    );
+    assert_eq!(
+        lockfile["packages"]["jsonlite"]["dependencies"],
+        json!(["digest"])
+    );
+
+    let sync_command = format!("cd {project_path} && rpx sync --no-install-project");
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &sync_command);
+    assert_eq!(exit_code, 1, "stdout was: {stdout}\nstderr was: {stderr}");
+    assert!(
+        stderr.contains("rpx::sync::dependency_cycle")
+            && stderr.contains("package `digest` is blocked by a dependency cycle")
+            && stderr.contains("package `jsonlite` is blocked by a dependency cycle"),
+        "stdout was: {stdout}\nstderr was: {stderr}"
+    );
+}
+
+#[test]
 fn sync_installs_project_without_mutating_its_sources() {
     let container = start_container();
     let project_path = "/tmp/rpx-project-sync-clean-sources";

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -75,7 +75,6 @@ fn install_sync_failure_wrappers(
     let command = format!(
         r#"mkdir -p {wrapper_path}/real {state_path}
 ln -s "$(command -v R)" {wrapper_path}/real/R
-ln -s "$(command -v Rscript)" {wrapper_path}/real/Rscript
 cat > {wrapper_path}/R <<'EOF'
 #!/bin/sh
 case "$*" in
@@ -96,14 +95,11 @@ case "$*" in
             exit "$status"
         fi
         ;;
-esac
-exec {wrapper_path}/real/R "$@"
-EOF
-cat > {wrapper_path}/Rscript <<'EOF'
-#!/bin/sh
-case "$*" in
-    *install.packages*digest*)
-        if [ "${{RPX_TEST_FAIL_DIGEST:-}}" = 1 ]; then
+    *CMD*INSTALL*)
+        artifact=
+        for argument in "$@"; do artifact=$argument; done
+        package=$(tar -xOzf "$artifact" --wildcards '*/DESCRIPTION' 2>/dev/null | grep -m1 '^Package:' | cut -d' ' -f2)
+        if [ "$package" = digest ] && [ "${{RPX_TEST_FAIL_DIGEST:-}}" = 1 ]; then
             attempts=0
             while [ ! -f "$RPX_TEST_STATE/root-active" ] && [ "$attempts" -lt 100 ]; do
                 sleep 0.05
@@ -119,9 +115,9 @@ case "$*" in
         fi
         ;;
 esac
-exec {wrapper_path}/real/Rscript "$@"
+exec {wrapper_path}/real/R "$@"
 EOF
-chmod +x {wrapper_path}/R {wrapper_path}/Rscript"#
+chmod +x {wrapper_path}/R"#
     );
     let (exit_code, stdout, stderr) = run_shell_command(container, &command);
     assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
@@ -138,28 +134,18 @@ fn install_lock_failure_wrapper(
 ) -> String {
     let command = format!(
         r#"mkdir -p {wrapper_path}/real {state_path}
-ln -s "$(command -v Rscript)" {wrapper_path}/real/Rscript
-cat > {wrapper_path}/Rscript <<'EOF'
+ln -s "$(command -v R)" {wrapper_path}/real/R
+cat > {wrapper_path}/R <<'EOF'
 #!/bin/sh
 case "$*" in
-    *install.packages*)
-        last=
-        second_last=
-        third_last=
-        for argument in "$@"; do
-            third_last=$second_last
-            second_last=$last
-            last=$argument
-        done
-        package=$second_last
-        library=$third_last
+    *CMD*INSTALL*)
+        artifact=
+        for argument in "$@"; do artifact=$argument; done
+        package=$(tar -xOzf "$artifact" --wildcards '*/DESCRIPTION' 2>/dev/null | grep -m1 '^Package:' | cut -d' ' -f2)
         case "$package" in
             testpkg)
                 if [ "${{RPX_TEST_ROOT_DELAY:-}}" = 1 ] && [ "${{RPX_TEST_FAIL_DIGEST:-}}" = 1 ]; then
                     rm -f "$RPX_TEST_STATE/root-cleaned" "$RPX_TEST_STATE/digest-failed"
-                    printf '%s\n' "$library" > "$RPX_TEST_STATE/root-library"
-                    printf '%s\n' "$R_LIBS_USER" > "$RPX_TEST_STATE/project-library"
-                    mkdir -p "$library/00LOCK-testpkg"
                     touch "$RPX_TEST_STATE/root-active"
                     attempts=0
                     while [ ! -f "$RPX_TEST_STATE/digest-failed" ] && [ "$attempts" -lt 1200 ]; do
@@ -167,7 +153,6 @@ case "$*" in
                         attempts=$((attempts + 1))
                     done
                     sleep 1
-                    rm -rf "$library/00LOCK-testpkg"
                     rm -f "$RPX_TEST_STATE/root-active"
                     touch "$RPX_TEST_STATE/root-cleaned"
                 fi
@@ -191,44 +176,14 @@ case "$*" in
         esac
         ;;
 esac
-exec {wrapper_path}/real/Rscript "$@"
+exec {wrapper_path}/real/R "$@"
 EOF
-chmod +x {wrapper_path}/Rscript"#
+chmod +x {wrapper_path}/R"#
     );
     let (exit_code, stdout, stderr) = run_shell_command(container, &command);
     assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
 
     format!("PATH={wrapper_path}:$PATH RPX_TEST_STATE={state_path} RPX_TEST_ROOT_DELAY=1")
-}
-
-fn install_missing_package_wrapper(
-    container: &testcontainers::core::Container<testcontainers::GenericImage>,
-    wrapper_path: &str,
-    state_path: &str,
-) -> String {
-    let command = format!(
-        r#"mkdir -p {wrapper_path}/real {state_path}
-ln -s "$(command -v Rscript)" {wrapper_path}/real/Rscript
-cat > {wrapper_path}/Rscript <<'EOF'
-#!/bin/sh
-case "$*" in
-    *install.packages*digest*)
-        if [ "${{RPX_TEST_MISSING_DIGEST:-}}" = 1 ]; then
-            printf '%s\n' "$*" > "$RPX_TEST_STATE/invocation"
-            echo "injected successful install output"
-            echo "unable to move temporary installation for digest" >&2
-            exit 0
-        fi
-        ;;
-esac
-exec {wrapper_path}/real/Rscript "$@"
-EOF
-chmod +x {wrapper_path}/Rscript"#
-    );
-    let (exit_code, stdout, stderr) = run_shell_command(container, &command);
-    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
-
-    format!("PATH={wrapper_path}:$PATH RPX_TEST_STATE={state_path}")
 }
 
 #[test]
@@ -317,7 +272,7 @@ fn sync_installs_project_without_mutating_its_sources() {
     assert_package_state(&container, project_path, "testpkg", "TRUE");
 
     let assert_clean = format!(
-        "cd {project_path} && test ! -e configured-during-install && test ! -e src/native.o && test ! -e src/testpkg.so && set -- \"$HOME/.cache/rpx/artifacts/source/v1/testpkg\"/*/artifact.tar.gz && test -f \"$1\" && set -- \"$HOME/.cache/rpx/artifacts/source/v1\"/*/*/.rpx-build-* && test ! -e \"$1\" && set -- \"$HOME/.cache/rpx/build-temp\"/rpx-install-* && test ! -e \"$1\""
+        "cd {project_path} && test ! -e configured-during-install && test ! -e src/native.o && test ! -e src/testpkg.so && set -- \"$HOME/.cache/rpx/artifacts/source/v1/testpkg\"/*/artifact.tar.gz && test -f \"$1\" && set -- \"$HOME/.cache/rpx/artifacts/source/v1\"/*/*/.rpx-build-* && test ! -e \"$1\" && set -- \"$HOME/.cache/rpx/installer/v1/.build\"/* && test ! -e \"$1\""
     );
     let (exit_code, stdout, stderr) = run_shell_command(&container, &assert_clean);
     assert_eq!(
@@ -372,12 +327,12 @@ Suggests: digest",
     let (exit_code, stdout, stderr) = run_shell_command(&container, &sync_command);
     assert_eq!(exit_code, 1, "stdout was: {stdout}\nstderr was: {stderr}");
     assert!(
-        stderr.contains("code Some(97)") && stderr.contains("injected digest"),
+        stderr.contains("status Some(97)") && stderr.contains("injected digest"),
         "stdout was: {stdout}\nstderr was: {stderr}"
     );
 
     let completed_root_command = format!(
-        "test -f {state_path}/root-cleaned && test ! -e {state_path}/root-active && set -- \"$HOME/.cache/rpx/artifacts/source/v1/testpkg\"/*/artifact.tar.gz && test -f \"$1\" && set -- \"$HOME/.cache/rpx/artifacts/source/v1\"/*/*/.rpx-build-* && test ! -e \"$1\" && set -- \"$HOME/.cache/rpx/build-temp\"/rpx-install-* && test ! -e \"$1\""
+        "test -f {state_path}/root-cleaned && test ! -e {state_path}/root-active && set -- \"$HOME/.cache/rpx/artifacts/source/v1/testpkg\"/*/artifact.tar.gz && test -f \"$1\" && set -- \"$HOME/.cache/rpx/artifacts/source/v1\"/*/*/.rpx-build-* && test ! -e \"$1\" && set -- \"$HOME/.cache/rpx/installer/v1/.build\"/* && test ! -e \"$1\""
     );
     let (exit_code, stdout, stderr) = run_shell_command(&container, &completed_root_command);
     assert_eq!(
@@ -427,12 +382,12 @@ Suggests: digest",
     let (exit_code, stdout, stderr) = run_shell_command(&container, &sync_command);
     assert_eq!(exit_code, 1, "stdout was: {stdout}\nstderr was: {stderr}");
     assert!(
-        stderr.contains("code Some(97)") && stderr.contains("injected digest install"),
+        stderr.contains("status Some(97)") && stderr.contains("injected digest install"),
         "stdout was: {stdout}\nstderr was: {stderr}"
     );
 
     let completed_root_command = format!(
-        "test -f {state_path}/root-cleaned && test ! -e {state_path}/root-active && root_library=$(cat {state_path}/root-library) && project_library=$(cat {state_path}/project-library) && test ! -e \"$root_library\" && set -- \"$project_library\"/00LOCK* && test ! -e \"$1\" && set -- \"$HOME/.cache/rpx/build-temp\"/rpx-install-* && test ! -e \"$1\""
+        "test -f {state_path}/root-cleaned && test ! -e {state_path}/root-active && set -- \"$HOME/.cache/rpx/installer/v1/.build\"/* && test ! -e \"$1\""
     );
     let (exit_code, stdout, stderr) = run_shell_command(&container, &completed_root_command);
     assert_eq!(
@@ -450,63 +405,6 @@ Suggests: digest",
         exit_code, 0,
         "retry left an install lock or workspace\nstdout was: {stdout}\nstderr was: {stderr}"
     );
-}
-
-#[test]
-fn successful_install_without_package_reports_output_and_preserves_workspace() {
-    let container = start_container();
-    let project_path = "/tmp/rpx-project-sync-missing-package";
-    let wrapper_path = "/tmp/rpx-sync-missing-package-wrappers";
-    let state_path = "/tmp/rpx-sync-missing-package-state";
-    write_description(
-        &container,
-        project_path,
-        "Package: testpkg
-Version: 0.1.0
-Title: Test Package
-Description: Test package for rpx integration tests.
-License: MIT
-Author: Test Author
-Maintainer: Test Author <test@example.com>
-Imports: digest",
-    );
-
-    let lock_command = format!("cd {project_path} && rpx lock");
-    let (exit_code, stdout, stderr) = run_shell_command(&container, &lock_command);
-    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
-
-    let wrapped_environment = install_missing_package_wrapper(&container, wrapper_path, state_path);
-    let sync_command = format!(
-        "cd {project_path} && {wrapped_environment} RPX_TEST_MISSING_DIGEST=1 RPX_KEEP_BUILD_TEMP=1 rpx sync"
-    );
-    let (exit_code, stdout, stderr) = run_shell_command(&container, &sync_command);
-    assert_eq!(exit_code, 1, "stdout was: {stdout}\nstderr was: {stderr}");
-    assert!(
-        stderr.contains("installed package directory is missing")
-            && stderr.contains("injected successful install output")
-            && stderr.contains("unable to move temporary installation")
-            && stderr.contains("artifact.tar.gz")
-            && stderr.contains("as source with R")
-            && stderr.contains("preserved failed package install workspace"),
-        "stdout was: {stdout}\nstderr was: {stderr}"
-    );
-
-    let assert_preserved = format!(
-        "case \"$(cat {state_path}/invocation)\" in *--vanilla*) ;; *) exit 1 ;; esac && set -- \"$HOME/.cache/rpx/build-temp\"/rpx-install-* && test -d \"$1\""
-    );
-    let (exit_code, stdout, stderr) = run_shell_command(&container, &assert_preserved);
-    assert_eq!(
-        exit_code, 0,
-        "install command was not vanilla or workspace was not preserved\nstdout was: {stdout}\nstderr was: {stderr}"
-    );
-
-    let retry_command = format!(
-        "rm -rf \"$HOME/.cache/rpx/build-temp\"/rpx-install-* && cd {project_path} && {wrapped_environment} rpx sync"
-    );
-    let (exit_code, stdout, stderr) = run_shell_command(&container, &retry_command);
-    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
-    assert_package_state(&container, project_path, "digest", "TRUE");
-    assert_package_state(&container, project_path, "testpkg", "TRUE");
 }
 
 #[test]

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -201,6 +201,36 @@ chmod +x {wrapper_path}/Rscript"#
     format!("PATH={wrapper_path}:$PATH RPX_TEST_STATE={state_path} RPX_TEST_ROOT_DELAY=1")
 }
 
+fn install_missing_package_wrapper(
+    container: &testcontainers::core::Container<testcontainers::GenericImage>,
+    wrapper_path: &str,
+    state_path: &str,
+) -> String {
+    let command = format!(
+        r#"mkdir -p {wrapper_path}/real {state_path}
+ln -s "$(command -v Rscript)" {wrapper_path}/real/Rscript
+cat > {wrapper_path}/Rscript <<'EOF'
+#!/bin/sh
+case "$*" in
+    *install.packages*digest*)
+        if [ "${{RPX_TEST_MISSING_DIGEST:-}}" = 1 ]; then
+            printf '%s\n' "$*" > "$RPX_TEST_STATE/invocation"
+            echo "injected successful install output"
+            echo "unable to move temporary installation for digest" >&2
+            exit 0
+        fi
+        ;;
+esac
+exec {wrapper_path}/real/Rscript "$@"
+EOF
+chmod +x {wrapper_path}/Rscript"#
+    );
+    let (exit_code, stdout, stderr) = run_shell_command(container, &command);
+    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
+
+    format!("PATH={wrapper_path}:$PATH RPX_TEST_STATE={state_path}")
+}
+
 #[test]
 fn runs_rpx_lock_from_current_library() {
     let container = start_container();
@@ -420,6 +450,63 @@ Suggests: digest",
         exit_code, 0,
         "retry left an install lock or workspace\nstdout was: {stdout}\nstderr was: {stderr}"
     );
+}
+
+#[test]
+fn successful_install_without_package_reports_output_and_preserves_workspace() {
+    let container = start_container();
+    let project_path = "/tmp/rpx-project-sync-missing-package";
+    let wrapper_path = "/tmp/rpx-sync-missing-package-wrappers";
+    let state_path = "/tmp/rpx-sync-missing-package-state";
+    write_description(
+        &container,
+        project_path,
+        "Package: testpkg
+Version: 0.1.0
+Title: Test Package
+Description: Test package for rpx integration tests.
+License: MIT
+Author: Test Author
+Maintainer: Test Author <test@example.com>
+Imports: digest",
+    );
+
+    let lock_command = format!("cd {project_path} && rpx lock");
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &lock_command);
+    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
+
+    let wrapped_environment = install_missing_package_wrapper(&container, wrapper_path, state_path);
+    let sync_command = format!(
+        "cd {project_path} && {wrapped_environment} RPX_TEST_MISSING_DIGEST=1 RPX_KEEP_BUILD_TEMP=1 rpx sync"
+    );
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &sync_command);
+    assert_eq!(exit_code, 1, "stdout was: {stdout}\nstderr was: {stderr}");
+    assert!(
+        stderr.contains("installed package directory is missing")
+            && stderr.contains("injected successful install output")
+            && stderr.contains("unable to move temporary installation")
+            && stderr.contains("artifact.tar.gz")
+            && stderr.contains("as source with R")
+            && stderr.contains("preserved failed package install workspace"),
+        "stdout was: {stdout}\nstderr was: {stderr}"
+    );
+
+    let assert_preserved = format!(
+        "case \"$(cat {state_path}/invocation)\" in *--vanilla*) ;; *) exit 1 ;; esac && set -- \"$HOME/.cache/rpx/build-temp\"/rpx-install-* && test -d \"$1\""
+    );
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &assert_preserved);
+    assert_eq!(
+        exit_code, 0,
+        "install command was not vanilla or workspace was not preserved\nstdout was: {stdout}\nstderr was: {stderr}"
+    );
+
+    let retry_command = format!(
+        "rm -rf \"$HOME/.cache/rpx/build-temp\"/rpx-install-* && cd {project_path} && {wrapped_environment} rpx sync"
+    );
+    let (exit_code, stdout, stderr) = run_shell_command(&container, &retry_command);
+    assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
+    assert_package_state(&container, project_path, "digest", "TRUE");
+    assert_package_state(&container, project_path, "testpkg", "TRUE");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- integrate `r-package-installer` 0.1.0 for validated immutable package preparation and transactional project-library updates
- extract Windows and macOS binary packages natively while continuing to use `R CMD INSTALL` for source packages
- replace manual package publication and removal with installer-managed package locks, rollback, cleanup, and Windows filesystem retries
- scan project libraries through the installer and schedule removal of extra packages alongside download, build, and install work
- keep required packages installed until their replacements are ready, avoiding a broken library when preparation fails
- use a global versioned installer cache with deterministic keys based on artifact content, package identity, R/host compatibility, build policy, and direct dependency names and versions
- reject invalid artifact cache entries and keep artifact selection consistent between downloading and installation
- remove the standalone package-graph validation pass and let the installation scheduler report dependency cycles when blocked tasks cannot reach zero

This replaces the diagnostic-only workaround with a transactional installation path that directly addresses failed package replacement on Windows.

Refs #115.
Closes #103.

## Test Plan

- `cargo fmt --all --check`
- `git diff --check`
- `cargo test`
  - 186 unit tests passed
  - 65 integration tests passed

## Scope

- no dedicated `RcppParallel` end-to-end test is added
- dependency changes do not expand the package installation set
- source cache dependency identity remains based on direct dependency names and versions
