### PR TITLE
docs: move documentation into this repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+All notable changes to rpx are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and rpx adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+[Unreleased]: https://github.com/rrepo-org/rpx/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/rrepo-org/rpx/compare/v1.7.0...v2.0.0
+
+## [Unreleased]
+
+## [2.0.0]
+
+### Breaking changes
+
+- Migrated `rpx.lock` to schema version 5. Existing lockfiles must be regenerated with `rpx lock` before they can be synchronized.
+- Removed `--default-repo` and `--no-default-repo` from `add`, `remove`, and `lock`. Projects now always have one persistent base repository, configured with `rpx repo base set` and restored with `rpx repo base reset`.
+- Reworked project initialization. `rpx init` now initializes only a new or completely empty target directory and generates an installable package by default.
+- Changed the operating-system project directory organization from Scalerail to rrepo. Existing caches and project libraries are not migrated and can be recreated with `rpx sync`.
+
+### Added
+
+- Added Git package repositories from GitHub, GitLab, Bitbucket, and generic Git URLs. Branches and tags are resolved to immutable commits in the lockfile.
+- Added persistent base, additional, and Git repository management through `rpx repo`.
+- Added `--depends`, `--imports`, `--linking-to`, `--suggests`, and `--dev` dependency field selection to `rpx add`.
+- Added version constraints to `rpx add` using forms such as `'digest@>=0.6.37'`.
+- Added automatic lower and next-major upper bounds when an unconstrained repository package is added.
+- Added `--no-install-project` to `add`, `remove`, and `sync` for synchronizing only package dependencies.
+- Added dependency-only projects through `rpx init --type project`.
+- Added interactive project type, base repository, development dependency, and Git repository selection to `rpx init`.
+- Added cross-platform end-to-end coverage for Linux, macOS, and Windows.
+
+### Changed
+
+- The built-in rrepo-backed CRAN universe is now an explicit base repository that can be replaced per project.
+- `rpx init` generates package metadata, namespace, build exclusions, license files, a lockfile, and an isolated project library in one flow.
+- Git repository operations use the installed `git` executable and the user's configured credential helpers or SSH agent.
+- Package metadata parsing and DESCRIPTION mutations use the shared `r-metadata` implementation.
+- Package installation uses library transactions so failed installs do not publish partial package directories.
+- Synchronization schedules package operations from the complete hard-dependency graph and reports dependency cycles and missing packages directly.
+- `rpx run` validates the locked environment, executes commands without an implicit shell, and reliably propagates command failures.
+
+### Fixed
+
+- Preserved R package installation diagnostics, including failures from packages such as `RcppParallel` on Windows.
+- Isolated source package builds from project and repository checkout directories.
+- Restored case-insensitive package sorting in `DESCRIPTION`.
+- Improved diagnostics for invalid CRAN package indexes and malformed package metadata.
+- Removed stale packages and interrupted installation state more reliably during synchronization.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ the selected field.
 
 ## Install
 
-`rpx` requires R and Git to be installed and available on `PATH`. Before using `rpx`, confirm that `Rscript` and `git` work in your shell.
+`rpx` requires R to be installed and available on `PATH`. Git is also required when using Git package remotes or asking `rpx init` to create a repository. Before using `rpx`, confirm that `Rscript` works in your shell and, when needed, that `git` does too.
 
 Install R:
 
@@ -87,6 +87,8 @@ Install the latest release on Windows:
 ```powershell
 powershell -ExecutionPolicy Bypass -c "irm https://rrepo.org/rpx/latest/rpx-installer.ps1 | iex"
 ```
+
+The documentation on `main` describes the upcoming rpx 2 release. Until rpx 2 is published as the latest stable release, use the Cargo command below to install the current development version.
 
 Windows binary signing is still being worked on. The PowerShell installer is available, but Windows Defender or SmartScreen may warn until the signing flow is finalized.
 
@@ -225,13 +227,13 @@ rpx repo base reset
 
 `rpx repo add` and `rpx repo remove` are shortcuts for the corresponding `rpx repo additional` commands. Remote arguments use the same syntax as the `Remotes` field in `DESCRIPTION`.
 
-The base repository is always enabled. A useful setup is to keep the built-in base universe and add another CRAN or CRAN-like repository as a fallback for binary artifacts:
+The base repository is always enabled. Additional CRAN or CRAN-like repositories make their package versions available to the resolver:
 
 ```bash
 rpx repo additional add https://packagemanager.posit.co/cran/latest
 ```
 
-During locking, `rpx` merges versions across enabled repositories. Existing locked versions are preferred when they are still available from enabled repositories. If the same version is available from multiple repositories, the earlier repository wins for the locked source URL.
+During locking, `rpx` merges versions across enabled repositories. Existing locked versions are preferred when they are still available from enabled repositories. If the same version is available from multiple repositories, the earlier repository wins for the locked source URL. Binary and source artifacts are retrieved from that locked repository; additional repositories are not artifact fallbacks for a package locked to another source.
 
 When a repository requires authentication, `rpx` prompts for an API key and stores it in the operating system keyring for that repository's origin.
 
@@ -255,13 +257,18 @@ For teams, rrepo provides the same registry model for private R packages: publis
 
 ## Documentation
 
-The full user guide lives at [rrepo.org](https://rrepo.org/documentation/overview):
+The rpx user guide is maintained in this repository:
 
-- [Install rpx](https://rrepo.org/documentation/install-rpx)
-- [Start a project](https://rrepo.org/documentation/start-a-project)
-- [Use an existing project](https://rrepo.org/documentation/use-an-existing-project)
-- [Run R](https://rrepo.org/documentation/run-r)
-- [Private packages](https://rrepo.org/documentation/private-packages)
+- [Overview](docs/01.overview.md)
+- [Install rpx](docs/02.install-rpx.md)
+- [Start a project](docs/03.start-a-project.md)
+- [Use an existing project](docs/04.use-an-existing-project.md)
+- [Manage dependencies](docs/05.manage-dependencies.md)
+- [Run commands](docs/06.run-r.md)
+- [Configure repositories](docs/07.repositories.md)
+- [Changelog](CHANGELOG.md)
+
+Documentation for the hosted rrepo service, including [private packages](https://rrepo.org/documentation/private-packages), package publishing, and API keys, remains at [rrepo.org](https://rrepo.org/documentation/overview).
 
 ## How It Works
 
@@ -286,4 +293,6 @@ The test suite depends on Docker and uses `testcontainers`.
 
 Integration tests run against the official `r-base` image and execute realistic package-management workflows inside containers. This keeps tests close to real usage while avoiding changes to your local R installation or package library.
 
-Releases are created by pushing a version tag such as `v1.1.0`. The release workflow builds precompiled binaries for Linux, macOS, and Windows, then uploads archives, checksums, and installers to GitHub Releases. The Docker workflow publishes `ghcr.io/rrepo-org/rpx` images for `linux/amd64` and `linux/arm64`.
+Before releasing, update the version in `Cargo.toml` and `Cargo.lock`, move the relevant entries from `Unreleased` into a matching version section in [`CHANGELOG.md`](CHANGELOG.md), and run the test suite. The changelog heading must contain the exact package version so cargo-dist can use it for the GitHub release title and body.
+
+Create a release by pushing a matching version tag such as `v2.0.0`. The cargo-dist workflow builds precompiled binaries for Linux, macOS, and Windows, then uploads archives, checksums, installers, and release notes to GitHub Releases. The Docker workflow publishes `ghcr.io/rrepo-org/rpx` images for `linux/amd64` and `linux/arm64`. Only stable `vMAJOR.MINOR.PATCH` tags update the `latest` download on `rrepo.org`.

--- a/docs/01.overview.md
+++ b/docs/01.overview.md
@@ -1,0 +1,71 @@
+---
+title: Overview
+description: Understand the rpx project model and its package management workflow.
+seo:
+  title: rpx overview
+  description: Learn how DESCRIPTION, rpx.lock, and isolated project libraries make R projects reproducible.
+sitemap:
+  priority: 0.9
+  changefreq: monthly
+---
+
+`rpx` manages dependencies for R package projects and dependency-only R projects. It treats `DESCRIPTION` as the dependency contract, resolves compatible package versions into `rpx.lock`, and installs the locked package set into an isolated project library.
+
+## Project model
+
+An rpx project has three related parts:
+
+- `DESCRIPTION` declares direct dependencies and their compatible version ranges.
+- `rpx.lock` records the exact R version, repositories, root requirements, package versions, and sources selected by the resolver.
+- The project library contains the installed package set represented by the lockfile.
+
+Commit `DESCRIPTION` and `rpx.lock`. The project library and rpx caches are local state and should not be committed.
+
+An installable package is the default project type. rpx installs the package alongside its dependencies unless `--no-install-project` is passed to `add`, `remove`, or `sync`. A dependency-only project records `Config/rpx/type: project` in `DESCRIPTION` and never installs itself.
+
+## Recommended workflow
+
+Use rpx commands to change dependencies so the declaration, lockfile, and library stay together:
+
+```bash
+rpx add jsonlite
+rpx add --dev testthat
+rpx remove digest
+rpx status
+```
+
+When you edit `DESCRIPTION` manually, regenerate the lockfile before synchronizing:
+
+```bash
+rpx lock
+rpx sync
+```
+
+`rpx sync` intentionally refuses to install when the current `DESCRIPTION`, repository configuration, R version, and lockfile disagree.
+
+Run tools through `rpx run` when they need the project library:
+
+```bash
+rpx run R
+rpx run Rscript scripts/check.R
+```
+
+## Project discovery
+
+Commands can run from a project directory or one of its descendants. rpx searches upward for the nearest Git worktree, `DESCRIPTION`, or `rpx.lock` and uses that directory as the project root.
+
+Each project receives a library identified by its filesystem path. Moving a project causes rpx to use a different project library, which can be recreated with `rpx sync`.
+
+## Package sources
+
+Every project has one base repository. It can also use additional CRAN-like or rrepo repositories and Git remotes. Repository choices are part of the lockfile so another machine retrieves packages from the same selected sources.
+
+rpx uses the public rrepo-backed CRAN universe at `https://upstream.rrepo.dev/cran` as its built-in base repository. See [Configure repositories](./07.repositories.md) to replace it or add other package sources.
+
+## Next steps
+
+- [Install rpx](./02.install-rpx.md)
+- [Start a new project](./03.start-a-project.md)
+- [Use an existing project](./04.use-an-existing-project.md)
+- [Manage dependencies](./05.manage-dependencies.md)
+- [Run commands](./06.run-r.md)

--- a/docs/02.install-rpx.md
+++ b/docs/02.install-rpx.md
@@ -1,0 +1,83 @@
+---
+title: Install rpx
+description: Install the rpx CLI on macOS, Linux, or Windows.
+seo:
+  title: Install rpx
+  description: Install the rpx CLI and confirm that R is available on PATH.
+sitemap:
+  priority: 0.8
+  changefreq: monthly
+---
+
+## Prerequisites
+
+rpx requires both `R` and `Rscript` during package-management workflows. Source packages are built with R and installed from the resulting artifacts. Confirm that both commands are available in your shell:
+
+```bash
+R --version
+Rscript --version
+```
+
+Install R from the appropriate distribution if it is not already available:
+
+- [Windows](https://cran.r-project.org/bin/windows/base/)
+- [macOS](https://cran.r-project.org/bin/macosx/)
+- [CRAN mirrors](https://cran.r-project.org/mirrors.html)
+
+rpx uses binary R packages on Windows and macOS when a selected repository provides them. It falls back to source packages when no usable binary is available. Source installation can require compilers, platform tools, and system libraries. Windows users may need [Rtools](https://cran.r-project.org/bin/windows/Rtools/).
+
+> [!NOTE]
+> This guide describes the upcoming rpx 2 release. Until rpx 2 is published as the latest stable release, use [Install from Git](#install-from-git) to install the documented CLI.
+
+## macOS and Linux
+
+Install the latest release with the shell installer:
+
+```bash
+curl -LsSf https://rrepo.org/rpx/latest/rpx-installer.sh | sh
+```
+
+## Windows
+
+Install the latest release with PowerShell:
+
+```powershell
+powershell -ExecutionPolicy Bypass -c "irm https://rrepo.org/rpx/latest/rpx-installer.ps1 | iex"
+```
+
+Windows Defender or SmartScreen may warn while binary signing is being finalized.
+
+## Install from Git
+
+Install the current source with Cargo:
+
+```bash
+cargo install --git https://github.com/rrepo-org/rpx.git
+```
+
+If Cargo is not installed, follow the [rustup installation instructions](https://rustup.rs/). Windows source builds also require the [Rust MSVC prerequisites](https://rust-lang.github.io/rustup/installation/windows-msvc.html).
+
+## Docker
+
+The published image contains the rpx executable and can be used to inspect the CLI:
+
+```bash
+docker run --rm ghcr.io/rrepo-org/rpx:latest --help
+```
+
+The image does not include R. For package workflows, copy the executable into an image that provides R:
+
+```dockerfile
+FROM r-base:latest
+COPY --link --from=ghcr.io/rrepo-org/rpx:latest /rpx /usr/local/bin/rpx
+```
+
+## Confirm the installation
+
+```bash
+rpx --version
+R --version
+Rscript --version
+```
+
+Continue with [Start a project](./03.start-a-project.md) or [Use an existing project](./04.use-an-existing-project.md).

--- a/docs/03.start-a-project.md
+++ b/docs/03.start-a-project.md
@@ -1,0 +1,83 @@
+---
+title: Start a project
+description: Create an installable R package or dependency-only project with rpx.
+seo:
+  title: Start an R project with rpx
+  description: Initialize an R project, select development dependencies, and create its first lockfile and project library.
+sitemap:
+  priority: 0.8
+  changefreq: monthly
+---
+
+`rpx init` creates an installable R package or dependency-only project, resolves its first lockfile, and synchronizes its project library.
+
+## Choose a project type
+
+An installable package is the default. It includes package metadata and is installed into the project library alongside its dependencies.
+
+A dependency-only project manages an environment without installing itself. Select it interactively or pass `--type project`:
+
+```bash
+rpx init --type project
+```
+
+Both types use `DESCRIPTION` and `rpx.lock`. Dependency-only projects are marked with `Config/rpx/type: project` in `DESCRIPTION`.
+
+## Interactive setup
+
+Run the initializer in a terminal:
+
+```bash
+rpx init
+```
+
+The interactive flow asks for the target directory, project type, package metadata, license, base repository, and development packages. It can add `testthat`, `roxygen2`, and `devtools` to `Suggests`.
+
+The base repository choices are rrepo and CRAN. rrepo is the default and uses the built-in `https://upstream.rrepo.dev/cran` repository without writing an explicit project setting. Choosing CRAN writes `Config/rpx/base-repository: https://cloud.r-project.org/` to `DESCRIPTION`.
+
+If the target is not already inside a Git worktree, rpx also offers to initialize a Git repository. This invokes the installed `git` executable, creates `.git` and an R-focused `.gitignore`, and does not create an initial commit or select a branch. Install Git and ensure `git` is on `PATH` before selecting this option.
+
+The target directory must either not exist or be completely empty. rpx does not overwrite or upgrade an existing project. Hidden files, including an existing `.git` directory, count as content.
+
+## Generated project
+
+Initialization creates the project files, including:
+
+- `DESCRIPTION`
+- `NAMESPACE`
+- `.Rbuildignore`
+- License files
+- `rpx.lock`
+
+For package projects, it then installs the package and its selected development dependencies into the project library. Dependency-only projects install only their selected dependencies. Commit the generated source files, `DESCRIPTION`, and `rpx.lock`; do not commit the project library.
+
+## Non-interactive setup
+
+Provide a path and metadata flags for deterministic automation:
+
+```bash
+rpx init ./mypkg \
+  --type package \
+  --name mypkg \
+  --title "My Package" \
+  --description "Utilities for my application." \
+  --author-name "Example Author" \
+  --author-email "author@example.com" \
+  --license mit
+```
+
+Supported license values are `mit`, `apache-2.0`, `gpl-2`, `gpl-3`, `agpl-3`, `lgpl-2.1`, `lgpl-3`, `cc0`, `cc-by-4.0`, and `proprietary`.
+
+When no terminal is available, omitted values use defaults, the project type defaults to `package`, rrepo is selected as the base repository, no development packages are selected, and Git is not initialized. There is no `init` flag for selecting CRAN non-interactively; configure a different base afterward with `rpx repo base set`. Supplying the target path and all metadata flags is recommended for CI or scripts.
+
+## Add a dependency
+
+Move into the generated project and add a package:
+
+```bash
+cd mypkg
+rpx add digest
+rpx run R
+```
+
+`rpx add` updates `DESCRIPTION`, resolves and writes `rpx.lock`, and synchronizes the project library. Continue with [Manage dependencies](./05.manage-dependencies.md) for dependency fields and version constraints.

--- a/docs/04.use-an-existing-project.md
+++ b/docs/04.use-an-existing-project.md
@@ -1,0 +1,96 @@
+---
+title: Use an existing project
+description: Lock and synchronize an existing R project.
+seo:
+  title: Use rpx with an existing R project
+  description: Create a lockfile, install a reproducible project library, and check project state with rpx.
+sitemap:
+  priority: 0.8
+  changefreq: monthly
+---
+
+rpx uses an R `DESCRIPTION` file as the project manifest. By default, an existing project is treated as an installable package and needs valid `Package` and `Version` fields plus the files required by `R CMD INSTALL`.
+
+For a dependency-only environment, add this field to `DESCRIPTION`:
+
+```text
+Config/rpx/type: project
+```
+
+Dependency-only projects do not install themselves. For an installable package that should temporarily synchronize only its dependencies, use `--no-install-project` instead.
+
+## Create the lockfile
+
+Run `rpx lock` from the project or one of its subdirectories:
+
+```bash
+rpx lock
+```
+
+The command resolves dependencies from `DESCRIPTION` and writes `rpx.lock`. It records the current R version, repository configuration, root requirements, selected packages, and package sources. It does not install packages.
+
+## Synchronize the library
+
+Install the locked package set and, for package projects, the project itself:
+
+```bash
+rpx sync
+```
+
+Synchronization is strict. It installs missing packages, replaces version mismatches, and removes unexpected packages from the project library. Local projects and Git packages are rebuilt and reinstalled because their contents can change without a version change. Source builds use isolated workspaces, so build products do not modify the project or checked-out package sources.
+
+Synchronize only the dependencies of an installable package with:
+
+```bash
+rpx sync --no-install-project
+```
+
+This remains exact synchronization. If the project package is already installed, rpx removes it while retaining the locked dependencies. The resulting package set must contain every non-base hard dependency required by the packages being installed.
+
+rpx schedules synchronization from the hard-dependency graph formed by `Depends`, `Imports`, and `LinkingTo`. It reports invalid package metadata, missing required packages, and dependency cycles. Independent package operations can complete before a later operation reports an error.
+
+If `DESCRIPTION` or the repository configuration has changed since the lockfile was written, update the lockfile first:
+
+```bash
+rpx lock
+rpx sync
+```
+
+## Check project state
+
+Use `status` before committing or in CI:
+
+```bash
+rpx status
+```
+
+It checks that `DESCRIPTION`, repository configuration, the current R version, `rpx.lock`, and the locked dependencies in the installed library agree. The project package is optional and its installed version is not checked, so package and dependency-only environments can both be in sync. A project in the expected state prints `Project is in sync`; drift produces a nonzero exit code and a diagnostic.
+
+## System dependencies
+
+rpx does not install operating-system dependencies. Provision required compilers, development headers, and system libraries before running `rpx sync`. Missing system dependencies typically surface while an R package is being built from source.
+
+## CI workflow
+
+A typical CI job restores the exact project state and runs a script in that environment:
+
+```bash
+rpx sync
+rpx status
+rpx run Rscript scripts/check.R
+```
+
+## What to commit
+
+Commit both `DESCRIPTION` and `rpx.lock`. Do not commit the isolated library or shared package cache; `rpx sync` recreates the library from the lockfile.
+
+If local state needs to be discarded, run:
+
+```bash
+rpx clean
+rpx sync
+```
+
+`rpx clean` removes all rpx project libraries and shared caches, not only the current project's library. Other projects will also need to recreate their libraries and download or rebuild cached artifacts.
+
+Package installs are staged and committed through library transactions so a failed install does not publish a partial package directory. A complete synchronization can still stop after other packages were successfully installed or removed. Fix the reported problem and rerun `rpx sync`; `rpx clean` should not be necessary for ordinary installation failures.

--- a/docs/05.manage-dependencies.md
+++ b/docs/05.manage-dependencies.md
@@ -1,0 +1,100 @@
+---
+title: Manage dependencies
+description: Add, constrain, move, and remove project dependencies with rpx.
+seo:
+  title: Manage R package dependencies with rpx
+  description: Keep DESCRIPTION, rpx.lock, and an isolated R project library synchronized when dependencies change.
+sitemap:
+  priority: 0.8
+  changefreq: monthly
+---
+
+Use `rpx add` and `rpx remove` instead of installing packages directly into the project library. These commands update `DESCRIPTION`, regenerate `rpx.lock`, and strictly synchronize the installed package set.
+
+## Add packages
+
+Add one or more packages to `Imports`, the default dependency field:
+
+```bash
+rpx add digest
+rpx add jsonlite cli
+```
+
+Select another dependency field with one of the mutually exclusive flags:
+
+```bash
+rpx add --depends R6
+rpx add --imports jsonlite
+rpx add --linking-to Rcpp
+rpx add --suggests testthat
+rpx add --dev roxygen2
+```
+
+`--dev` is an alias for `--suggests`. `Enhances` is not currently supported.
+
+rpx treats the project's `Suggests` as development dependencies: they are root requirements that are resolved, locked, and installed. The `Suggests` of transitive packages are not installed.
+
+Adding a package already declared in another supported field moves it to the selected field. Existing relations for that package are removed from `Depends`, `Imports`, `LinkingTo`, and `Suggests` before the new relation is added.
+
+## Default version bounds
+
+For an unconstrained non-base package resolved from a repository, rpx records the selected version as a lower bound and the next major version as an upper bound. If `examplepkg` resolves to `1.4.2`, rpx writes:
+
+```text
+Imports:
+    examplepkg (>= 1.4.2),
+    examplepkg (< 2.0.0)
+```
+
+For a `0.x` package, the upper bound is `< 1.0.0`.
+
+R base packages remain unbounded requirements and do not receive package entries in `rpx.lock`.
+
+This is an opinionated default based on semantic versioning. R packages do not universally follow semantic versioning, so review and adjust the range when a package's compatibility policy requires it.
+
+## Explicit constraints
+
+Use `PACKAGE@OPERATORVERSION` without spaces to provide a constraint:
+
+```bash
+rpx add --dev 'digest@>=0.6.37'
+```
+
+Supported operators are `<`, `<=`, `==`, `!=`, `>=`, and `>`. An explicit constraint replaces the automatic bounds and any existing supported relation for that package.
+
+## Remove packages
+
+Remove one or more direct dependencies:
+
+```bash
+rpx remove digest
+rpx remove jsonlite cli
+```
+
+The packages are removed from `Depends`, `Imports`, `LinkingTo`, and `Suggests`. rpx then relocks and synchronizes the whole library, which can also remove packages that are no longer transitively required or were installed manually.
+
+## Dependency-only synchronization
+
+Projects created with `rpx init --type project` always synchronize only their dependencies. For an installable package, `add` and `remove` install the current project package after updating its dependencies by default. Use `--no-install-project` to synchronize only the dependency set:
+
+```bash
+rpx add --no-install-project digest
+rpx remove --no-install-project digest
+```
+
+The flag removes an already installed copy of the project package. It does not relax dependency validation: every non-base hard dependency required by the resulting package set must still be present.
+
+## Manual DESCRIPTION changes
+
+If you edit dependencies in `DESCRIPTION` directly, regenerate the lockfile and synchronize explicitly:
+
+```bash
+rpx lock
+rpx sync
+```
+
+`rpx lock` only resolves and writes the lockfile. `rpx sync` only installs a lockfile that agrees with the current project configuration.
+
+`add` and `remove` write `DESCRIPTION` and `rpx.lock` before synchronizing packages. If a later build or installation fails, the metadata remains updated and other package operations may already have completed. Individual package installs are transactional, so a failed install does not publish a partial package directory. Fix the reported problem and retry with `rpx sync`; `rpx clean` should not normally be required.
+
+Installing a package through `install.packages()` inside `rpx run R` does not update `DESCRIPTION` or `rpx.lock`. `rpx status` reports it as unexpected and the next `rpx sync` removes it.

--- a/docs/06.run-r.md
+++ b/docs/06.run-r.md
@@ -1,0 +1,59 @@
+---
+title: Run commands
+description: Run R and other commands with the rpx project library activated.
+seo:
+  title: Run commands in an rpx project environment
+  description: Use rpx run to execute R, Rscript, and project tools with the isolated R package library activated.
+sitemap:
+  priority: 0.8
+  changefreq: monthly
+---
+
+`rpx run` validates the locked project environment, then executes a command with the isolated R package library activated through `R_LIBS_USER`.
+
+## Start R
+
+```bash
+rpx run R
+```
+
+Packages installed by `rpx sync` are available in the session without changing your global R library.
+
+## Run scripts and tools
+
+Pass a command and its arguments after `rpx run`:
+
+```bash
+rpx run Rscript scripts/check.R
+rpx run Rscript -e 'cat(.libPaths()[1])'
+rpx run R CMD check .
+```
+
+The command is executed directly, not through a shell. rpx preserves the caller's current working directory, environment, arguments, and standard streams, even when it discovers the project root in a parent directory. The command's exit status is propagated, which makes `rpx run` suitable for scripts and CI.
+
+Although the project environment is an R library, `rpx run` can execute any command that should inherit `R_LIBS_USER`.
+
+## Shell expressions
+
+Because no shell is started implicitly, pipes, redirects, variable expansion, and other shell expressions are not interpreted. Invoke a shell explicitly when they are needed:
+
+```bash
+rpx run sh -c 'Rscript scripts/check.R | tee check.log'
+```
+
+On Windows, invoke PowerShell or `cmd /C` explicitly for equivalent shell behavior.
+
+## Environment validation
+
+Before starting the command, `rpx run` requires a readable, supported `rpx.lock` that agrees with `DESCRIPTION`, the repository configuration, and the current R version. It refuses to run when a locked dependency is missing or installed at the wrong version.
+
+Extra packages do not prevent a command from running, although `rpx status` reports them as unexpected. An installable project's own package is optional, matching `--no-install-project`; dependency-only projects never require one.
+
+`rpx run` validates but does not synchronize the environment. Run synchronization explicitly when the library is not ready:
+
+```bash
+rpx sync
+rpx run Rscript scripts/check.R
+```
+
+Avoid using `install.packages()` to manage project dependencies inside an rpx session. A directly installed package is not added to `DESCRIPTION` or `rpx.lock`, is reported as unexpected by `rpx status`, and is removed by strict synchronization. Use `rpx add` instead.

--- a/docs/07.repositories.md
+++ b/docs/07.repositories.md
@@ -1,0 +1,160 @@
+---
+title: Repositories
+description: Configure base, additional, and Git package repositories for rpx.
+seo:
+  title: Configure package repositories in rpx
+  description: Replace the base package universe, add CRAN-like repositories and Git remotes, and manage private repository credentials.
+sitemap:
+  priority: 0.8
+  changefreq: monthly
+---
+
+Repository configuration is stored in `DESCRIPTION` and captured in `rpx.lock`. Every project has one base repository and can also use Git remotes and additional repositories.
+
+## Repository classes
+
+rpx builds the effective repository list in this order:
+
+1. The base repository.
+2. Git remotes from `Remotes`.
+3. Additional repositories from `Additional_repositories`.
+
+During resolution, rpx prefers an existing locked version when it remains compatible and available. Otherwise it selects the highest compatible version across the configured repositories. If the same version is available from more than one source, the earlier repository in the effective list wins.
+
+The selected repository is written to `rpx.lock`. Binary and source artifact requests for that package use its locked repository; an additional repository is not a fallback for artifacts from another locked source.
+
+## Base repository
+
+The built-in base repository is:
+
+```text
+https://upstream.rrepo.dev/cran
+```
+
+Replace it for a project with:
+
+```bash
+rpx repo base set https://<org-slug>.rrepo.dev/<repo-slug>
+```
+
+This writes `Config/rpx/base-repository` in `DESCRIPTION`. It replaces the previous base; it does not add a second base repository.
+
+Return to the built-in base with:
+
+```bash
+rpx repo base reset
+```
+
+The base repository is always present and cannot be disabled.
+
+## Additional repositories
+
+Add a CRAN-like or rrepo repository alongside the base:
+
+```bash
+rpx repo additional add https://cloud.r-project.org
+```
+
+Remove it with:
+
+```bash
+rpx repo additional remove https://cloud.r-project.org
+```
+
+The shorter `rpx repo add` and `rpx repo remove` commands are aliases for the corresponding additional-repository commands:
+
+```bash
+rpx repo add https://cloud.r-project.org
+rpx repo remove https://cloud.r-project.org
+```
+
+Repository changes regenerate `rpx.lock` but do not synchronize the project library. Run `rpx sync` after changing repositories when the installed environment should match the new lockfile.
+
+## Git remotes
+
+Git must be installed and available on `PATH` to add, resolve, or install Git remotes. Add packages from GitHub, GitLab, Bitbucket, or a generic Git repository through the `Remotes` field:
+
+```bash
+rpx repo remote add github::owner/repository@main
+rpx repo remote add gitlab@code.example::group/repository@develop
+rpx repo remote add bitbucket::owner/repository/subdir@v1
+rpx repo remote add 'git::https://example.com/team/repository.git@main'
+```
+
+Remove a remote using its normalized specification:
+
+```bash
+rpx repo remote remove github::owner/repository@main
+```
+
+Locking resolves a branch, tag, or default branch to an immutable commit and records that commit in `rpx.lock`. Generic Git remotes support HTTPS, SSH URLs, and SCP-like SSH syntax. Plain HTTP, local paths, `file://` URLs, and credentials embedded in HTTPS URLs are rejected.
+
+Git HTTPS authentication uses configured Git credential helpers. SSH authentication uses the SSH agent.
+
+## List repositories
+
+List every effective repository:
+
+```bash
+rpx repo list
+```
+
+Filter by repository class:
+
+```bash
+rpx repo list --type base
+rpx repo list --type additional
+rpx repo list --type remote
+```
+
+The base entry reports whether it is built in or configured. Additional repositories and remotes report that they came from `DESCRIPTION`.
+
+## Private repositories
+
+Obtain the repository URL and an API key from your repository provider. For rrepo-hosted packages, dashboard setup and API-key permissions are documented at [rrepo.org](https://rrepo.org/documentation/private-packages).
+
+Configure the private repository as the base when it represents the project's primary package universe:
+
+```bash
+rpx repo base set https://<org-slug>.rrepo.dev/<repo-slug>
+```
+
+Or add it without replacing the base:
+
+```bash
+rpx repo additional add https://<org-slug>.rrepo.dev/<repo-slug>
+```
+
+When a repository responds with HTTP 401, interactive rpx prompts for an API key and stores it in the operating system keyring. Non-interactive commands cannot prompt and require a usable key to have been stored previously.
+
+Credentials are scoped to the repository origin: scheme, host, and port. Repositories at different paths on the same origin share the stored credential.
+
+Remove a credential when removing an additional repository:
+
+```bash
+rpx repo additional remove https://<org-slug>.rrepo.dev/<repo-slug> --remove-credential
+```
+
+Remove the configured base credential while resetting to the built-in base:
+
+```bash
+rpx repo base reset --remove-credential
+```
+
+## Migrating from default-repository flags
+
+rpx 2 removes `--default-repo` and `--no-default-repo` from `add`, `remove`, and `lock`. The base repository is now a persistent project setting instead of a per-command choice.
+
+Replace the built-in repository with:
+
+```bash
+rpx repo base set https://example.org/cran
+```
+
+Restore the built-in repository with:
+
+```bash
+rpx repo base reset
+```
+
+There is no rpx 2 configuration for resolving with no base repository.


### PR DESCRIPTION
## Summary

- move the rpx CLI guide into this repository as Nuxt Content-compatible Markdown
- update the guide for the rpx 2 project, Git, repository, dependency, and synchronization flows
- add a cargo-dist-compatible changelog starting with the upcoming 2.0.0 release
- point the README at the repository-owned guide and document the release workflow

The hosted rrepo service documentation remains on rrepo.org. Its Nuxt application will need a separate change to consume this repository as the canonical rpx documentation source.

## Validation

- `cargo test` (187 unit tests and 65 integration tests passed)
- cargo-dist 0.31.0 `plan --tag=v2.0.0`
- cargo-dist 0.31.0 manifest assertion for the 2.0.0 announcement title and changelog body
- `git diff --check`
- verified installer, repository, container registry, and hosted service documentation URLs

Closes #80
Closes #71