### PR TITLE
feat: use namespace-qualified rrepo URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,12 +210,12 @@ rpx clean
 
 The package universe is the set of package versions and metadata available to the resolver.
 
-By default, `rpx` uses the public rrepo-backed CRAN universe at `https://upstream.rrepo.dev/cran`. This gives the resolver CRAN package metadata through rrepo APIs, including historical package metadata instead of only today's latest package state.
+By default, `rpx` uses the public rrepo-backed CRAN universe at `https://rrepo.dev/upstream/cran`. This gives the resolver CRAN package metadata through rrepo APIs, including historical package metadata instead of only today's latest package state.
 
 Projects can configure a base repository, additional rrepo or CRAN-like repositories, and package remotes:
 
 ```bash
-rpx repo base set https://<org-slug>.rrepo.dev/<repo-slug>
+rpx repo base set https://rrepo.dev/<org-slug>/<repo-slug>
 rpx repo additional add https://cloud.r-project.org
 rpx repo add https://packagemanager.posit.co/cran/latest
 rpx repo remote add github::owner/repository@main
@@ -242,12 +242,12 @@ Projects can set `Config/rpx/base-repository` in `DESCRIPTION` to replace the bu
 For private package universes, add an rrepo repository for your organization:
 
 ```bash
-rpx repo additional add https://<org-slug>.rrepo.dev/<repo-slug>
+rpx repo additional add https://rrepo.dev/<org-slug>/<repo-slug>
 ```
 
 ## rrepo
 
-`rpx` can use CRAN and CRAN-like repositories, but its default package universe is the rrepo-backed CRAN mirror at `https://upstream.rrepo.dev/cran`.
+`rpx` can use CRAN and CRAN-like repositories, but its default package universe is the rrepo-backed CRAN mirror at `https://rrepo.dev/upstream/cran`.
 
 A plain CRAN-style mirror is mostly a package distribution endpoint. It is enough for installing available packages, but it is not a registry API built around dependency solving, package history, artifact selection, authentication, and private packages.
 

--- a/docs/01.overview.md
+++ b/docs/01.overview.md
@@ -60,7 +60,7 @@ Each project receives a library identified by its filesystem path. Moving a proj
 
 Every project has one base repository. It can also use additional CRAN-like or rrepo repositories and Git remotes. Repository choices are part of the lockfile so another machine retrieves packages from the same selected sources.
 
-rpx uses the public rrepo-backed CRAN universe at `https://upstream.rrepo.dev/cran` as its built-in base repository. See [Configure repositories](./07.repositories.md) to replace it or add other package sources.
+rpx uses the public rrepo-backed CRAN universe at `https://rrepo.dev/upstream/cran` as its built-in base repository. See [Configure repositories](./07.repositories.md) to replace it or add other package sources.
 
 ## Next steps
 

--- a/docs/03.start-a-project.md
+++ b/docs/03.start-a-project.md
@@ -33,7 +33,7 @@ rpx init
 
 The interactive flow asks for the target directory, project type, package metadata, license, base repository, and development packages. It can add `testthat`, `roxygen2`, and `devtools` to `Suggests`.
 
-The base repository choices are rrepo and CRAN. rrepo is the default and uses the built-in `https://upstream.rrepo.dev/cran` repository without writing an explicit project setting. Choosing CRAN writes `Config/rpx/base-repository: https://cloud.r-project.org/` to `DESCRIPTION`.
+The base repository choices are rrepo and CRAN. rrepo is the default and uses the built-in `https://rrepo.dev/upstream/cran` repository without writing an explicit project setting. Choosing CRAN writes `Config/rpx/base-repository: https://cloud.r-project.org/` to `DESCRIPTION`.
 
 If the target is not already inside a Git worktree, rpx also offers to initialize a Git repository. This invokes the installed `git` executable, creates `.git` and an R-focused `.gitignore`, and does not create an initial commit or select a branch. Install Git and ensure `git` is on `PATH` before selecting this option.
 

--- a/docs/07.repositories.md
+++ b/docs/07.repositories.md
@@ -28,13 +28,13 @@ The selected repository is written to `rpx.lock`. Binary and source artifact req
 The built-in base repository is:
 
 ```text
-https://upstream.rrepo.dev/cran
+https://rrepo.dev/upstream/cran
 ```
 
 Replace it for a project with:
 
 ```bash
-rpx repo base set https://<org-slug>.rrepo.dev/<repo-slug>
+rpx repo base set https://rrepo.dev/<org-slug>/<repo-slug>
 ```
 
 This writes `Config/rpx/base-repository` in `DESCRIPTION`. It replaces the previous base; it does not add a second base repository.
@@ -116,13 +116,13 @@ Obtain the repository URL and an API key from your repository provider. For rrep
 Configure the private repository as the base when it represents the project's primary package universe:
 
 ```bash
-rpx repo base set https://<org-slug>.rrepo.dev/<repo-slug>
+rpx repo base set https://rrepo.dev/<org-slug>/<repo-slug>
 ```
 
 Or add it without replacing the base:
 
 ```bash
-rpx repo additional add https://<org-slug>.rrepo.dev/<repo-slug>
+rpx repo additional add https://rrepo.dev/<org-slug>/<repo-slug>
 ```
 
 When a repository responds with HTTP 401, interactive rpx prompts for an API key and stores it in the operating system keyring. Non-interactive commands cannot prompt and require a usable key to have been stored previously.
@@ -132,7 +132,7 @@ Credentials are scoped to the repository origin: scheme, host, and port. Reposit
 Remove a credential when removing an additional repository:
 
 ```bash
-rpx repo additional remove https://<org-slug>.rrepo.dev/<repo-slug> --remove-credential
+rpx repo additional remove https://rrepo.dev/<org-slug>/<repo-slug> --remove-credential
 ```
 
 Remove the configured base credential while resetting to the built-in base:

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -25,7 +25,7 @@ pub use git::GitRepository;
 pub use local::LocalRepository;
 pub use rrepo::RrepoRepository;
 
-const BUILT_IN_REPOSITORY_BASE_URL: &str = "https://upstream.rrepo.dev/cran";
+const BUILT_IN_REPOSITORY_BASE_URL: &str = "https://rrepo.dev/upstream/cran";
 
 static BUILT_IN_REPOSITORY_URL: LazyLock<Url> = LazyLock::new(|| {
     parse_repository_url(BUILT_IN_REPOSITORY_BASE_URL)

--- a/tests/deps.rs
+++ b/tests/deps.rs
@@ -106,7 +106,7 @@ fn runs_rpx_add_inside_custom_r_image() {
     assert!(lockfile["packages"].get("testpkg").is_none());
     assert_eq!(
         lockfile["repos"][0]["url"],
-        "https://upstream.rrepo.dev/cran"
+        "https://rrepo.dev/upstream/cran"
     );
     assert!(
         lockfile["requirements"]
@@ -456,13 +456,13 @@ Imports: digest",
         lockfile["repos"].as_array().is_some_and(|repositories| {
             repositories
                 .iter()
-                .any(|repository| repository["url"] == "https://upstream.rrepo.dev/cran")
+                .any(|repository| repository["url"] == "https://rrepo.dev/upstream/cran")
         }),
         "lockfile was: {lockfile}"
     );
     assert_eq!(
         lockfile["packages"]["digest"]["repository"],
-        "https://upstream.rrepo.dev/cran"
+        "https://rrepo.dev/upstream/cran"
     );
 }
 

--- a/tests/repo.rs
+++ b/tests/repo.rs
@@ -91,7 +91,7 @@ fn resets_configured_base_and_relocks_with_builtin_repository() {
     assert_eq!(description.matches("Title:").count(), 1);
     assert!(description.contains("Title: Normalized Title"));
     assert!(description.find("Title:").unwrap() < description.find("Version:").unwrap());
-    assert!(lockfile.contains("https://upstream.rrepo.dev/cran"));
+    assert!(lockfile.contains("https://rrepo.dev/upstream/cran"));
 }
 
 #[test]
@@ -101,13 +101,13 @@ fn sets_normalized_base_repository() {
     create_package_project(&container, project_path);
 
     let command =
-        format!("cd {project_path} && rpx repo base set https://upstream.rrepo.dev/cran/");
+        format!("cd {project_path} && rpx repo base set https://rrepo.dev/upstream/cran/");
     let (exit_code, stdout, stderr) = run_shell_command(&container, &command);
 
     assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");
     let description = read_project_file(&container, project_path, "DESCRIPTION");
-    assert!(description.contains("Config/rpx/base-repository: https://upstream.rrepo.dev/cran"));
-    assert!(!description.contains("https://upstream.rrepo.dev/cran/"));
+    assert!(description.contains("Config/rpx/base-repository: https://rrepo.dev/upstream/cran"));
+    assert!(!description.contains("https://rrepo.dev/upstream/cran/"));
 
     let command = format!("cd {project_path} && rpx lock");
     let (exit_code, stdout, stderr) = run_shell_command(&container, &command);
@@ -126,11 +126,11 @@ fn additional_shortcut_detects_normalized_duplicate_without_relocking() {
     append_description(
         &container,
         project_path,
-        "Additional_repositories: https://upstream.rrepo.dev/cran/",
+        "Additional_repositories: https://rrepo.dev/upstream/cran/",
     );
     let before = read_project_file(&container, project_path, "DESCRIPTION");
 
-    let command = format!("cd {project_path} && rpx repo add https://upstream.rrepo.dev/cran");
+    let command = format!("cd {project_path} && rpx repo add https://rrepo.dev/upstream/cran");
     let (exit_code, stdout, stderr) = run_shell_command(&container, &command);
 
     assert_eq!(exit_code, 0, "stdout was: {stdout}\nstderr was: {stderr}");


### PR DESCRIPTION
## Summary
- Switch the built-in repository to https://rrepo.dev/upstream/cran so all requests derived from it use the apex directly.
- Update repository documentation and examples to namespace-qualified URLs.
- Update existing test fixtures and expectations for the built-in URL.

## Dependency
Blocked by [RRE-37](https://linear.app/rrepo/issue/RRE-37/support-namespace-qualified-repository-urls). Keep this PR in draft until the canonical gateway routes are available.

Closes [RRE-48](https://linear.app/rrepo/issue/RRE-48/update-rpx-built-in-repository-urls-to-namespace-qualified-apex-urls).

## Testing
Not run, as requested.