### PR TITLE
feat: relabel package installation progress messages

### DIFF
--- a/src/sync.rs
+++ b/src/sync.rs
@@ -953,10 +953,10 @@ impl InstallArtifact {
         }
     }
 
-    fn progress_action(&self) -> &'static str {
+    fn installation_action(&self) -> &'static str {
         match self.kind {
-            ArtifactKind::Binary(_) => "extracting",
-            ArtifactKind::Source => "installing",
+            ArtifactKind::Binary(_) => "installing binary",
+            ArtifactKind::Source => "installing source",
         }
     }
 
@@ -1139,10 +1139,11 @@ async fn install_package(
         let r_version_for_prepare = r_version.clone();
 
         span.record("stage", "preparing cache");
-        span.pb_set_message(&format!(
+        let installation_message = format!(
             "{package} {version} {}",
-            artifact.progress_action()
-        ));
+            artifact.installation_action()
+        );
+        span.pb_set_message(&installation_message);
         let entry = tokio::task::spawn_blocking(move || {
             let artifact_digest = artifact_digest(&artifact_path).map_err(|source| {
                 InstallPackageError::ArtifactDigest {
@@ -1182,7 +1183,7 @@ async fn install_package(
         .map_err(|source| InstallPackageError::Join { source })??;
 
         span.record("stage", "updating project library");
-        span.pb_set_message(&format!("{package} {version} publishing"));
+        span.pb_set_message(&installation_message);
         let installer = installer.clone();
         let project_library = project_library.to_path_buf();
         let outcome =
@@ -1362,6 +1363,21 @@ mod tests {
     use crate::repository::{PackageRepository, built_in_repository};
     use r_description::Description;
     use r_metadata::Remote;
+
+    #[test]
+    fn install_artifact_actions_use_r_installation_terms() {
+        let binary = InstallArtifact {
+            path: PathBuf::new(),
+            kind: ArtifactKind::Binary(BinaryFormat::Zip),
+        };
+        let source = InstallArtifact {
+            path: PathBuf::new(),
+            kind: ArtifactKind::Source,
+        };
+
+        assert_eq!(binary.installation_action(), "installing binary");
+        assert_eq!(source.installation_action(), "installing source");
+    }
 
     #[test]
     fn package_requires_install_respects_source_and_version() {


### PR DESCRIPTION
### Motivation

- The in-progress span messages exposed implementation details like "extracting" and "publishing" instead of R-oriented installation terminology. 
- R users expect distinctions between binary and source installs, so progress spans should use user-facing labels that match R terminology.

### Description

- Renamed `InstallArtifact::progress_action` to `InstallArtifact::installation_action` and updated its return values to `"installing binary"` and `"installing source"` in `src/sync.rs`. 
- Replaced ad-hoc formatted progress messages with a single `installation_message` used for both installer preparation and project-library materialization. 
- Added a unit test `install_artifact_actions_use_r_installation_terms` that asserts the new installation labels for binary and source artifacts.

### Testing

- Ran `cargo fmt --check` which succeeded. 
- Ran `cargo test --lib` and the library tests passed (188 passed, 0 failed). 
- Ran the focused test `cargo test --lib sync::tests::install_artifact_actions_use_r_installation_terms` which passed. 
- Attempted a full `cargo test` and some Docker-backed CLI tests failed to run because `/var/run/docker.sock` is unavailable in the environment, and `cargo clippy --all-targets --all-features -- -D warnings` was blocked by existing lint violations unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a9f16d84758833190a9aa0d29729394)