### PR TITLE
docs: streamline README and compare R package managers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing
+
+## Running tests
+
+Run the test suite with:
+
+```bash
+cargo test
+```
+
+The integration tests require Docker and use `testcontainers` with the official `r-base` image. They exercise package-management workflows without changing your local R installation or package library.
+
+## Preparing a release
+
+Before releasing:
+
+1. Update the version in `Cargo.toml` and `Cargo.lock`.
+2. Move the relevant entries from `Unreleased` into a matching version section in [CHANGELOG.md](CHANGELOG.md). The heading must contain the exact package version so cargo-dist can use it for the GitHub release title and body.
+3. Run the test suite.
+
+Create a release by pushing a matching version tag such as `v2.0.0`. The cargo-dist workflow builds and signs release artifacts, publishing archives, checksums, installers, and release notes to GitHub Releases and uploading release assets to R2 for distribution through `rrepo.org`.
+
+The Docker workflow publishes `ghcr.io/rrepo-org/rpx` images for `linux/amd64` and `linux/arm64`. Only stable `vMAJOR.MINOR.PATCH` tags update the `latest` download on `rrepo.org`.

--- a/README.md
+++ b/README.md
@@ -53,9 +53,24 @@ rpx lock
 rpx sync
 ```
 
+## How rpx compares
+
+| | rpx | rv | uvr | renv | pak | rig |
+|---|---|---|---|---|---|---|
+| **Primary focus** | Constraint-driven project environments | Declarative project environments | Package and R-version management | Project snapshot and restore | Package resolution and installation | R-version management |
+| **Dependency declaration** | `DESCRIPTION` | `rproject.toml` | `uvr.toml` | Project discovery or `DESCRIPTION` | Package requests or `DESCRIPTION` | — |
+| **Version selection** | Explicit ranges with automatic bounds | Repository snapshots and package sources | Version requirements | Recorded versions and explicit installs | Package requests and constraints | — |
+| **Lockfile** | `rpx.lock` | `rv.lock` | `uvr.lock` | `renv.lock` | CI-oriented lockfiles | — |
+| **Remove packages outside the locked set** | Default during sync | Supported during sync | Supported during sync | Optional during restore | Not its primary workflow | — |
+| **R-version management** | Planned; currently uses installed R | Selects installed R | Installs and selects R | Records R version; installation is external | Uses installed R | Installs and selects R |
+
+rpx focuses on resolving compatibility requirements expressed in standard R metadata and maintaining the resulting project environment. R-version management is on the roadmap; today, rpx uses the R installation available on `PATH` and validates its version against the lockfile.
+
+Sources: [rv](https://a2-ai.github.io/rv-docs/), [rv version selection](https://a2-ai.github.io/rv-docs/cookbook/pkg_version/), [uvr](https://github.com/nbafrank/uvr), [renv](https://rstudio.github.io/renv/), [renv restore](https://rstudio.github.io/renv/reference/restore.html), [pak](https://pak.r-lib.org/), [rig](https://github.com/r-lib/rig). Comparison reviewed September 2026.
+
 ## Package sources
 
-rpx uses the rrepo repository API to discover package versions and dependency metadata. We host a CRAN mirror as one of rrepo's repositories, giving rpx access to CRAN packages through that interface. You can also configure other repositories, private packages, and Git sources.
+Resolving across package versions requires access to their dependency metadata. The rrepo repository API exposes that information directly, including historical versions, so rpx can compare candidates before downloading package archives. We host a CRAN mirror as one of rrepo's repositories to make CRAN packages available through this interface. rpx also supports other repositories, private packages, and Git sources.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -2,286 +2,69 @@
 
 **Modern package management for R.**
 
-`rpx` brings modern package-management semantics to R projects. Packages declare compatible dependency ranges in [`DESCRIPTION`](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#The-DESCRIPTION-file), `rpx` resolves those constraints before installation, and `rpx.lock` records the exact result.
+rpx resolves compatible R package versions before installation, records them in `rpx.lock`, and maintains an isolated library for each project. Dependencies stay in the standard R `DESCRIPTION` format, so your project remains an ordinary R package.
 
-`rpx` works with `rrepo`, the registry infrastructure that provides the package metadata needed for reliable resolution across public, private, and historical R packages.
+- Automatic dependency bounds, from the selected version to below the next major release.
+- A locked package set shared by developers and CI.
+- Public, private, and Git package sources.
 
-The short version:
-
-- `rpx` is the developer workflow.
-- `rrepo` provides registry APIs for CRAN mirrors and private repositories.
-- `DESCRIPTION` declares compatibility.
-- `rpx.lock` records the exact solution.
-
-## Why rpx Exists
-
-R projects should not depend on whatever happens to be installed in a user's global library. `rpx` gives each project its own locked package set and runs R with that project library active.
-
-Use `rpx` when you want:
-
-1. A committed `rpx.lock` for the exact package versions used by the project.
-2. A local project library that can be recreated from that lockfile.
-3. Dependency declarations in `DESCRIPTION` that give the resolver useful version bounds.
-4. CI and developer machines using the same package set without sharing a global library.
-
-The important difference from a snapshot-only workflow is that `DESCRIPTION` is not only a list of package names. It is the input to the resolver.
-
-## Dependency Bounds
-
-Most R packages either leave dependency versions unbounded or only set a lower bound. Compatibility is often handled outside the dependency declaration, especially through [CRAN reverse dependency checks](https://r-pkgs.org/release.html#sec-release-revdep-checks).
-
-`rpx` moves more of that compatibility information into `DESCRIPTION`, where the resolver can use it directly. When you add a package, `rpx` records the version it selected as the lower bound and the next major version as the upper bound.
-
-For example, adding a package resolved at `1.4.2` writes:
-
-```text
-Imports:
-    examplepkg (>= 1.4.2),
-    examplepkg (< 2.0.0)
-```
-
-The lower bound prevents the solver from choosing a version older than the one you added. The upper bound prevents an automatic jump to the next major version unless you change the constraint. Packages are added to `Imports` by default; use a dependency-type flag to select another field:
-
-```bash
-rpx add --depends package
-rpx add --imports package
-rpx add --linking-to package
-rpx add --suggests package
-```
-
-The flags are mutually exclusive. `--dev` is an alias for `--suggests`. `Enhances` is not currently supported.
-
-This uses semver because the major version is the common place to signal breaking changes. R packages do not universally follow semver, so this is not a guarantee that every `1.x` release is compatible or every `2.x` release is incompatible. It is a default constraint that is safer than leaving the dependency open-ended.
-
-For `0.x` packages, `rpx` records the selected version as the lower bound and `< 1.0.0` as the upper bound.
-
-To set a constraint yourself, use `PACKAGE@OPERATORVERSION`. For example, this writes
-`digest (>= 0.6.37)` to `Suggests`:
-
-```bash
-rpx add --dev 'digest@>=0.6.37'
-```
-
-Supported operators are `<`, `<=`, `==`, `!=`, `>=`, and `>`. A constrained add replaces every
-existing relation for that package in `DESCRIPTION` before adding the requested relation to
-the selected field.
+**[Documentation](https://rrepo.org/documentation/overview)**
 
 ## Install
 
-`rpx` requires R to be installed and available on `PATH`. Git is also required when using Git package remotes or asking `rpx init` to create a repository. Before using `rpx`, confirm that `Rscript` works in your shell and, when needed, that `git` does too.
+Install R and make sure `R` and `Rscript` are available on `PATH`.
 
-Install R:
-
-- Windows: https://cran.r-project.org/bin/windows/base/
-- macOS: https://cran.r-project.org/bin/macosx/
-- CRAN mirrors: https://cran.r-project.org/mirrors.html
-
-Install the latest release on macOS or Linux:
+### macOS and Linux
 
 ```bash
 curl -LsSf https://rrepo.org/rpx/latest/rpx-installer.sh | sh
 ```
 
-Install the latest release on Windows:
+### Windows
 
 ```powershell
 powershell -ExecutionPolicy Bypass -c "irm https://rrepo.org/rpx/latest/rpx-installer.ps1 | iex"
 ```
 
-The documentation on `main` describes the upcoming rpx 2 release. Until rpx 2 is published as the latest stable release, use the Cargo command below to install the current development version.
+For source installation, Docker, and platform prerequisites, see the [installation guide](https://rrepo.org/documentation/install-rpx).
 
-Windows binary signing is still being worked on. The PowerShell installer is available, but Windows Defender or SmartScreen may warn until the signing flow is finalized.
+## Quick start
 
-You can also install `rpx` from Git with Cargo:
-
-```bash
-cargo install --git https://github.com/rrepo-org/rpx.git
-```
-
-If you do not already have Rust and Cargo installed, install them with `rustup`:
-
-- Rust: https://rustup.rs/
-- Windows Rust/MSVC prerequisites: https://rust-lang.github.io/rustup/installation/windows-msvc.html
-
-`rpx` prefers binary R package artifacts on Windows and macOS when available, but some packages may still need to be built from source. On Windows, install Rtools if you hit source-build requirements:
-
-- Rtools: https://cran.r-project.org/bin/windows/Rtools/
-
-You can also run the Docker image directly:
-
-```bash
-docker run --rm ghcr.io/rrepo-org/rpx:latest --help
-```
-
-The Docker image contains the `rpx` binary but does not include R. For project workflows, copy `rpx` into an image that provides R:
-
-```dockerfile
-FROM r-base:latest
-COPY --link --from=ghcr.io/rrepo-org/rpx:latest /rpx /usr/local/bin/rpx
-```
-
-## Start a New Project
-
-Create a `DESCRIPTION` file, add a dependency, and start R through `rpx`:
+Create a project with the interactive initializer:
 
 ```bash
 rpx init
-rpx add digest
+```
+
+From the project directory:
+
+```bash
+rpx add jsonlite
+rpx add --dev testthat
 rpx run R
 ```
 
-Use `rpx init --type project` when the project only needs dependency
-management. This writes `Config/rpx/type: project` to `DESCRIPTION`; the
-project keeps its package name and version as its resolver namespace, but is
-not installed into the project library.
+Adding dependencies updates `DESCRIPTION`, resolves the lockfile, and synchronizes the project library. Commit `DESCRIPTION` and `rpx.lock` so the environment can be recreated with `rpx sync`.
 
-Interactive initialization can add `testthat`, `roxygen2`, and `devtools` to
-`Suggests`. `rpx init` resolves the initial lockfile and syncs the project
-library before completing.
-
-`rpx add` updates `DESCRIPTION`, resolves a compatible package set, writes `rpx.lock`, and syncs the project library.
-
-## Use an Existing Project
-
-For an R package project that already has a `DESCRIPTION` file, create the lockfile and install the locked package set:
+For an existing project with a `DESCRIPTION` file, resolve its dependencies and install the environment:
 
 ```bash
 rpx lock
 rpx sync
-rpx run R
 ```
 
-By default, `rpx add`, `rpx remove`, and `rpx sync` also install the current
-project package. Use `--no-install-project` to synchronize its dependencies
-without installing the project itself:
+## Package sources
 
-```bash
-rpx sync --no-install-project
-```
-
-Like `uv sync`, synchronization is exact: this flag removes an already
-installed copy of the project while retaining its dependencies. The resulting
-package set must still contain every non-base dependency required for installation.
-
-Projects with `Config/rpx/type: project` always use dependency-only
-synchronization. Their package namespace is unavailable during resolution, so
-the project and other packages cannot depend on it.
-
-Commit both `DESCRIPTION` and `rpx.lock`. Do not commit the project library or local cache; `rpx sync` recreates local state from the lockfile.
-
-## Daily Workflow
-
-Add or remove direct dependencies with `rpx` so DESCRIPTION, the lockfile, and the project library stay together:
-
-```bash
-rpx add jsonlite
-rpx remove digest
-```
-
-Check the project before committing or in CI:
-
-```bash
-rpx status
-```
-
-Run R commands through `rpx run` so R sees the project library:
-
-```bash
-rpx run R
-rpx run Rscript scripts/check.R
-```
-
-`rpx run` executes the command directly without a shell. It preserves the
-current working directory, environment, and standard streams while setting
-`R_LIBS_USER` to the project library. Invoke a shell explicitly when using
-shell syntax such as pipes, redirects, or variable expansion:
-
-```bash
-rpx run sh -c 'Rscript scripts/check.R | tee check.log'
-```
-
-If local package state becomes confusing, remove all project libraries and caches:
-
-```bash
-rpx clean
-```
-
-## Repository Management
-
-The package universe is the set of package versions and metadata available to the resolver.
-
-By default, `rpx` uses the public rrepo-backed CRAN universe at `https://rrepo.dev/upstream/cran`. This gives the resolver CRAN package metadata through rrepo APIs, including historical package metadata instead of only today's latest package state.
-
-Projects can configure a base repository, additional rrepo or CRAN-like repositories, and package remotes:
-
-```bash
-rpx repo base set https://rrepo.dev/<org-slug>/<repo-slug>
-rpx repo additional add https://cloud.r-project.org
-rpx repo add https://packagemanager.posit.co/cran/latest
-rpx repo remote add github::owner/repository@main
-rpx repo list
-rpx repo additional remove https://cloud.r-project.org
-rpx repo remote remove github::owner/repository@main
-rpx repo base reset
-```
-
-`rpx repo add` and `rpx repo remove` are shortcuts for the corresponding `rpx repo additional` commands. Remote arguments use the same syntax as the `Remotes` field in `DESCRIPTION`.
-
-The base repository is always enabled. Additional CRAN or CRAN-like repositories make their package versions available to the resolver:
-
-```bash
-rpx repo additional add https://packagemanager.posit.co/cran/latest
-```
-
-During locking, `rpx` merges versions across enabled repositories. Existing locked versions are preferred when they are still available from enabled repositories. If the same version is available from multiple repositories, the earlier repository wins for the locked source URL. Binary and source artifacts are retrieved from that locked repository; additional repositories are not artifact fallbacks for a package locked to another source.
-
-When a repository requires authentication, `rpx` prompts for an API key and stores it in the operating system keyring for that repository's origin.
-
-Projects can set `Config/rpx/base-repository` in `DESCRIPTION` to replace the built-in base repository. When the field is absent, `rpx` uses the built-in repository.
-
-For private package universes, add an rrepo repository for your organization:
-
-```bash
-rpx repo additional add https://rrepo.dev/<org-slug>/<repo-slug>
-```
-
-## rrepo
-
-`rpx` can use CRAN and CRAN-like repositories, but its default package universe is the rrepo-backed CRAN mirror at `https://rrepo.dev/upstream/cran`.
-
-A plain CRAN-style mirror is mostly a package distribution endpoint. It is enough for installing available packages, but it is not a registry API built around dependency solving, package history, artifact selection, authentication, and private packages.
-
-`rrepo.org` mirrors CRAN and exposes that package universe through rrepo APIs. That gives `rpx` a default source for CRAN package versions, dependency metadata, historical package metadata, and platform artifacts.
-
-For teams, rrepo provides the same registry model for private R packages: publishing, access control, and private package metadata that can be resolved together with CRAN packages.
+rpx uses the rrepo repository API to discover package versions and dependency metadata. We host a CRAN mirror as one of rrepo's repositories, giving rpx access to CRAN packages through that interface. You can also configure other repositories, private packages, and Git sources.
 
 ## Documentation
 
-The rpx user guide is maintained in this repository:
+- [User guide](https://rrepo.org/documentation/overview) — overview and getting started.
+- [Managing dependencies](https://rrepo.org/documentation/manage-dependencies) — version bounds and dependency types.
+- [Repositories](https://rrepo.org/documentation/repositories) — public, private, and Git sources.
+- [Changelog](CHANGELOG.md) — release notes and breaking changes.
 
-- [Overview](docs/01.overview.md)
-- [Install rpx](docs/02.install-rpx.md)
-- [Start a project](docs/03.start-a-project.md)
-- [Use an existing project](docs/04.use-an-existing-project.md)
-- [Manage dependencies](docs/05.manage-dependencies.md)
-- [Run commands](docs/06.run-r.md)
-- [Configure repositories](docs/07.repositories.md)
-- [Changelog](CHANGELOG.md)
-
-Documentation for the hosted rrepo service, including [private packages](https://rrepo.org/documentation/private-packages), package publishing, and API keys, remains at [rrepo.org](https://rrepo.org/documentation/overview).
-
-## How It Works
-
-- `DESCRIPTION` is the dependency declaration and compatibility contract.
-- `rpx.lock` records the resolved package set, package sources, and R runtime metadata.
-- `rpx lock` resolves dependencies from enabled repositories and writes `rpx.lock`; it does not install packages.
-- `rpx` prefers existing locked versions when they are still available from enabled repositories.
-- `rpx sync` installs the packages in `rpx.lock` and installable current projects into the project library by default.
-- `--no-install-project` is available on `rpx add`, `rpx remove`, and `rpx sync` for dependency-only synchronization.
-- `rpx sync` tries Windows and macOS binary artifacts from enabled repositories when available, then falls back to the locked source artifact.
-- `rpx run` sets the R library path for the command it runs.
-
-## Local Development
+## Development
 
 Run the test suite with:
 
@@ -289,10 +72,6 @@ Run the test suite with:
 cargo test
 ```
 
-The test suite depends on Docker and uses `testcontainers`.
+Integration tests require Docker and use `testcontainers` with the official `r-base` image to exercise package-management workflows without modifying your local R library.
 
-Integration tests run against the official `r-base` image and execute realistic package-management workflows inside containers. This keeps tests close to real usage while avoiding changes to your local R installation or package library.
-
-Before releasing, update the version in `Cargo.toml` and `Cargo.lock`, move the relevant entries from `Unreleased` into a matching version section in [`CHANGELOG.md`](CHANGELOG.md), and run the test suite. The changelog heading must contain the exact package version so cargo-dist can use it for the GitHub release title and body.
-
-Create a release by pushing a matching version tag such as `v2.0.0`. The cargo-dist workflow builds precompiled binaries for Linux, macOS, and Windows, then uploads archives, checksums, installers, and release notes to GitHub Releases. The Docker workflow publishes `ghcr.io/rrepo-org/rpx` images for `linux/amd64` and `linux/arm64`. Only stable `vMAJOR.MINOR.PATCH` tags update the `latest` download on `rrepo.org`.
+Release-maintenance instructions are in [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
## Summary
- Refocus the README on installation, a quick start, and links to the user guide on rrepo.org.
- Move testing and release-maintenance instructions into CONTRIBUTING.md.
- Add a sourced comparison of rpx, rv, uvr, renv, pak, and rig covering declarations, version selection, lockfiles, synchronization, and R-version management.
- Clearly mark rpx R-version management as planned and explain historical metadata resolution through the rrepo API and hosted CRAN mirror.
- Remove outdated upcoming-v2 and unfinished Windows-signing notices.

## Commits
- Streamlined README and contributor instructions.
- Comparison matrix and expanded package-source explanation.

## Validation
- Reviewed comparison claims against upstream documentation and rpx implementation.
- `git diff --check` passed.
- Documentation-only changes; no runtime tests required.