### PR TITLE
docs: use canonical website links for imported documentation

### DIFF
--- a/docs/01.overview.md
+++ b/docs/01.overview.md
@@ -60,12 +60,12 @@ Each project receives a library identified by its filesystem path. Moving a proj
 
 Every project has one base repository. It can also use additional CRAN-like or rrepo repositories and Git remotes. Repository choices are part of the lockfile so another machine retrieves packages from the same selected sources.
 
-rpx uses the public rrepo-backed CRAN universe at `https://rrepo.dev/upstream/cran` as its built-in base repository. See [Configure repositories](./07.repositories.md) to replace it or add other package sources.
+rpx uses the public rrepo-backed CRAN universe at `https://rrepo.dev/upstream/cran` as its built-in base repository. See [Configure repositories](https://rrepo.org/documentation/repositories) to replace it or add other package sources.
 
 ## Next steps
 
-- [Install rpx](./02.install-rpx.md)
-- [Start a new project](./03.start-a-project.md)
-- [Use an existing project](./04.use-an-existing-project.md)
-- [Manage dependencies](./05.manage-dependencies.md)
-- [Run commands](./06.run-r.md)
+- [Install rpx](https://rrepo.org/documentation/install-rpx)
+- [Start a new project](https://rrepo.org/documentation/start-a-project)
+- [Use an existing project](https://rrepo.org/documentation/use-an-existing-project)
+- [Manage dependencies](https://rrepo.org/documentation/manage-dependencies)
+- [Run commands](https://rrepo.org/documentation/run-r)

--- a/docs/02.install-rpx.md
+++ b/docs/02.install-rpx.md
@@ -80,4 +80,4 @@ R --version
 Rscript --version
 ```
 
-Continue with [Start a project](./03.start-a-project.md) or [Use an existing project](./04.use-an-existing-project.md).
+Continue with [Start a project](https://rrepo.org/documentation/start-a-project) or [Use an existing project](https://rrepo.org/documentation/use-an-existing-project).

--- a/docs/03.start-a-project.md
+++ b/docs/03.start-a-project.md
@@ -80,4 +80,4 @@ rpx add digest
 rpx run R
 ```
 
-`rpx add` updates `DESCRIPTION`, resolves and writes `rpx.lock`, and synchronizes the project library. Continue with [Manage dependencies](./05.manage-dependencies.md) for dependency fields and version constraints.
+`rpx add` updates `DESCRIPTION`, resolves and writes `rpx.lock`, and synchronizes the project library. Continue with [Manage dependencies](https://rrepo.org/documentation/manage-dependencies) for dependency fields and version constraints.


### PR DESCRIPTION
Replace numbered Markdown cross-links with canonical rrepo.org/documentation URLs so these documents can be imported unchanged into the website. Same-page anchors and other content are unchanged.

Companion to the website's RRE-60 integration. Merge this before enabling the website's main-branch docs import; Manage dependencies is included in that integration.