### PR TITLE
ci: enable native Azure signing with pinned cargo-dist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,10 +62,9 @@ jobs:
           persist-credentials: false
           submodules: recursive
       - name: Install dist
-        # we specify bash to get pipefail; it guards against the `curl` command
-        # failing. otherwise `sh` won't catch that `curl` returned non-0
+        # Pin unreleased Azure signing support; restore this override after generation.
         shell: bash
-        run: "cargo install --git https://github.com/axodotdev/cargo-dist/ --branch=main --locked cargo-dist"
+        run: "cargo install --git https://github.com/axodotdev/cargo-dist/ --rev c65a1a932e2661e05d6640716850d36b0f47efd7 --locked cargo-dist"
       - name: Cache dist
         uses: actions/upload-artifact@v7
         with:
@@ -130,7 +129,8 @@ jobs:
             echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           fi
       - name: Install dist
-        run: ${{ matrix.install_dist.run }}
+        # The generated matrix tracks main; use the same revision as the plan job.
+        run: "cargo install --git https://github.com/axodotdev/cargo-dist/ --rev c65a1a932e2661e05d6640716850d36b0f47efd7 --locked cargo-dist"
       # Get the dist-manifest
       - name: Fetch local artifacts
         uses: actions/download-artifact@v8
@@ -242,7 +242,8 @@ jobs:
           persist-credentials: false
           submodules: recursive
       - name: Install dist
-        run: "cargo install --git https://github.com/axodotdev/cargo-dist/ --branch=main --locked cargo-dist"
+        # Keep the Windows signing tool at the same revision as the artifact builds.
+        run: "cargo install --git https://github.com/axodotdev/cargo-dist/ --rev c65a1a932e2661e05d6640716850d36b0f47efd7 --locked cargo-dist"
       - name: Fetch artifacts
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@
 name: Release
 permissions:
   "contents": "write"
+  "id-token": "write"
 
 # This task will run whenever you push a git tag that looks like a version
 # like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
@@ -64,9 +65,9 @@ jobs:
         # we specify bash to get pipefail; it guards against the `curl` command
         # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.31.0/cargo-dist-installer.sh | sh"
+        run: "cargo install --git https://github.com/axodotdev/cargo-dist/ --branch=main --locked cargo-dist"
       - name: Cache dist
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/dist
@@ -82,7 +83,7 @@ jobs:
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-plan-dist-manifest
           path: plan-dist-manifest.json
@@ -108,6 +109,7 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    environment: release
     container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -131,7 +133,7 @@ jobs:
         run: ${{ matrix.install_dist.run }}
       # Get the dist-manifest
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -139,6 +141,17 @@ jobs:
       - name: Install dependencies
         run: |
           ${{ matrix.packages_install }}
+      - name: Azure login
+        if: ${{ contains(join(matrix.targets, ','), 'windows') }}
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: Install Azure Artifact Signing module
+        if: ${{ contains(join(matrix.targets, ','), 'windows') }}
+        shell: pwsh
+        run: Install-Module -Name ArtifactSigning -Force -Repository PSGallery
       - name: Build artifacts
         run: |
           # Actually do builds and make zips and whatnot
@@ -158,7 +171,7 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-build-local-${{ join(matrix.targets, '_') }}
           path: |
@@ -180,14 +193,14 @@ jobs:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Get all the local artifacts for the global tasks to use (for e.g. checksums)
       - name: Fetch local artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -205,9 +218,65 @@ jobs:
 
           cp dist-manifest.json "$BUILD_MANIFEST_NAME"
       - name: "Upload artifacts"
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: artifacts-build-global
+          path: |
+            ${{ steps.cargo-dist.outputs.paths }}
+            ${{ env.BUILD_MANIFEST_NAME }}
+
+  # Sign globally-built Windows artifacts after all artifact builds complete
+  sign-artifacts:
+    needs:
+      - plan
+      - build-global-artifacts
+    if: ${{ always() && needs.build-global-artifacts.result == 'success' }}
+    runs-on: windows-2022
+    environment: release
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+          submodules: recursive
+      - name: Install dist
+        run: "cargo install --git https://github.com/axodotdev/cargo-dist/ --branch=main --locked cargo-dist"
+      - name: Fetch artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: artifacts-build-global
+          path: target/distrib/
+          merge-multiple: true
+      - name: Azure login
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: Install Azure Artifact Signing module
+        shell: pwsh
+        run: Install-Module -Name ArtifactSigning -Force -Repository PSGallery
+      - name: Sign artifacts
+        shell: pwsh
+        run: |
+          dist sign ${{ needs.plan.outputs.tag-flag }} --output-format=json | Out-File -FilePath dist-manifest.json -Encoding utf8
+          Write-Host "artifacts signed successfully"
+      - id: cargo-dist
+        name: Post-signing
+        shell: bash
+        run: |
+          echo "paths<<EOF" >> "$GITHUB_OUTPUT"
+          dist print-upload-files-from-manifest --manifest dist-manifest.json >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+          cp dist-manifest.json "$BUILD_MANIFEST_NAME"
+      - name: "Replace global artifacts"
+        uses: actions/upload-artifact@v7
+        with:
+          name: artifacts-build-global
+          overwrite: true
           path: |
             ${{ steps.cargo-dist.outputs.paths }}
             ${{ env.BUILD_MANIFEST_NAME }}
@@ -217,8 +286,9 @@ jobs:
       - plan
       - build-local-artifacts
       - build-global-artifacts
+      - sign-artifacts
     # Only run if we're "publishing", and only if plan, local and global didn't fail (skipped is fine)
-    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') }}
+    if: ${{ always() && needs.plan.result == 'success' && needs.plan.outputs.publishing == 'true' && (needs.build-global-artifacts.result == 'skipped' || needs.build-global-artifacts.result == 'success') && (needs.build-local-artifacts.result == 'skipped' || needs.build-local-artifacts.result == 'success') && needs.sign-artifacts.result == 'success' }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: "ubuntu-22.04"
@@ -230,14 +300,14 @@ jobs:
           persist-credentials: false
           submodules: recursive
       - name: Install cached dist
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: cargo-dist-cache
           path: ~/.cargo/bin/
       - run: chmod +x ~/.cargo/bin/dist
       # Fetch artifacts from scratch-storage
       - name: Fetch artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: target/distrib/
@@ -250,14 +320,14 @@ jobs:
           cat dist-manifest.json
           echo "manifest=$(jq -c "." dist-manifest.json)" >> "$GITHUB_OUTPUT"
       - name: "Upload dist-manifest.json"
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           # Overwrite the previous copy
           name: artifacts-dist-manifest
           path: dist-manifest.json
       # Create a GitHub Release while uploading all files to it
       - name: "Download GitHub Artifacts"
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: artifacts-*
           path: artifacts
@@ -283,6 +353,7 @@ jobs:
       - plan
       - build-local-artifacts
       - build-global-artifacts
+      - sign-artifacts
     uses: ./.github/workflows/upload-r2.yml
     with:
       plan: ${{ needs.plan.outputs.val }}

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -5,6 +5,11 @@ members = ["cargo:."]
 [dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
 cargo-dist-version = "0.32.0-github-main"
+# CI overrides branch installs with upstream main at
+# c65a1a932e2661e05d6640716850d36b0f47efd7 for unreleased Azure signing support.
+# After regenerating CI, restore the --rev pin in plan, local builds, and signing.
+# Remove these overrides when switching to a release containing the Azure support.
+allow-dirty = ["ci"]
 # CI backends to support
 ci = "github"
 # The installers to generate for each app

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -4,7 +4,7 @@ members = ["cargo:."]
 # Config for 'dist'
 [dist]
 # The preferred dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.31.0"
+cargo-dist-version = "0.32.0-github-main"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
@@ -21,3 +21,9 @@ simple-download-url = "https://rrepo.org/rpx/{tag}"
 host-jobs = ["./upload-r2"]
 # Whether to install an updater program
 install-updater = false
+
+# Sign Windows executables and the PowerShell installer with Azure Artifact Signing
+[dist.azure-windows-sign]
+endpoint = "https://weu.codesigning.azure.net/"
+account-name = "rpx-signing-account"
+certificate-profile-name = "rpx-public-trust"


### PR DESCRIPTION
## Summary
Enable native Azure Artifact Signing for Windows release binaries and the PowerShell installer using upstream cargo-dist main pinned to `c65a1a932e2661e05d6640716850d36b0f47efd7`.

Related: [RRE-9](https://linear.app/rrepo/issue/RRE-9), [RRE-15](https://linear.app/rrepo/issue/RRE-15), [upstream cargo-dist PR #2396](https://github.com/axodotdev/cargo-dist/pull/2396).

## Review by commit
1. `18e1e92` — enable Azure signing and generate the clean upstream workflow. Passed `dist generate --check` before customization.
2. `1753cbd` — override installation in plan, local builds, and signing with the exact upstream SHA; document the override and enable `allow-dirty = ["ci"]`.

Global builds and hosting reuse the cached pinned coordinator binary. Both GitHub hosting and R2 upload wait for the Windows signing job.

## Azure change applied separately
Updated the existing production federated credential on `github-rpx-release-signing` from `repo:scalerail-solutions/rpx:environment:release` to `repo:rrepo-org/rpx:environment:release`, then verified it with Azure CLI. The issuer and audience are unchanged.

The existing repository Azure identity secrets are present. The signing configuration uses the active `rpx-public-trust` profile on `rpx-signing-account` in West Europe.

## Validation
- Installed cargo-dist from the exact upstream revision with `--locked`.
- Clean generation: `dist generate --check` passed.
- `dist plan` passed before and after customization.
- actionlint v1.7.12 passed for release.yml and upload-r2.yml (external shellcheck/pyflakes disabled).
- `git diff --check` passed.

End-to-end OIDC login, signatures, final checksums, and Windows installation will be verified in a prerelease after explicit approval. No release tag or prerelease has been created.