### PR TITLE
docs: clarify project types and repository interface

### DIFF
--- a/docs/01.overview.md
+++ b/docs/01.overview.md
@@ -56,22 +56,12 @@ Commands can run from a project directory or one of its descendants. rpx searche
 
 Each project receives a library identified by its filesystem path. Moving a project causes rpx to use a different project library, which can be recreated with `rpx sync`.
 
-## Package sources
+## Why rrepo?
 
-Dependency resolution needs more than a list of today's packages. A project may need an earlier release to satisfy its version constraints, and the resolver needs to compare the dependencies of candidate versions before deciding what to install.
+Resolving dependencies requires knowing which package versions are available and what each version depends on. CRAN's package index only provides that information for current releases. Older versions remain in source archives without a supported API for discovering and comparing them, forcing rpx to scrape archive listings and inspect package contents for dependency metadata—a significantly slower approach that cannot reliably work across mirrors.
 
-### Where CRAN falls short
+The rrepo repository API makes package versions and dependency metadata directly available to rpx. This lets the resolver compare candidate versions before downloading package archives for installation. The same interface supports public package collections and private repositories.
 
-CRAN is built around the current release of each package. Its package index provides a limited view of the available versions: it does not include a historical version catalog or dependency metadata for older releases. Source archives preserve older packages, but CRAN does not expose a supported API for discovering and comparing those versions.
+To keep the packages you already use from CRAN available through this interface, we host a **CRAN mirror as one of rrepo's repositories**. That mirror, at `https://rrepo.dev/upstream/cran`, is the default repository in rpx. CRAN is the source of those packages; rrepo provides the interface for resolving and retrieving them.
 
-rpx can work around part of this by scraping archive directory listings and downloading source archives to inspect their dependencies. Directory listings are a web-server behavior, not a supported repository interface: some mirrors expose them and others do not. Reliable dependency resolution should not depend on whether a mirror happens to allow directory browsing.
-
-### A common repository interface
-
-A repository interface should let clients discover packages, list their available versions, retrieve dependency metadata, and download selected artifacts. Those operations should work consistently regardless of where the packages originate or who hosts them.
-
-The rrepo repository API provides that common interface. A repository can expose public CRAN packages or host an organization's private packages, while rpx uses the same resolution workflow for both. Package discovery and historical metadata are explicit parts of the interface, so the resolver can compare versions before downloading package archives for installation.
-
-The public repository at `https://rrepo.dev/upstream/cran` implements this interface for CRAN packages and is the default source in rpx. The hosted service is one use of the interface; the same operations support repositories with different package collections and access requirements.
-
-Every project has one base repository and can also use additional repositories and Git remotes. rpx supports traditional CRAN-like repositories alongside repositories implementing the rrepo API. The lockfile records the selected sources so another machine retrieves packages from the same repositories.
+Each project can use a different base repository, add other repositories, or include packages from Git. rpx also supports traditional CRAN-like repositories directly. The lockfile records the selected sources alongside the package versions.

--- a/docs/01.overview.md
+++ b/docs/01.overview.md
@@ -9,7 +9,9 @@ sitemap:
   changefreq: monthly
 ---
 
-`rpx` manages dependencies for R package projects and dependency-only R projects. It treats `DESCRIPTION` as the dependency contract, resolves compatible package versions into `rpx.lock`, and installs the locked package set into an isolated project library.
+`rpx` manages R dependencies for packages, applications, and analysis projects. It resolves compatible package versions, records them in a lockfile, and installs them into an isolated project library.
+
+When you develop an R package, rpx installs your package alongside its dependencies so you can use it in the project environment. For an application or analysis, a dependency-only project manages the packages your code needs without requiring the project itself to be installed as a package.
 
 ## Project model
 
@@ -20,8 +22,6 @@ An rpx project has three related parts:
 - The project library contains the installed package set represented by the lockfile.
 
 Commit `DESCRIPTION` and `rpx.lock`. The project library and rpx caches are local state and should not be committed.
-
-An installable package is the default project type. rpx installs the package alongside its dependencies unless `--no-install-project` is passed to `add`, `remove`, or `sync`. A dependency-only project records `Config/rpx/type: project` in `DESCRIPTION` and never installs itself.
 
 ## Recommended workflow
 
@@ -58,14 +58,20 @@ Each project receives a library identified by its filesystem path. Moving a proj
 
 ## Package sources
 
-Every project has one base repository. It can also use additional CRAN-like or rrepo repositories and Git remotes. Repository choices are part of the lockfile so another machine retrieves packages from the same selected sources.
+Dependency resolution needs more than a list of today's packages. A project may need an earlier release to satisfy its version constraints, and the resolver needs to compare the dependencies of candidate versions before deciding what to install.
 
-rpx uses the public rrepo-backed CRAN universe at `https://rrepo.dev/upstream/cran` as its built-in base repository. See [Configure repositories](./07.repositories.md) to replace it or add other package sources.
+### Where CRAN falls short
 
-## Next steps
+CRAN is built around the current release of each package. Its package index provides a limited view of the available versions: it does not include a historical version catalog or dependency metadata for older releases. Source archives preserve older packages, but CRAN does not expose a supported API for discovering and comparing those versions.
 
-- [Install rpx](./02.install-rpx.md)
-- [Start a new project](./03.start-a-project.md)
-- [Use an existing project](./04.use-an-existing-project.md)
-- [Manage dependencies](./05.manage-dependencies.md)
-- [Run commands](./06.run-r.md)
+rpx can work around part of this by scraping archive directory listings and downloading source archives to inspect their dependencies. Directory listings are a web-server behavior, not a supported repository interface: some mirrors expose them and others do not. Reliable dependency resolution should not depend on whether a mirror happens to allow directory browsing.
+
+### A common repository interface
+
+A repository interface should let clients discover packages, list their available versions, retrieve dependency metadata, and download selected artifacts. Those operations should work consistently regardless of where the packages originate or who hosts them.
+
+The rrepo repository API provides that common interface. A repository can expose public CRAN packages or host an organization's private packages, while rpx uses the same resolution workflow for both. Package discovery and historical metadata are explicit parts of the interface, so the resolver can compare versions before downloading package archives for installation.
+
+The public repository at `https://rrepo.dev/upstream/cran` implements this interface for CRAN packages and is the default source in rpx. The hosted service is one use of the interface; the same operations support repositories with different package collections and access requirements.
+
+Every project has one base repository and can also use additional repositories and Git remotes. rpx supports traditional CRAN-like repositories alongside repositories implementing the rrepo API. The lockfile records the selected sources so another machine retrieves packages from the same repositories.

--- a/docs/02.install-rpx.md
+++ b/docs/02.install-rpx.md
@@ -79,5 +79,3 @@ rpx --version
 R --version
 Rscript --version
 ```
-
-Continue with [Start a project](./03.start-a-project.md) or [Use an existing project](./04.use-an-existing-project.md).

--- a/docs/02.install-rpx.md
+++ b/docs/02.install-rpx.md
@@ -11,12 +11,7 @@ sitemap:
 
 ## Prerequisites
 
-rpx requires both `R` and `Rscript` during package-management workflows. Source packages are built with R and installed from the resulting artifacts. Confirm that both commands are available in your shell:
-
-```bash
-R --version
-Rscript --version
-```
+Install R and make sure its `R` and `Rscript` commands are available on `PATH`.
 
 Install R from the appropriate distribution if it is not already available:
 
@@ -25,9 +20,6 @@ Install R from the appropriate distribution if it is not already available:
 - [CRAN mirrors](https://cran.r-project.org/mirrors.html)
 
 rpx uses binary R packages on Windows and macOS when a selected repository provides them. It falls back to source packages when no usable binary is available. Source installation can require compilers, platform tools, and system libraries. Windows users may need [Rtools](https://cran.r-project.org/bin/windows/Rtools/).
-
-> [!NOTE]
-> This guide describes the upcoming rpx 2 release. Until rpx 2 is published as the latest stable release, use [Install from Git](#install-from-git) to install the documented CLI.
 
 ## macOS and Linux
 
@@ -45,8 +37,6 @@ Install the latest release with PowerShell:
 powershell -ExecutionPolicy Bypass -c "irm https://rrepo.org/rpx/latest/rpx-installer.ps1 | iex"
 ```
 
-Windows Defender or SmartScreen may warn while binary signing is being finalized.
-
 ## Install from Git
 
 Install the current source with Cargo:
@@ -55,27 +45,13 @@ Install the current source with Cargo:
 cargo install --git https://github.com/rrepo-org/rpx.git
 ```
 
-If Cargo is not installed, follow the [rustup installation instructions](https://rustup.rs/). Windows source builds also require the [Rust MSVC prerequisites](https://rust-lang.github.io/rustup/installation/windows-msvc.html).
+If Cargo is not installed, follow the [rustup installation instructions](https://rustup.rs/).
 
 ## Docker
 
-The published image contains the rpx executable and can be used to inspect the CLI:
-
-```bash
-docker run --rm ghcr.io/rrepo-org/rpx:latest --help
-```
-
-The image does not include R. For package workflows, copy the executable into an image that provides R:
+Add rpx to your R container using the published Docker image:
 
 ```dockerfile
 FROM r-base:latest
 COPY --link --from=ghcr.io/rrepo-org/rpx:latest /rpx /usr/local/bin/rpx
-```
-
-## Confirm the installation
-
-```bash
-rpx --version
-R --version
-Rscript --version
 ```

--- a/docs/03.start-a-project.md
+++ b/docs/03.start-a-project.md
@@ -1,6 +1,6 @@
 ---
 title: Start a project
-description: Create an installable R package or dependency-only project with rpx.
+description: Create an R package or legacy project with the interactive rpx initializer.
 seo:
   title: Start an R project with rpx
   description: Initialize an R project, select development dependencies, and create its first lockfile and project library.
@@ -9,75 +9,42 @@ sitemap:
   changefreq: monthly
 ---
 
-`rpx init` creates an installable R package or dependency-only project, resolves its first lockfile, and synchronizes its project library.
-
-## Choose a project type
-
-An installable package is the default. It includes package metadata and is installed into the project library alongside its dependencies.
-
-A dependency-only project manages an environment without installing itself. Select it interactively or pass `--type project`:
-
-```bash
-rpx init --type project
-```
-
-Both types use `DESCRIPTION` and `rpx.lock`. Dependency-only projects are marked with `Config/rpx/type: project` in `DESCRIPTION`.
-
-## Interactive setup
-
-Run the initializer in a terminal:
+Run the interactive initializer:
 
 ```bash
 rpx init
 ```
 
-The interactive flow asks for the target directory, project type, package metadata, license, base repository, and development packages. It can add `testthat`, `roxygen2`, and `devtools` to `Suggests`.
+rpx guides you through creating a project, resolves its dependencies, and prepares its isolated library. Choose a new or empty directory for the project.
 
-The base repository choices are rrepo and CRAN. rrepo is the default and uses the built-in `https://rrepo.dev/upstream/cran` repository without writing an explicit project setting. Choosing CRAN writes `Config/rpx/base-repository: https://cloud.r-project.org/` to `DESCRIPTION`.
+## Project types
 
-If the target is not already inside a Git worktree, rpx also offers to initialize a Git repository. This invokes the installed `git` executable, creates `.git` and an R-focused `.gitignore`, and does not create an initial commit or select a branch. Install Git and ensure `git` is on `PATH` before selecting this option.
+- **R package** — Organizes your code into reusable functions that you can load from the project library. Suitable for libraries, applications, and analyses. rpx installs the package alongside its dependencies.
+- **Legacy project** — Supports existing project structures that are not R packages. rpx manages their dependencies without installing the project itself.
 
-The target directory must either not exist or be completely empty. rpx does not overwrite or upgrade an existing project. Hidden files, including an existing `.git` directory, count as content.
+The project type is stored in `DESCRIPTION`. Legacy projects are marked with:
 
-## Generated project
-
-Initialization creates the project files, including:
-
-- `DESCRIPTION`
-- `NAMESPACE`
-- `.Rbuildignore`
-- License files
-- `rpx.lock`
-
-For package projects, it then installs the package and its selected development dependencies into the project library. Dependency-only projects install only their selected dependencies. Commit the generated source files, `DESCRIPTION`, and `rpx.lock`; do not commit the project library.
-
-## Non-interactive setup
-
-Provide a path and metadata flags for deterministic automation:
-
-```bash
-rpx init ./mypkg \
-  --type package \
-  --name mypkg \
-  --title "My Package" \
-  --description "Utilities for my application." \
-  --author-name "Example Author" \
-  --author-email "author@example.com" \
-  --license mit
+```text
+Config/rpx/type: project
 ```
 
-Supported license values are `mit`, `apache-2.0`, `gpl-2`, `gpl-3`, `agpl-3`, `lgpl-2.1`, `lgpl-3`, `cc0`, `cc-by-4.0`, and `proprietary`.
+Without this field, rpx treats the project as an R package. Both types declare dependencies in `DESCRIPTION` and record the resolved package set in `rpx.lock`.
 
-When no terminal is available, omitted values use defaults, the project type defaults to `package`, rrepo is selected as the base repository, no development packages are selected, and Git is not initialized. There is no `init` flag for selecting CRAN non-interactively; configure a different base afterward with `rpx repo base set`. Supplying the target path and all metadata flags is recommended for CI or scripts.
+## Project setup
 
-## Add a dependency
+The initializer lets you configure:
 
-Move into the generated project and add a package:
+- Project location and metadata.
+- License.
+- Base package repository: rrepo or CRAN.
+- Development tools such as `testthat`, `roxygen2`, and `devtools`.
+- Git initialization when the project is not already inside a Git worktree. Git must be installed to use this option.
+
+## Ready to work
+
+When setup finishes, the project files, lockfile, and library are ready. From the project directory, you can add packages or start R:
 
 ```bash
-cd mypkg
 rpx add digest
 rpx run R
 ```
-
-`rpx add` updates `DESCRIPTION`, resolves and writes `rpx.lock`, and synchronizes the project library.

--- a/docs/03.start-a-project.md
+++ b/docs/03.start-a-project.md
@@ -80,4 +80,4 @@ rpx add digest
 rpx run R
 ```
 
-`rpx add` updates `DESCRIPTION`, resolves and writes `rpx.lock`, and synchronizes the project library. Continue with [Manage dependencies](./05.manage-dependencies.md) for dependency fields and version constraints.
+`rpx add` updates `DESCRIPTION`, resolves and writes `rpx.lock`, and synchronizes the project library.

--- a/docs/04.use-an-existing-project.md
+++ b/docs/04.use-an-existing-project.md
@@ -9,88 +9,56 @@ sitemap:
   changefreq: monthly
 ---
 
-rpx uses an R `DESCRIPTION` file as the project manifest. By default, an existing project is treated as an installable package and needs valid `Package` and `Version` fields plus the files required by `R CMD INSTALL`.
+From a project containing a `DESCRIPTION` file, resolve its dependencies:
 
-For a dependency-only environment, add this field to `DESCRIPTION`:
+```bash
+rpx lock
+```
+
+This creates `rpx.lock`, recording the selected package versions and sources without installing them.
+
+## Package or legacy project
+
+We recommend keeping your project structured as an R package, with reusable functions that can be loaded from its project library.
+
+Existing projects may need initialization changes before they can be installed as packages. During installation, R evaluates top-level package code and saves the resulting objects for later loading. Code that creates temporary caches, opens connections, or registers loggers at the top level can therefore capture installation-time state instead of initializing it in the session where you use the package.
+
+Create session-dependent resources when the package loads, when they are first needed, or through a setup function. Ordinary functions and closures containing R data do not generally need this treatment.
+
+For legacy code that still depends on being sourced in the current session, `DESCRIPTION` can mark the project as:
 
 ```text
 Config/rpx/type: project
 ```
 
-Dependency-only projects do not install themselves. For an installable package that should temporarily synchronize only its dependencies, use `--no-install-project` instead.
+rpx then manages its dependencies without installing the project itself. If you change this setting after locking, run `rpx lock` again.
 
-## Create the lockfile
-
-Run `rpx lock` from the project or one of its subdirectories:
-
-```bash
-rpx lock
-```
-
-The command resolves dependencies from `DESCRIPTION` and writes `rpx.lock`. It records the current R version, repository configuration, root requirements, selected packages, and package sources. It does not install packages.
-
-## Synchronize the library
-
-Install the locked package set and, for package projects, the project itself:
+## Install the environment
 
 ```bash
 rpx sync
 ```
 
-Synchronization is strict. It installs missing packages, replaces version mismatches, and removes unexpected packages from the project library. Local projects and Git packages are rebuilt and reinstalled because their contents can change without a version change. Source builds use isolated workspaces, so build products do not modify the project or checked-out package sources.
+rpx installs the locked dependencies into the project library and installs the project itself when it is an R package. Synchronization also replaces mismatched versions and removes packages outside the locked set.
 
-Synchronize only the dependencies of an installable package with:
+Packages built from source may require compilers and system libraries to be installed beforehand.
+
+## Work in the project
+
+Start R with the project library available:
 
 ```bash
-rpx sync --no-install-project
+rpx run R
 ```
 
-This remains exact synchronization. If the project package is already installed, rpx removes it while retaining the locked dependencies. The resulting package set must contain every non-base hard dependency required by the packages being installed.
-
-rpx schedules synchronization from the hard-dependency graph formed by `Depends`, `Imports`, and `LinkingTo`. It reports invalid package metadata, missing required packages, and dependency cycles. Independent package operations can complete before a later operation reports an error.
-
-If `DESCRIPTION` or the repository configuration has changed since the lockfile was written, update the lockfile first:
+Or run a script:
 
 ```bash
-rpx lock
-rpx sync
-```
-
-## Check project state
-
-Use `status` before committing or in CI:
-
-```bash
-rpx status
-```
-
-It checks that `DESCRIPTION`, repository configuration, the current R version, `rpx.lock`, and the locked dependencies in the installed library agree. The project package is optional and its installed version is not checked, so package and dependency-only environments can both be in sync. A project in the expected state prints `Project is in sync`; drift produces a nonzero exit code and a diagnostic.
-
-## System dependencies
-
-rpx does not install operating-system dependencies. Provision required compilers, development headers, and system libraries before running `rpx sync`. Missing system dependencies typically surface while an R package is being built from source.
-
-## CI workflow
-
-A typical CI job restores the exact project state and runs a script in that environment:
-
-```bash
-rpx sync
-rpx status
 rpx run Rscript scripts/check.R
 ```
 
-## What to commit
+Use `rpx status` to check whether the project configuration, lockfile, and installed dependencies agree.
 
-Commit both `DESCRIPTION` and `rpx.lock`. Do not commit the isolated library or shared package cache; `rpx sync` recreates the library from the lockfile.
+## Share the environment
 
-If local state needs to be discarded, run:
-
-```bash
-rpx clean
-rpx sync
-```
-
-`rpx clean` removes all rpx project libraries and shared caches, not only the current project's library. Other projects will also need to recreate their libraries and download or rebuild cached artifacts.
-
-Package installs are staged and committed through library transactions so a failed install does not publish a partial package directory. A complete synchronization can still stop after other packages were successfully installed or removed. Fix the reported problem and rerun `rpx sync`; `rpx clean` should not be necessary for ordinary installation failures.
+Commit `DESCRIPTION` and `rpx.lock`. Other developers and CI can recreate the environment with `rpx sync`; the project library and caches should not be committed.

--- a/docs/05.manage-dependencies.md
+++ b/docs/05.manage-dependencies.md
@@ -9,36 +9,23 @@ sitemap:
   changefreq: monthly
 ---
 
-Use `rpx add` and `rpx remove` instead of installing packages directly into the project library. These commands update `DESCRIPTION`, regenerate `rpx.lock`, and strictly synchronize the installed package set.
+## Add and remove packages
 
-## Add packages
-
-Add one or more packages to `Imports`, the default dependency field:
+Add a package by name:
 
 ```bash
 rpx add digest
+```
+
+You can add several packages at once:
+
+```bash
 rpx add jsonlite cli
 ```
 
-Select another dependency field with one of the mutually exclusive flags:
+rpx resolves compatible versions from your configured repositories, adds the dependencies to `DESCRIPTION`, updates `rpx.lock`, and installs them into the project library.
 
-```bash
-rpx add --depends R6
-rpx add --imports jsonlite
-rpx add --linking-to Rcpp
-rpx add --suggests testthat
-rpx add --dev roxygen2
-```
-
-`--dev` is an alias for `--suggests`. `Enhances` is not currently supported.
-
-rpx treats the project's `Suggests` as development dependencies: they are root requirements that are resolved, locked, and installed. The `Suggests` of transitive packages are not installed.
-
-Adding a package already declared in another supported field moves it to the selected field. Existing relations for that package are removed from `Depends`, `Imports`, `LinkingTo`, and `Suggests` before the new relation is added.
-
-## Default version bounds
-
-For an unconstrained non-base package resolved from a repository, rpx records the selected version as a lower bound and the next major version as an upper bound. If `examplepkg` resolves to `1.4.2`, rpx writes:
+You usually don't need to specify a version. For a newly added dependency, rpx selects the latest compatible version and records a range from that version up to, but excluding, the next major release. For example, selecting `1.4.2` produces:
 
 ```text
 Imports:
@@ -46,55 +33,72 @@ Imports:
     examplepkg (< 2.0.0)
 ```
 
-For a `0.x` package, the upper bound is `< 1.0.0`.
+This allows later releases within the same major version while requiring an explicit change before adopting the next major release. The lockfile records the exact selected version, so synchronizing another machine does not silently upgrade it. For `0.x` packages, the upper bound is `< 1.0.0`.
 
-R base packages remain unbounded requirements and do not receive package entries in `rpx.lock`.
+These bounds assume major versions signal breaking changes. You can adjust them when a package follows a different compatibility policy.
 
-This is an opinionated default based on semantic versioning. R packages do not universally follow semantic versioning, so review and adjust the range when a package's compatibility policy requires it.
+### Custom constraints
 
-## Explicit constraints
-
-Use `PACKAGE@OPERATORVERSION` without spaces to provide a constraint:
+When you need a specific constraint, use `PACKAGE@OPERATORVERSION`:
 
 ```bash
-rpx add --dev 'digest@>=0.6.37'
+rpx add 'digest@>=0.6.37'
 ```
 
-Supported operators are `<`, `<=`, `==`, `!=`, `>=`, and `>`. An explicit constraint replaces the automatic bounds and any existing supported relation for that package.
+Supported operators are `<`, `<=`, `==`, `!=`, `>=`, and `>`. Quote the expression so your shell does not interpret the operators.
 
-## Remove packages
+An explicit constraint replaces the automatically generated bounds and any existing constraints for that package.
 
-Remove one or more direct dependencies:
+### Remove packages
 
 ```bash
 rpx remove digest
 rpx remove jsonlite cli
 ```
 
-The packages are removed from `Depends`, `Imports`, `LinkingTo`, and `Suggests`. rpx then relocks and synchronizes the whole library, which can also remove packages that are no longer transitively required or were installed manually.
+rpx removes the declarations from `DESCRIPTION`, updates the lockfile, and synchronizes the library. Packages that are no longer needed by the remaining dependencies are removed too.
 
-## Dependency-only synchronization
+## Dependency types
 
-Projects created with `rpx init --type project` always synchronize only their dependencies. For an installable package, `add` and `remove` install the current project package after updating its dependencies by default. Use `--no-install-project` to synchronize only the dependency set:
+rpx uses the standard R `DESCRIPTION` fields:
+
+| Field | Purpose |
+|---|---|
+| `Imports` | Required packages used by your code. The default for `rpx add`. |
+| `Depends` | Required packages also attached when your package is attached. |
+| `LinkingTo` | Packages providing headers for compilation. |
+| `Suggests` | Optional packages for tests, examples, vignettes, or additional functionality. |
+| `Enhances` | Packages your code optionally extends or integrates with. rpx does not install these. |
+
+Because suggested packages are not required to install or load your package, rpx also uses `Suggests` for development dependencies, preserving the standard `DESCRIPTION` format.
 
 ```bash
-rpx add --no-install-project digest
-rpx remove --no-install-project digest
+rpx add --dev testthat
+rpx add --depends R6
+rpx add --linking-to Rcpp
 ```
 
-The flag removes an already installed copy of the project package. It does not relax dependency validation: every non-base hard dependency required by the resulting package set must still be present.
+`--dev` is an alias for `--suggests`. rpx installs your project's suggestions, but not the suggestions of its dependencies. Adding an existing dependency under another type moves it to that field.
 
-## Manual DESCRIPTION changes
+## Editing DESCRIPTION
 
-If you edit dependencies in `DESCRIPTION` directly, regenerate the lockfile and synchronize explicitly:
+If you edit dependencies in `DESCRIPTION` directly, resolve them again before synchronizing the library:
 
 ```bash
 rpx lock
 rpx sync
 ```
 
-`rpx lock` only resolves and writes the lockfile. `rpx sync` only installs a lockfile that agrees with the current project configuration.
+Installing a package through `install.packages()` changes the library without recording a dependency in `DESCRIPTION` or `rpx.lock`. A later synchronization removes packages outside the locked set. Use `rpx add` to keep the dependency recorded.
 
-`add` and `remove` write `DESCRIPTION` and `rpx.lock` before synchronizing packages. If a later build or installation fails, the metadata remains updated and other package operations may already have completed. Individual package installs are transactional, so a failed install does not publish a partial package directory. Fix the reported problem and retry with `rpx sync`; `rpx clean` should not normally be required.
+If installation fails after a dependency change, fix the reported problem and run `rpx sync` again.
 
-Installing a package through `install.packages()` inside `rpx run R` does not update `DESCRIPTION` or `rpx.lock`. `rpx status` reports it as unexpected and the next `rpx sync` removes it.
+## Installing only dependencies
+
+For a package project, `add` and `remove` also install your project package. Use `--no-install-project` when you only want its dependencies installed:
+
+```bash
+rpx add --no-install-project digest
+```
+
+If the project package is already installed in the project library, this flag removes it.

--- a/docs/06.run-r.md
+++ b/docs/06.run-r.md
@@ -9,15 +9,13 @@ sitemap:
   changefreq: monthly
 ---
 
-`rpx run` validates the locked project environment, then executes a command with the isolated R package library activated through `R_LIBS_USER`.
-
 ## Start R
 
 ```bash
 rpx run R
 ```
 
-Packages installed by `rpx sync` are available in the session without changing your global R library.
+This starts R with the project library available, including the project package if installed. rpx sets `R_LIBS_USER` for the command so it uses the project library without changing your global R library.
 
 ## Run scripts and tools
 
@@ -25,35 +23,30 @@ Pass a command and its arguments after `rpx run`:
 
 ```bash
 rpx run Rscript scripts/check.R
-rpx run Rscript -e 'cat(.libPaths()[1])'
 rpx run R CMD check .
 ```
 
-The command is executed directly, not through a shell. rpx preserves the caller's current working directory, environment, arguments, and standard streams, even when it discovers the project root in a parent directory. The command's exit status is propagated, which makes `rpx run` suitable for scripts and CI.
+rpx can run any executable with the project environment. It passes through the command's arguments, keeps your current working directory, and returns its exit status, making it suitable for scripts and CI.
 
-Although the project environment is an R library, `rpx run` can execute any command that should inherit `R_LIBS_USER`.
+## Shell commands
 
-## Shell expressions
-
-Because no shell is started implicitly, pipes, redirects, variable expansion, and other shell expressions are not interpreted. Invoke a shell explicitly when they are needed:
+rpx executes commands directly rather than starting a shell. Your calling shell can still interpret pipes and redirects, but rpx does not interpret shell syntax itself. To run a whole shell expression with the project environment, invoke a shell explicitly:
 
 ```bash
 rpx run sh -c 'Rscript scripts/check.R | tee check.log'
 ```
 
-On Windows, invoke PowerShell or `cmd /C` explicitly for equivalent shell behavior.
+On Windows, use PowerShell or `cmd /C` for equivalent shell behavior.
 
-## Environment validation
+## Environment checks
 
-Before starting the command, `rpx run` requires a readable, supported `rpx.lock` that agrees with `DESCRIPTION`, the repository configuration, and the current R version. It refuses to run when a locked dependency is missing or installed at the wrong version.
+Before starting a command, rpx checks that the lockfile matches the project configuration and current R version, and that its dependencies are installed at the expected versions. It does not install or update packages automatically.
 
-Extra packages do not prevent a command from running, although `rpx status` reports them as unexpected. An installable project's own package is optional, matching `--no-install-project`; dependency-only projects never require one.
-
-`rpx run` validates but does not synchronize the environment. Run synchronization explicitly when the library is not ready:
+If dependency declarations have changed, resolve them and synchronize the library:
 
 ```bash
+rpx lock
 rpx sync
-rpx run Rscript scripts/check.R
 ```
 
-Avoid using `install.packages()` to manage project dependencies inside an rpx session. A directly installed package is not added to `DESCRIPTION` or `rpx.lock`, is reported as unexpected by `rpx status`, and is removed by strict synchronization. Use `rpx add` instead.
+If the lockfile is current but installed dependencies are missing or at the wrong versions, run `rpx sync` before retrying the command.

--- a/docs/07.repositories.md
+++ b/docs/07.repositories.md
@@ -3,153 +3,25 @@ title: Repositories
 description: Configure base, additional, and Git package repositories for rpx.
 seo:
   title: Configure package repositories in rpx
-  description: Replace the base package universe, add CRAN-like repositories and Git remotes, and manage private repository credentials.
+  description: Choose package sources, add Git remotes, and authenticate with private repositories.
 sitemap:
   priority: 0.8
   changefreq: monthly
 ---
 
-Repository configuration is stored in `DESCRIPTION` and captured in `rpx.lock`. Every project has one base repository and can also use Git remotes and additional repositories.
+Repository settings live in `DESCRIPTION`, and the lockfile records where each selected package comes from. Every project has one base repository and can include additional repositories and Git sources.
 
-## Repository classes
-
-rpx builds the effective repository list in this order:
-
-1. The base repository.
-2. Git remotes from `Remotes`.
-3. Additional repositories from `Additional_repositories`.
-
-During resolution, rpx prefers an existing locked version when it remains compatible and available. Otherwise it selects the highest compatible version across the configured repositories. If the same version is available from more than one source, the earlier repository in the effective list wins.
-
-The selected repository is written to `rpx.lock`. Binary and source artifact requests for that package use its locked repository; an additional repository is not a fallback for artifacts from another locked source.
+Repository changes update `rpx.lock`. Run `rpx sync` afterward to apply them to the installed environment.
 
 ## Base repository
 
-The built-in base repository is:
-
-```text
-https://rrepo.dev/upstream/cran
-```
-
-Replace it for a project with:
+rpx starts with the CRAN mirror at `https://rrepo.dev/upstream/cran` as its primary package source. You can replace it for a project, for example to use CRAN directly:
 
 ```bash
-rpx repo base set https://rrepo.dev/<org-slug>/<repo-slug>
+rpx repo base set https://cloud.r-project.org
 ```
 
-This writes `Config/rpx/base-repository` in `DESCRIPTION`. It replaces the previous base; it does not add a second base repository.
-
-Return to the built-in base with:
-
-```bash
-rpx repo base reset
-```
-
-The base repository is always present and cannot be disabled.
-
-## Additional repositories
-
-Add a CRAN-like or rrepo repository alongside the base:
-
-```bash
-rpx repo additional add https://cloud.r-project.org
-```
-
-Remove it with:
-
-```bash
-rpx repo additional remove https://cloud.r-project.org
-```
-
-The shorter `rpx repo add` and `rpx repo remove` commands are aliases for the corresponding additional-repository commands:
-
-```bash
-rpx repo add https://cloud.r-project.org
-rpx repo remove https://cloud.r-project.org
-```
-
-Repository changes regenerate `rpx.lock` but do not synchronize the project library. Run `rpx sync` after changing repositories when the installed environment should match the new lockfile.
-
-## Git remotes
-
-Git must be installed and available on `PATH` to add, resolve, or install Git remotes. Add packages from GitHub, GitLab, Bitbucket, or a generic Git repository through the `Remotes` field:
-
-```bash
-rpx repo remote add github::owner/repository@main
-rpx repo remote add gitlab@code.example::group/repository@develop
-rpx repo remote add bitbucket::owner/repository/subdir@v1
-rpx repo remote add 'git::https://example.com/team/repository.git@main'
-```
-
-Remove a remote using its normalized specification:
-
-```bash
-rpx repo remote remove github::owner/repository@main
-```
-
-Locking resolves a branch, tag, or default branch to an immutable commit and records that commit in `rpx.lock`. Generic Git remotes support HTTPS, SSH URLs, and SCP-like SSH syntax. Plain HTTP, local paths, `file://` URLs, and credentials embedded in HTTPS URLs are rejected.
-
-Git HTTPS authentication uses configured Git credential helpers. SSH authentication uses the SSH agent.
-
-## List repositories
-
-List every effective repository:
-
-```bash
-rpx repo list
-```
-
-Filter by repository class:
-
-```bash
-rpx repo list --type base
-rpx repo list --type additional
-rpx repo list --type remote
-```
-
-The base entry reports whether it is built in or configured. Additional repositories and remotes report that they came from `DESCRIPTION`.
-
-## Private repositories
-
-Obtain the repository URL and an API key from your repository provider. For rrepo-hosted packages, dashboard setup and API-key permissions are documented at [rrepo.org](https://rrepo.org/documentation/private-packages).
-
-Configure the private repository as the base when it represents the project's primary package universe:
-
-```bash
-rpx repo base set https://rrepo.dev/<org-slug>/<repo-slug>
-```
-
-Or add it without replacing the base:
-
-```bash
-rpx repo additional add https://rrepo.dev/<org-slug>/<repo-slug>
-```
-
-When a repository responds with HTTP 401, interactive rpx prompts for an API key and stores it in the operating system keyring. Non-interactive commands cannot prompt and require a usable key to have been stored previously.
-
-Credentials are scoped to the repository origin: scheme, host, and port. Repositories at different paths on the same origin share the stored credential.
-
-Remove a credential when removing an additional repository:
-
-```bash
-rpx repo additional remove https://rrepo.dev/<org-slug>/<repo-slug> --remove-credential
-```
-
-Remove the configured base credential while resetting to the built-in base:
-
-```bash
-rpx repo base reset --remove-credential
-```
-
-## Migrating from default-repository flags
-
-rpx 2 removes `--default-repo` and `--no-default-repo` from `add`, `remove`, and `lock`. The base repository is now a persistent project setting instead of a per-command choice.
-
-Replace the built-in repository with:
-
-```bash
-rpx repo base set https://example.org/cran
-```
+This stores the selected URL in `Config/rpx/base-repository` in `DESCRIPTION`.
 
 Restore the built-in repository with:
 
@@ -157,4 +29,62 @@ Restore the built-in repository with:
 rpx repo base reset
 ```
 
-There is no rpx 2 configuration for resolving with no base repository.
+## Additional repositories
+
+Add another collection of packages alongside the base, such as your team's private repository:
+
+```bash
+rpx repo additional add https://rrepo.dev/my-team/packages
+```
+
+Additional repositories are stored in `Additional_repositories` in `DESCRIPTION`. Remove one with:
+
+```bash
+rpx repo additional remove https://rrepo.dev/my-team/packages
+```
+
+## Git packages
+
+Git repositories can supply packages outside a package registry. Git must be installed and available on `PATH`.
+
+```bash
+rpx repo remote add github::owner/repository@main
+```
+
+Remotes are stored in the `Remotes` field in `DESCRIPTION`. rpx supports GitHub, GitLab, Bitbucket, and generic Git URLs. You can select a branch or tag after `@`, and a package subdirectory after the repository name. For example, `github::owner/repository/subdir@v1` selects a package in `subdir` at tag `v1`.
+
+When resolving dependencies, rpx records the selected Git commit in `rpx.lock`, so later installations use that commit even if the branch moves.
+
+Remove a remote with:
+
+```bash
+rpx repo remote remove github::owner/repository@main
+```
+
+HTTPS authentication uses your configured Git credential helpers. SSH authentication uses the SSH agent.
+
+## Private repositories
+
+Use the repository URL and API key supplied by your provider. When authentication is required, interactive rpx prompts for the key and stores it in the operating system keyring. Non-interactive runs need a usable key stored beforehand.
+
+Credentials are scoped to the repository origin: scheme, host, and port. Repositories at different paths on the same origin share the stored credential.
+
+To remove the stored credential along with a repository, pass `--remove-credential`:
+
+```bash
+rpx repo additional remove https://rrepo.dev/my-team/packages --remove-credential
+```
+
+The flag is also available on `rpx repo base reset`. Because credentials are shared by origin, removing one also affects other repositories using that credential.
+
+## Inspect repositories and selection
+
+List the project's configured sources:
+
+```bash
+rpx repo list
+```
+
+rpx prefers an existing locked version when it remains compatible and available. Otherwise, it selects the highest compatible version across the configured repositories. When the same version appears in multiple sources, the order is base repository, Git remotes, then additional repositories.
+
+Adding a repository makes its packages available for resolution. Downloads use each package's locked source; another repository is not an artifact fallback for that package.


### PR DESCRIPTION
## Summary
- Introduce package, application, and analysis project use cases in the overview instead of leading with flags and metadata fields.
- Explain the limitations of CRAN historical metadata discovery and its dependence on mirror directory listings.
- Present the rrepo repository API as a common interface for public and private package repositories, with the hosted CRAN repository as one implementation.
- Remove Next steps and Continue with cross-page navigation from the overview, installation, and project setup pages.

## Validation
- Reviewed the copy against the CRAN and rrepo repository implementations.
- `git diff --check` passed.

This documentation branch is based on main and is independent of the Azure signing PR.